### PR TITLE
Normalized* family of packed vectors does not work for negative values.

### DIFF
--- a/src/Graphics/PackedVector/NormalizedByte2.cs
+++ b/src/Graphics/PackedVector/NormalizedByte2.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		public Vector2 ToVector2()
 		{
 			return new Vector2(
-				((sbyte) (packedValue & 0xFF)) / 127.0f,
-				((sbyte) (packedValue >> 8)) / 127.0f
+				((sbyte)(packedValue & 0xFF)) / 127.0f,
+				((sbyte)((packedValue >> 8) & 0xFF)) / 127.0f
 			);
 		}
 
@@ -116,10 +116,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static ushort Pack(float x, float y)
 		{
-			return (ushort) (
-				((ushort) Math.Round(MathHelper.Clamp(x, -1, 1) * 127.0f)) |
-				(((ushort) Math.Round(MathHelper.Clamp(y, -1, 1) * 127.0f)) << 8)
-			);
+			int byte2 = (((ushort)(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0) & 0x00FF;
+			int byte1 = (((ushort)(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8) & 0xFF00;
+
+			return (ushort)(byte2 | byte1);
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/NormalizedByte2.cs
+++ b/src/Graphics/PackedVector/NormalizedByte2.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		public Vector2 ToVector2()
 		{
 			return new Vector2(
-				((sbyte)(packedValue & 0xFF)) / 127.0f,
-				((sbyte)((packedValue >> 8) & 0xFF)) / 127.0f
+				((sbyte) (packedValue & 0xFF)) / 127.0f,
+				((sbyte) ((packedValue >> 8) & 0xFF)) / 127.0f
 			);
 		}
 
@@ -116,10 +116,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static ushort Pack(float x, float y)
 		{
-			int byte2 = (((ushort)(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0) & 0x00FF;
-			int byte1 = (((ushort)(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8) & 0xFF00;
+			int byte2 = (((ushort) (MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0) & 0x00FF;
+			int byte1 = (((ushort) (MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8) & 0xFF00;
 
-			return (ushort)(byte2 | byte1);
+			return (ushort) (byte2 | byte1);
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/NormalizedByte4.cs
+++ b/src/Graphics/PackedVector/NormalizedByte4.cs
@@ -57,10 +57,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		public Vector4 ToVector4()
 		{
 			return new Vector4(
-				((sbyte)(packedValue & 0xFF)) / 127.0f,
-				((sbyte)((packedValue >> 8) & 0xFF)) / 127.0f,
-				((sbyte)((packedValue >> 16) & 0xFF)) / 127.0f,
-				((sbyte)((packedValue >> 24) & 0xFF)) / 127.0f
+				((sbyte) (packedValue & 0xFF)) / 127.0f,
+				((sbyte) ((packedValue >> 8) & 0xFF)) / 127.0f,
+				((sbyte) ((packedValue >> 16) & 0xFF)) / 127.0f,
+				((sbyte) ((packedValue >> 24) & 0xFF)) / 127.0f
 			);
 		}
 
@@ -113,10 +113,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static uint Pack(float x, float y, float z, float w)
 		{
-			uint byte4 = (((uint)(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0) & 0x000000FF;
-			uint byte3 = (((uint)(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8) & 0x0000FF00;
-			uint byte2 = (((uint)(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) << 16) & 0x00FF0000;
-			uint byte1 = (((uint)(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) << 24) & 0xFF000000;
+			uint byte4 = (((uint) (MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0) & 0x000000FF;
+			uint byte3 = (((uint) (MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8) & 0x0000FF00;
+			uint byte2 = (((uint) (MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) << 16) & 0x00FF0000;
+			uint byte1 = (((uint) (MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) << 24) & 0xFF000000;
 
 			return byte4 | byte3 | byte2 | byte1;
 		}

--- a/src/Graphics/PackedVector/NormalizedByte4.cs
+++ b/src/Graphics/PackedVector/NormalizedByte4.cs
@@ -57,10 +57,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		public Vector4 ToVector4()
 		{
 			return new Vector4(
-				((sbyte) (packedValue & 0xFF)) / 127.0f,
-				((sbyte) ((packedValue >> 8) & 0xFF)) / 127.0f,
-				((sbyte) ((packedValue >> 16) & 0xFF)) / 127.0f,
-				((sbyte) (packedValue >> 24)) / 127.0f
+				((sbyte)(packedValue & 0xFF)) / 127.0f,
+				((sbyte)((packedValue >> 8) & 0xFF)) / 127.0f,
+				((sbyte)((packedValue >> 16) & 0xFF)) / 127.0f,
+				((sbyte)((packedValue >> 24) & 0xFF)) / 127.0f
 			);
 		}
 
@@ -113,12 +113,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static uint Pack(float x, float y, float z, float w)
 		{
-			return (uint) (
-				((uint) Math.Round(MathHelper.Clamp(x, -1, 1) * 127.0f)) |
-				(((uint) Math.Round(MathHelper.Clamp(y, -1, 1) * 127.0f)) << 8) |
-				(((uint) Math.Round(MathHelper.Clamp(z, -1, 1) * 127.0f)) << 16) |
-				(((uint) Math.Round(MathHelper.Clamp(w, -1, 1) * 127.0f)) << 24)
-			);
+			uint byte4 = (((uint)(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0) & 0x000000FF;
+			uint byte3 = (((uint)(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8) & 0x0000FF00;
+			uint byte2 = (((uint)(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) << 16) & 0x00FF0000;
+			uint byte1 = (((uint)(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) << 24) & 0xFF000000;
+
+			return byte4 | byte3 | byte2 | byte1;
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/NormalizedShort2.cs
+++ b/src/Graphics/PackedVector/NormalizedShort2.cs
@@ -59,8 +59,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			const float maxVal = 0x7FFF;
 
 			return new Vector2(
-				(short)(packedValue & 0xFFFF) / maxVal,
-				(short)(packedValue >> 0x10) / maxVal
+				(short) (packedValue & 0xFFFF) / maxVal,
+				(short) (packedValue >> 0x10) / maxVal
 			);
 		}
 
@@ -121,8 +121,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			const float max = 0x7FFF;
 			const float min = -max;
 
-			uint word2 = (uint)((int)MathHelper.Clamp((float)Math.Round(x * max), min, max) & 0xFFFF);
-			uint word1 = (uint)(((int)MathHelper.Clamp((float)Math.Round(y * max), min, max) & 0xFFFF) << 0x10);
+			uint word2 = (uint) ((int) MathHelper.Clamp((float) Math.Round(x * max), min, max) & 0xFFFF);
+			uint word1 = (uint) (((int) MathHelper.Clamp((float) Math.Round(y * max), min, max) & 0xFFFF) << 0x10);
 
 			return (word2 | word1);
 		}

--- a/src/Graphics/PackedVector/NormalizedShort2.cs
+++ b/src/Graphics/PackedVector/NormalizedShort2.cs
@@ -56,9 +56,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public Vector2 ToVector2()
 		{
+			const float maxVal = 0x7FFF;
+
 			return new Vector2(
-				((short) (packedValue & 0xFFFF)) / 32767.0f,
-				((short) (packedValue >> 16)) / 32767.0f
+				(short)(packedValue & 0xFFFF) / maxVal,
+				(short)(packedValue >> 0x10) / maxVal
 			);
 		}
 
@@ -116,10 +118,13 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static uint Pack(float x, float y)
 		{
-			return (uint) (
-				((uint) Math.Round(MathHelper.Clamp(x, -1, 1) * 32767.0f)) |
-				(((uint) Math.Round(MathHelper.Clamp(y, -1, 1) * 32767.0f)) << 16)
-			);
+			const float max = 0x7FFF;
+			const float min = -max;
+
+			uint word2 = (uint)((int)MathHelper.Clamp((float)Math.Round(x * max), min, max) & 0xFFFF);
+			uint word1 = (uint)(((int)MathHelper.Clamp((float)Math.Round(y * max), min, max) & 0xFFFF) << 0x10);
+
+			return (word2 | word1);
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/NormalizedShort4.cs
+++ b/src/Graphics/PackedVector/NormalizedShort4.cs
@@ -59,10 +59,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			const float maxVal = 0x7FFF;
 
 			return new Vector4(
-				((short)((packedValue >> 0x00) & 0xFFFF)) / maxVal,
-				((short)((packedValue >> 0x10) & 0xFFFF)) / maxVal,
-				((short)((packedValue >> 0x20) & 0xFFFF)) / maxVal,
-				((short)((packedValue >> 0x30) & 0xFFFF)) / maxVal
+				((short) ((packedValue >> 0x00) & 0xFFFF)) / maxVal,
+				((short) ((packedValue >> 0x10) & 0xFFFF)) / maxVal,
+				((short) ((packedValue >> 0x20) & 0xFFFF)) / maxVal,
+				((short) ((packedValue >> 0x30) & 0xFFFF)) / maxVal
 			);
 		}
 
@@ -118,10 +118,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			const float max = 0x7FFF;
 			const float min = -max;
 
-			var word4 = ((ulong)MathHelper.Clamp((float)Math.Round(x * max), min, max) & 0xFFFF) << 0x00;
-			var word3 = ((ulong)MathHelper.Clamp((float)Math.Round(y * max), min, max) & 0xFFFF) << 0x10;
-			var word2 = ((ulong)MathHelper.Clamp((float)Math.Round(z * max), min, max) & 0xFFFF) << 0x20;
-			var word1 = ((ulong)MathHelper.Clamp((float)Math.Round(w * max), min, max) & 0xFFFF) << 0x30;
+			var word4 = ((ulong) MathHelper.Clamp((float) Math.Round(x * max), min, max) & 0xFFFF) << 0x00;
+			var word3 = ((ulong) MathHelper.Clamp((float) Math.Round(y * max), min, max) & 0xFFFF) << 0x10;
+			var word2 = ((ulong) MathHelper.Clamp((float) Math.Round(z * max), min, max) & 0xFFFF) << 0x20;
+			var word1 = ((ulong) MathHelper.Clamp((float) Math.Round(w * max), min, max) & 0xFFFF) << 0x30;
 
 			return (word4 | word3 | word2 | word1);
 		}

--- a/src/Graphics/PackedVector/NormalizedShort4.cs
+++ b/src/Graphics/PackedVector/NormalizedShort4.cs
@@ -56,11 +56,13 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public Vector4 ToVector4()
 		{
+			const float maxVal = 0x7FFF;
+
 			return new Vector4(
-				((short) (packedValue & 0xFFFF)) / 32767.0f,
-				((short) ((packedValue >> 16) & 0xFFFF)) / 32767.0f,
-				((short) ((packedValue >> 32) & 0xFFFF)) / 32767.0f,
-				((short) (packedValue >> 48)) / 32767.0f
+				((short)((packedValue >> 0x00) & 0xFFFF)) / maxVal,
+				((short)((packedValue >> 0x10) & 0xFFFF)) / maxVal,
+				((short)((packedValue >> 0x20) & 0xFFFF)) / maxVal,
+				((short)((packedValue >> 0x30) & 0xFFFF)) / maxVal
 			);
 		}
 
@@ -113,12 +115,15 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static ulong Pack(float x, float y, float z, float w)
 		{
-			return (ulong) (
-				((ulong) Math.Round(MathHelper.Clamp(x, -1, 1) * 32767.0f)) |
-				(((ulong) Math.Round(MathHelper.Clamp(y, -1, 1) * 32767.0f)) << 16) |
-				(((ulong) Math.Round(MathHelper.Clamp(z, -1, 1) * 32767.0f)) << 32) |
-				(((ulong) Math.Round(MathHelper.Clamp(w, -1, 1) * 32767.0f)) << 48)
-			);
+			const float max = 0x7FFF;
+			const float min = -max;
+
+			var word4 = ((ulong)MathHelper.Clamp((float)Math.Round(x * max), min, max) & 0xFFFF) << 0x00;
+			var word3 = ((ulong)MathHelper.Clamp((float)Math.Round(y * max), min, max) & 0xFFFF) << 0x10;
+			var word2 = ((ulong)MathHelper.Clamp((float)Math.Round(z * max), min, max) & 0xFFFF) << 0x20;
+			var word1 = ((ulong)MathHelper.Clamp((float)Math.Round(w * max), min, max) & 0xFFFF) << 0x30;
+
+			return (word4 | word3 | word2 | word1);
 		}
 
 		#endregion


### PR DESCRIPTION
Normalized* family of packed vectors (namely NormalizedByte2, NormalizedByte4, NormalizedShort2, NormalizedShort4) does not pack negative values correctly. It looks like Pack() method drops all bytes after the first one for values < 0.

XNA docs for Normalized* state that it is a "Packed vector type containing * 8-bit signed normalized values, ranging from −1 to 1.", so negative values should be supported.


Ways to reproduce:
Just convert any negative vectors between each other
```
Vector2 target = Vector2(-1, -1);
Assert.AreEqual(target , new NormalizedShort2(target).ToVector2());  // throws
```
Also by looking at the value: `-Vector4.One` packed into 4 bytes should look like 0x81818181, but instead I've got `0xFFFFFF81`


How to fix:
I am not very good at bit math, so I just grabbed Pack() code from Monogame, it seems to work for all test cases.