### PR TITLE
Event types

### DIFF
--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Xna.Framework.Audio
 				if (	!INTERNAL_eventPlayed[i] &&
 					INTERNAL_timer.ElapsedMilliseconds > INTERNAL_eventList[i].Timestamp	)
 				{
-          INTERNAL_eventList[i].Apply();
+					INTERNAL_eventList[i].Apply();
 					INTERNAL_eventPlayed[i] = true;
 				}
 			}

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -409,7 +409,6 @@ namespace Microsoft.Xna.Framework.Audio
 			INTERNAL_activeSound.GatherEvents(INTERNAL_eventList);
 			foreach (XACTEvent evt in INTERNAL_eventList)
 			{
-				evt.Cue = this;
 				INTERNAL_eventPlayed.Add(false);
 				INTERNAL_eventLoops.Add(evt, 0);
 			}
@@ -503,7 +502,7 @@ namespace Microsoft.Xna.Framework.Audio
 				if (	!INTERNAL_eventPlayed[i] &&
 					INTERNAL_timer.ElapsedMilliseconds > INTERNAL_eventList[i].Timestamp	)
 				{
-					INTERNAL_eventList[i].Apply();
+					INTERNAL_eventList[i].Apply(this, null);
 					INTERNAL_eventPlayed[i] = true;
 				}
 			}

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -502,25 +502,26 @@ namespace Microsoft.Xna.Framework.Audio
 				if (	!INTERNAL_eventPlayed[i] &&
 					INTERNAL_timer.ElapsedMilliseconds > INTERNAL_eventList[i].Timestamp	)
 				{
-					uint type = INTERNAL_eventList[i].Type;
+
+					XACTEvent.EventTypeCode type = INTERNAL_eventList[i].Type;
 					if (type == 0)
 					{
 						// FIXME: NullEvent used as a placeholder for unsupported event types.
 						Debug.Assert(INTERNAL_eventList[i] is NullEvent);
 					}
-					else if (type == 1)
+					else if (type == XACTEvent.EventTypeCode.PlayWave)
 					{
 						PlayWave((PlayWaveEvent) INTERNAL_eventList[i]);
 					}
-					else if (type == 2)
+					else if (type == XACTEvent.EventTypeCode.SetVolume)
 					{
 						eventVolume = ((SetVolumeEvent) INTERNAL_eventList[i]).GetVolume();
 					}
-					else if (type == 3)
+					else if (type == XACTEvent.EventTypeCode.SetEquationPitch)
 					{
 						eventPitch = ((SetEquationPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
 					}
-					else if (type == 4)
+					else if (type == XACTEvent.EventTypeCode.SetRandomPitch)
 					{
 						eventPitch = ((SetRandomPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
 					}

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -503,38 +503,7 @@ namespace Microsoft.Xna.Framework.Audio
 				if (	!INTERNAL_eventPlayed[i] &&
 					INTERNAL_timer.ElapsedMilliseconds > INTERNAL_eventList[i].Timestamp	)
 				{
-
-					XACTEvent.EventTypeCode type = INTERNAL_eventList[i].Type;
-					if (type == 0)
-					{
-						// FIXME: NullEvent used as a placeholder for unsupported event types.
-						//Debug.Assert(INTERNAL_eventList[i] is NullEvent);
-						INTERNAL_eventList[i].Apply();
-					}
-					else if (type == XACTEvent.EventTypeCode.PlayWave)
-					{
-						//PlayWave((PlayWaveEvent) INTERNAL_eventList[i]);
-						INTERNAL_eventList[i].Apply();
-					}
-					else if (type == XACTEvent.EventTypeCode.SetVolume)
-					{
-						//eventVolume = ((SetVolumeEvent) INTERNAL_eventList[i]).GetVolume();
-						INTERNAL_eventList[i].Apply();
-					}
-					else if (type == XACTEvent.EventTypeCode.SetEquationPitch)
-					{
-						//eventPitch = ((SetEquationPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
-						INTERNAL_eventList[i].Apply();
-					}
-					else if (type == XACTEvent.EventTypeCode.SetRandomPitch)
-					{
-						//eventPitch = ((SetRandomPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
-						INTERNAL_eventList[i].Apply();
-					}
-					else
-					{
-						throw new NotImplementedException("Unhandled XACTEvent type!");
-					}
+          INTERNAL_eventList[i].Apply();
 					INTERNAL_eventPlayed[i] = true;
 				}
 			}

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Xna.Framework.Audio
 		private List<float> INTERNAL_rpcTrackPitches;
 
 		// Events can control volume/pitch as well!
-		private float eventVolume;
-		private float eventPitch;
+		internal float eventVolume;
+		internal float eventPitch;
 
 		// User-controlled sounds require a bit more trickery.
 		private bool INTERNAL_userControlledPlaying;
@@ -409,6 +409,7 @@ namespace Microsoft.Xna.Framework.Audio
 			INTERNAL_activeSound.GatherEvents(INTERNAL_eventList);
 			foreach (XACTEvent evt in INTERNAL_eventList)
 			{
+				evt.Cue = this;
 				INTERNAL_eventPlayed.Add(false);
 				INTERNAL_eventLoops.Add(evt, 0);
 			}
@@ -507,23 +508,28 @@ namespace Microsoft.Xna.Framework.Audio
 					if (type == 0)
 					{
 						// FIXME: NullEvent used as a placeholder for unsupported event types.
-						Debug.Assert(INTERNAL_eventList[i] is NullEvent);
+						//Debug.Assert(INTERNAL_eventList[i] is NullEvent);
+						INTERNAL_eventList[i].Apply();
 					}
 					else if (type == XACTEvent.EventTypeCode.PlayWave)
 					{
-						PlayWave((PlayWaveEvent) INTERNAL_eventList[i]);
+						//PlayWave((PlayWaveEvent) INTERNAL_eventList[i]);
+						INTERNAL_eventList[i].Apply();
 					}
 					else if (type == XACTEvent.EventTypeCode.SetVolume)
 					{
-						eventVolume = ((SetVolumeEvent) INTERNAL_eventList[i]).GetVolume();
+						//eventVolume = ((SetVolumeEvent) INTERNAL_eventList[i]).GetVolume();
+						INTERNAL_eventList[i].Apply();
 					}
 					else if (type == XACTEvent.EventTypeCode.SetEquationPitch)
 					{
-						eventPitch = ((SetEquationPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
+						//eventPitch = ((SetEquationPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
+						INTERNAL_eventList[i].Apply();
 					}
 					else if (type == XACTEvent.EventTypeCode.SetRandomPitch)
 					{
-						eventPitch = ((SetRandomPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
+						//eventPitch = ((SetRandomPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
+						INTERNAL_eventList[i].Apply();
 					}
 					else
 					{
@@ -941,7 +947,7 @@ namespace Microsoft.Xna.Framework.Audio
 			return true;
 		}
 
-		private void PlayWave(PlayWaveEvent evt, float? prevVolume = null, float? prevPitch = null)
+		internal void PlayWave(PlayWaveEvent evt, float? prevVolume = null, float? prevPitch = null)
 		{
 			SoundEffectInstance sfi = evt.GenerateInstance(
 				INTERNAL_activeSound.Volume,

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -503,7 +503,12 @@ namespace Microsoft.Xna.Framework.Audio
 					INTERNAL_timer.ElapsedMilliseconds > INTERNAL_eventList[i].Timestamp	)
 				{
 					uint type = INTERNAL_eventList[i].Type;
-					if (type == 1)
+					if (type == 0)
+					{
+						// FIXME: NullEvent used as a placeholder for unsupported event types.
+						Debug.Assert(INTERNAL_eventList[i] is NullEvent);
+					}
+					else if (type == 1)
 					{
 						PlayWave((PlayWaveEvent) INTERNAL_eventList[i]);
 					}
@@ -513,7 +518,11 @@ namespace Microsoft.Xna.Framework.Audio
 					}
 					else if (type == 3)
 					{
-						eventPitch = ((SetPitchEvent) INTERNAL_eventList[i]).GetPitch();
+						eventPitch = ((SetEquationPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
+					}
+					else if (type == 4)
+					{
+						eventPitch = ((SetRandomPitchEvent)INTERNAL_eventList[i]).GetPitch(eventPitch);
 					}
 					else
 					{

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -853,7 +853,7 @@ namespace Microsoft.Xna.Framework.Audio
 		{
 			foreach (XACTEvent curEvent in Events)
 			{
-				if (curEvent.Type == 1)
+				if (curEvent.Type == XACTEvent.EventTypeCode.PlayWave)
 				{
 					((PlayWaveEvent) curEvent).LoadTracks(
 						audioEngine,
@@ -866,10 +866,17 @@ namespace Microsoft.Xna.Framework.Audio
 
 	internal abstract class XACTEvent
 	{
-		public uint Type
+		public enum EventTypeCode
+		{
+			PlayWave = 1,
+			SetVolume = 2,
+			SetEquationPitch = 3,
+			SetRandomPitch = 4
+		}
+
+		public EventTypeCode Type
 		{
 			get;
-			private set;
 		}
 
 		public uint Timestamp
@@ -884,12 +891,12 @@ namespace Microsoft.Xna.Framework.Audio
 
 		protected static readonly Random random = new Random();
 
-		public XACTEvent(uint type, uint timestamp)
+		public XACTEvent(EventTypeCode type, uint timestamp)
 			: this(type, timestamp, 0, 0)
 		{
 		}
 
-		protected XACTEvent(uint type, uint timestamp, int count, float frequency)			
+		protected XACTEvent(EventTypeCode type, uint timestamp, int count, float frequency)			
 		{
 			Type = type;
 			Timestamp = timestamp;
@@ -950,7 +957,7 @@ namespace Microsoft.Xna.Framework.Audio
 			ushort trackVariationType,
 			bool trackVariationOnLoop,
 			byte[] weights
-		) : base(1, timestamp) {
+		) : base(EventTypeCode.PlayWave, timestamp) {
 			INTERNAL_tracks = tracks;
 			INTERNAL_waveBanks = waveBanks;
 			INTERNAL_minPitch = minPitch;
@@ -1122,7 +1129,7 @@ namespace Microsoft.Xna.Framework.Audio
 			uint timestamp,
 			float min,
 			float max
-		) : base(2, timestamp) {
+		) : base(EventTypeCode.SetVolume, timestamp) {
 			INTERNAL_min = min;
 			INTERNAL_max = max;
 		}
@@ -1142,7 +1149,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public SetEquationPitchEvent(uint timestamp, float value, XACTClip.XactEventOp operation, int count = 0,
 			float frequency = 0)
-			: base(3, timestamp, count, frequency)
+			: base(EventTypeCode.SetEquationPitch, timestamp, count, frequency)
 		{
 			this.value = value;
 			this.operation = operation;
@@ -1170,7 +1177,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public SetRandomPitchEvent(uint timestamp, float min, float max, XACTClip.XactEventOp operation, int count = 0,
 			float frequency = 0)
-			: base(4, timestamp, count, frequency)
+			: base(EventTypeCode.SetRandomPitch, timestamp, count, frequency)
 		{
 			this.min = min;
 			this.max = max;

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -889,6 +889,8 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public float Frequency { get; private set; }
 
+		public Cue Cue { get; set; }
+
 		protected static readonly Random random = new Random();
 
 		public XACTEvent(EventTypeCode type, uint timestamp)
@@ -902,7 +904,10 @@ namespace Microsoft.Xna.Framework.Audio
 			Timestamp = timestamp;
 			Count = count;
 			Frequency = frequency;
+			Cue = null;
 		}
+
+		public abstract void Apply();
 	}
 
 	internal class PlayWaveEvent : XACTEvent
@@ -1118,6 +1123,11 @@ namespace Microsoft.Xna.Framework.Audio
 				);
 			}
 		}
+
+		public override void Apply()
+		{
+			Cue.PlayWave(this);
+		}
 	}
 
 	internal class SetVolumeEvent : XACTEvent
@@ -1139,6 +1149,11 @@ namespace Microsoft.Xna.Framework.Audio
 			return INTERNAL_min + (float) (
 				random.NextDouble() * (INTERNAL_max - INTERNAL_min)
 			);
+		}
+
+		public override void Apply()
+		{
+			Cue.eventVolume = GetVolume();
 		}
 	}
 
@@ -1166,6 +1181,11 @@ namespace Microsoft.Xna.Framework.Audio
 				default:
 					return currentPitch;
 			}
+		}
+
+		public override void Apply()
+		{
+			Cue.eventPitch = GetPitch(Cue.eventPitch);
 		}
 	}
 
@@ -1197,6 +1217,11 @@ namespace Microsoft.Xna.Framework.Audio
 					return currentPitch;
 			}
 		}
+
+		public override void Apply()
+		{
+			Cue.eventPitch = GetPitch(Cue.eventPitch);
+		}
 	}
 
 	internal class NullEvent : XACTEvent
@@ -1205,6 +1230,11 @@ namespace Microsoft.Xna.Framework.Audio
 			uint timestamp
 		) : base(0, timestamp)
 		{
+		}
+
+		public override void Apply()
+		{
+			// Do nothing.
 		}
 	}
 }

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -376,11 +376,11 @@ namespace Microsoft.Xna.Framework.Audio
 				reader.ReadUInt16();
 
 				// Load the Event
-				if (eventType == 0) // StopEvent
+				if (eventType == 0x00) // StopEvent
 				{
 					// TODO: Codename OhGodNo
 				}
-				else if (eventType == 1) // Basic PlayWaveEvent
+				else if (eventType == 0x01) // Basic PlayWaveEvent
 				{
 					// Unknown value
 					reader.ReadByte();
@@ -495,7 +495,7 @@ namespace Microsoft.Xna.Framework.Audio
 						weights
 					);
 				}
-				else if (eventType == 4) // PlayWaveEvent with effect variation
+				else if (eventType == 0x04) // PlayWaveEvent with effect variation
 				{
 					// Unknown value
 					reader.ReadByte();
@@ -577,7 +577,7 @@ namespace Microsoft.Xna.Framework.Audio
 						new byte[] { 0xFF }
 					);
 				}
