### PR TITLE
Rectangle.Contains(ref Rectangle, out result) treats passed rectangle like a point

### DIFF
--- a/src/Rectangle.cs
+++ b/src/Rectangle.cs
@@ -261,9 +261,9 @@ namespace Microsoft.Xna.Framework
 		public void Contains(ref Rectangle value, out bool result)
 		{
 			result = (	(this.X <= value.X) &&
-					(value.X < (this.X + this.Width)) &&
+					((value.X + value.Width) <= (this.X + this.Width)) &&
 					(this.Y <= value.Y) &&
-					(value.Y < (this.Y + this.Height))	);
+					((value.Y + value.Height) <= (this.Y + this.Height))	);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Implementation for `Rectangle.Contains(ref Rectangle, out result)` is identical to `Rectangle.Contains(ref Point value, out bool result)`, guess it is a typo.

How to repro:
Assert.IsFalse(new Rectangle(0, 0, 5, 5).Contains(new Rectangle(1, 1, 5, 5))); // throws