### PR TITLE
Fix for clearing a MediaQueue containing a disposed Song.

### DIFF
--- a/src/Media/Xiph/Song.cs
+++ b/src/Media/Xiph/Song.cs
@@ -286,12 +286,12 @@ namespace Microsoft.Xna.Framework.Media
 			timer.Stop();
 			timer.Reset();
 
-            if (!IsDisposed)
-            {
-                soundStream.Stop();
-                soundStream.BufferNeeded -= QueueBuffer;
-                Vorbisfile.ov_time_seek(vorbisFile, 0.0);
-            }			
+			if (!IsDisposed)
+			{
+				soundStream.Stop();
+				soundStream.BufferNeeded -= QueueBuffer;
+				Vorbisfile.ov_time_seek(vorbisFile, 0.0);
+			}			
 		}
 
 		internal float[] GetSamples()

--- a/src/Media/Xiph/Song.cs
+++ b/src/Media/Xiph/Song.cs
@@ -286,9 +286,12 @@ namespace Microsoft.Xna.Framework.Media
 			timer.Stop();
 			timer.Reset();
 
-			soundStream.Stop();
-			soundStream.BufferNeeded -= QueueBuffer;
-			Vorbisfile.ov_time_seek(vorbisFile, 0.0);
+            if (!IsDisposed)
+            {
+                soundStream.Stop();
+                soundStream.BufferNeeded -= QueueBuffer;
+                Vorbisfile.ov_time_seek(vorbisFile, 0.0);
+            }			
 		}
 
 		internal float[] GetSamples()


### PR DESCRIPTION
Steps to reproduce the issue:
- Play Song A using MediaPlayer
- Call MediaPlayer.Stop() and dispose Song A
- Notice that MediaPlayer's MediaQueue still holds a reference to Song A
- Try to play Song B using MediaPlayer

MediaPlayer.Play() clears the MediaQueue which executes the Stop() method for all its Songs, which could be disposed already.