-				else if (eventType == 6) // PlayWaveEvent with track/effect variation
+				else if (eventType == 0x06) // PlayWaveEvent with track/effect variation
 				{
 					// Unknown value
 					reader.ReadByte();
@@ -775,7 +775,7 @@ namespace Microsoft.Xna.Framework.Audio
 							break;
 					}
 				}
-				else if (eventType == 8) // SetVolumeEvent
+				else if (eventType == 0x08) // SetVolumeEvent
 				{
 					// Unknown values
 					reader.ReadBytes(2);

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -310,6 +310,24 @@ namespace Microsoft.Xna.Framework.Audio
 
 	internal class XACTClip
 	{
+		internal enum XactEventSettingType
+		{
+			Equation = 0x00,
+			Ramp = 0x01
+		}
+
+		internal enum XactEventEquationType
+		{
+			Value = 0x04,
+			Random = 0x08
+		}
+
+		internal enum XactEventOp
+		{
+			Replace = 0x00,
+			Add = 0x01
+		}
+
 		public XACTEvent[] Events
 		{
 			get;
@@ -337,24 +355,6 @@ namespace Microsoft.Xna.Framework.Audio
 				false,
 				new byte[] { 0xFF }
 			);
-		}
-
-		internal enum XactEventSettingType
-		{
-			Equation = 0x00,
-			Ramp = 0x01
-		}
-
-		internal enum XactEventEquationType
-		{
-			Value = 0x04,
-			Random = 0x08
-		}
-
-		internal enum XactEventOp
-		{
-			Replace = 0x00,
-			Add = 0x01
 		}
 
 		public XACTClip(BinaryReader reader, double clipVolume, byte filterType)

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -843,7 +843,7 @@ namespace Microsoft.Xna.Framework.Audio
 							{
 								case XactEventEquationType.Value:
 									// Absolute or relative value to set to.
-									float eventValue = reader.ReadSingle() / 100.0f;
+									float eventValue = XACTCalculator.CalculateAmplitudeRatio(reader.ReadSingle() / 100.0f);
 
 									// Unused/unknown trailing bytes.
 									reader.ReadBytes(9);
@@ -863,9 +863,9 @@ namespace Microsoft.Xna.Framework.Audio
 									}
 									break;
 								case XactEventEquationType.Random:
-									// Random pitch Min/Max.
-									float eventMin = reader.ReadSingle() / 100.0f;
-									float eventMax = reader.ReadSingle() / 100.0f;
+									// Random min/max.
+									float eventMin = XACTCalculator.CalculateAmplitudeRatio(reader.ReadSingle() / 100.0f);
+									float eventMax = XACTCalculator.CalculateAmplitudeRatio(reader.ReadSingle() / 100.0f);
 
 									// Unused/unknown trailing bytes.
 									reader.ReadBytes(5);

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -979,8 +979,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public float Frequency { get; private set; }
 
-		public Cue Cue { get; set; }
-
 		protected static readonly Random random = new Random();
 
 		public XACTEvent(uint timestamp)
@@ -993,10 +991,9 @@ namespace Microsoft.Xna.Framework.Audio
 			Timestamp = timestamp;
 			Count = count;
 			Frequency = frequency;
-			Cue = null;
 		}
 
-		public abstract void Apply();
+		public abstract void Apply(Cue cue, XACTClip track);
 	}
 
 	internal class StopEvent : XACTEvent
@@ -1013,19 +1010,19 @@ namespace Microsoft.Xna.Framework.Audio
 			Scope = scope;
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
 			AudioStopOptions stopOptions = StopOptions;
 
 			switch (Scope)
 			{
 				case XACTClip.StopEventScope.Cue:
-					Cue.Stop(stopOptions);
+					cue.Stop(stopOptions);
 					break;
 				case XACTClip.StopEventScope.Track:
 					// FIXME: Need to stop the track
 					// FACT currently doesn't appear to support multiple tracks anyway.
-					//Track.Stop(stopOptions);
+					//track.Stop(stopOptions);
 					throw new NotImplementedException("Stop events targeting the track are not supported!");
 					break;
 			}
@@ -1246,9 +1243,9 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
-			Cue.PlayWave(this);
+			cue.PlayWave(this);
 		}
 	}
 
@@ -1265,9 +1262,9 @@ namespace Microsoft.Xna.Framework.Audio
 			this.operation = operation;
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
-			Cue.eventVolume = GetVolume(Cue.eventVolume);
+			cue.eventVolume = GetVolume(cue.eventVolume);
 		}
 
 		private float GetVolume(float currentVolume)
@@ -1299,9 +1296,9 @@ namespace Microsoft.Xna.Framework.Audio
 			this.operation = operation;
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
-			Cue.eventVolume = GetVolume(Cue.eventVolume);
+			cue.eventVolume = GetVolume(cue.eventVolume);
 		}
 
 		private float GetVolume(float currentVolume)
@@ -1332,9 +1329,9 @@ namespace Microsoft.Xna.Framework.Audio
 			this.operation = operation;
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
-			Cue.eventPitch = GetPitch(Cue.eventPitch);
+			cue.eventPitch = GetPitch(cue.eventPitch);
 		}
 
 		private float GetPitch(float currentPitch)
@@ -1366,9 +1363,9 @@ namespace Microsoft.Xna.Framework.Audio
 			this.operation = operation;
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
-			Cue.eventPitch = GetPitch(Cue.eventPitch);
+			cue.eventPitch = GetPitch(cue.eventPitch);
 		}
 
 		private float GetPitch(float currentPitch)
@@ -1397,7 +1394,7 @@ namespace Microsoft.Xna.Framework.Audio
 			this.markerData = markerData;
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
 			// FIXME: Implement action for a marker event. Some kind of callback?
 		}
@@ -1411,7 +1408,7 @@ namespace Microsoft.Xna.Framework.Audio
 		{
 		}
 
-		public override void Apply()
+		public override void Apply(Cue cue, XACTClip track)
 		{
 			// Do nothing.
 		}

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -1191,16 +1191,17 @@ namespace Microsoft.Xna.Framework.Audio
 			INTERNAL_max = max;
 		}
 
-		public float GetVolume()
-		{
-			return INTERNAL_min + (float) (
-				random.NextDouble() * (INTERNAL_max - INTERNAL_min)
-			);
-		}
 
 		public override void Apply()
 		{
 			Cue.eventVolume = GetVolume();
+		}
+
+		private float GetVolume()
+		{
+			return INTERNAL_min + (float)(
+				random.NextDouble() * (INTERNAL_max - INTERNAL_min)
+			);
 		}
 	}
 
@@ -1217,7 +1218,12 @@ namespace Microsoft.Xna.Framework.Audio
 			this.operation = operation;
 		}
 
-		public float GetPitch(float currentPitch)
+		public override void Apply()
+		{
+			Cue.eventPitch = GetPitch(Cue.eventPitch);
+		}
+
+		private float GetPitch(float currentPitch)
 		{
 			switch (operation)
 			{
@@ -1228,11 +1234,6 @@ namespace Microsoft.Xna.Framework.Audio
 				default:
 					return currentPitch;
 			}
-		}
-
-		public override void Apply()
-		{
-			Cue.eventPitch = GetPitch(Cue.eventPitch);
 		}
 	}
 
@@ -1251,7 +1252,12 @@ namespace Microsoft.Xna.Framework.Audio
 			this.operation = operation;
 		}
 
-		public float GetPitch(float currentPitch)
+		public override void Apply()
+		{
+			Cue.eventPitch = GetPitch(Cue.eventPitch);
+		}
+
+		private float GetPitch(float currentPitch)
 		{
 			float randomPitch = min + (float)(random.NextDouble() * (max - min));
 			switch (operation)
@@ -1263,11 +1269,6 @@ namespace Microsoft.Xna.Framework.Audio
 				default:
 					return currentPitch;
 			}
-		}
-
-		public override void Apply()
-		{
-			Cue.eventPitch = GetPitch(Cue.eventPitch);
 		}
 	}
 

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Xna.Framework.Audio
 		{
 			foreach (XACTClip curClip in INTERNAL_clips)
 			{
-				curClip.LoadTracks(audioEngine, waveBankNames);
+				curClip.LoadEvents(audioEngine, waveBankNames);
 			}
 			HasLoadedTracks = true;
 		}
@@ -849,13 +849,13 @@ namespace Microsoft.Xna.Framework.Audio
 			frequency = reader.ReadUInt16() / 1000.0f;
 		}
 
-		public void LoadTracks(AudioEngine audioEngine, List<string> waveBankNames)
+		public void LoadEvents(AudioEngine audioEngine, List<string> waveBankNames)
 		{
 			foreach (XACTEvent curEvent in Events)
 			{
 				if (curEvent.Type == XACTEvent.EventTypeCode.PlayWave)
 				{
-					((PlayWaveEvent) curEvent).LoadTracks(
+					((PlayWaveEvent) curEvent).LoadWaves(
 						audioEngine,
 						waveBankNames
 					);
@@ -977,7 +977,7 @@ namespace Microsoft.Xna.Framework.Audio
 			INTERNAL_curWave = -1;
 		}
 
-		public void LoadTracks(AudioEngine audioEngine, List<string> waveBankNames)
+		public void LoadWaves(AudioEngine audioEngine, List<string> waveBankNames)
 		{
 			for (int i = 0; i < INTERNAL_waves.Length; i += 1)
 			{

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -853,7 +853,7 @@ namespace Microsoft.Xna.Framework.Audio
 		{
 			foreach (XACTEvent curEvent in Events)
 			{
-				if (curEvent.Type == XACTEvent.EventTypeCode.PlayWave)
+				if (curEvent is PlayWaveEvent)
 				{
 					((PlayWaveEvent) curEvent).LoadWaves(
 						audioEngine,
@@ -866,19 +866,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 	internal abstract class XACTEvent
 	{
-		public enum EventTypeCode
-		{
-			PlayWave = 1,
-			SetVolume = 2,
-			SetEquationPitch = 3,
-			SetRandomPitch = 4
-		}
-
-		public EventTypeCode Type
-		{
-			get;
-		}
-
 		public uint Timestamp
 		{
 			get;
@@ -893,14 +880,13 @@ namespace Microsoft.Xna.Framework.Audio
 
 		protected static readonly Random random = new Random();
 
-		public XACTEvent(EventTypeCode type, uint timestamp)
-			: this(type, timestamp, 0, 0)
+		public XACTEvent(uint timestamp)
+			: this(timestamp, 0, 0)
 		{
 		}
 
-		protected XACTEvent(EventTypeCode type, uint timestamp, int count, float frequency)			
+		protected XACTEvent(uint timestamp, int count, float frequency)			
 		{
-			Type = type;
 			Timestamp = timestamp;
 			Count = count;
 			Frequency = frequency;
@@ -962,7 +948,7 @@ namespace Microsoft.Xna.Framework.Audio
 			ushort trackVariationType,
 			bool trackVariationOnLoop,
 			byte[] weights
-		) : base(EventTypeCode.PlayWave, timestamp) {
+		) : base(timestamp) {
 			INTERNAL_tracks = tracks;
 			INTERNAL_waveBanks = waveBanks;
 			INTERNAL_minPitch = minPitch;
@@ -1139,7 +1125,7 @@ namespace Microsoft.Xna.Framework.Audio
 			uint timestamp,
 			float min,
 			float max
-		) : base(EventTypeCode.SetVolume, timestamp) {
+		) : base(timestamp) {
 			INTERNAL_min = min;
 			INTERNAL_max = max;
 		}
@@ -1164,7 +1150,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public SetEquationPitchEvent(uint timestamp, float value, XACTClip.XactEventOp operation, int count = 0,
 			float frequency = 0)
-			: base(EventTypeCode.SetEquationPitch, timestamp, count, frequency)
+			: base(timestamp, count, frequency)
 		{
 			this.value = value;
 			this.operation = operation;
@@ -1197,7 +1183,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public SetRandomPitchEvent(uint timestamp, float min, float max, XACTClip.XactEventOp operation, int count = 0,
 			float frequency = 0)
-			: base(EventTypeCode.SetRandomPitch, timestamp, count, frequency)
+			: base(timestamp, count, frequency)
 		{
 			this.min = min;
 			this.max = max;
@@ -1228,7 +1214,7 @@ namespace Microsoft.Xna.Framework.Audio
 	{
 		public NullEvent(
 			uint timestamp
-		) : base(0, timestamp)
+		) : base(timestamp)
 		{
 		}
 


### PR DESCRIPTION
This body of work represents my effort to help support at least the parsing of all event types allowed on tracks attached to sounds. I wanted to get this pull request started to get feedback.

At this point it parses all event types I could create with the XACT3 tool (Feb 2010 build).  There are a couple of event types still in the code that are not handled, but I don't know what they are or how to create them.

For many of them I was also able to implement the run-time behavior for the events:

- Stop - Immediate/AsAuthored and Cue scope.  Track scope is not implemented.
- Pitch/Volume - SettingType of Equation, Equation Types of Value and Random, Operations of Replace and Add. Ramp is parsed but not implemented. Repeat behavior is parsed but not implemented.
- Marker - Parsed but not implemented.

Alas, there is still more work to be done to support run-time behavior for the following that was also mentioned above:

- Repeating Events - They are parsed and the data is available, but the mechanics to reshedule the events has not been started.
- Ramp Setting Type - These are parsed and the data is available, but the bounding of the event between the timestamp and the duration, and the respective interpolation are not implemented yet.
- Markers - I've never used these myself, and my understanding is they don't necessarily work correctly in XACT either.

The code could be refactored to avoid duplication as a next step.  But it's a start, and what has been implemented passes my comparison tests. It looks like Play wave also suffers from this. 