### PR TITLE
Fix additive volume calculations. They should be in decibel space.

### DIFF
--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -875,7 +875,7 @@ namespace Microsoft.Xna.Framework.Audio
 						if (equationType == XactEventEquationType.Value)
 						{
 							// Absolute or relative value to set to.
-							float eventValue = XACTCalculator.CalculateAmplitudeRatio(reader.ReadSingle() / 100.0f);
+							float eventValue = reader.ReadSingle() / 100.0f;
 
 							// Unused/unknown trailing bytes.
 							reader.ReadBytes(9);
@@ -911,8 +911,8 @@ namespace Microsoft.Xna.Framework.Audio
 						else if (equationType == XactEventEquationType.Random)
 						{
 							// Random min/max.
-							float eventMin = XACTCalculator.CalculateAmplitudeRatio(reader.ReadSingle() / 100.0f);
-							float eventMax = XACTCalculator.CalculateAmplitudeRatio(reader.ReadSingle() / 100.0f);
+							float eventMin = reader.ReadSingle() / 100.0f;
+							float eventMax = reader.ReadSingle() / 100.0f;
 
 							// Unused/unknown trailing bytes.
 							reader.ReadBytes(5);
@@ -1359,9 +1359,11 @@ namespace Microsoft.Xna.Framework.Audio
 			switch (operation)
 			{
 				case XACTClip.XactEventOp.Replace:
-					return value;
+					return XACTCalculator.CalculateAmplitudeRatio(value);
 				case XACTClip.XactEventOp.Add:
-					return currentVolume + value;
+					return XACTCalculator.CalculateAmplitudeRatio(
+						XACTCalculator.CalculateDecibels(currentVolume) 
+						+ value);
 				default:
 					return currentVolume;
 			}
@@ -1398,13 +1400,15 @@ namespace Microsoft.Xna.Framework.Audio
 
 		private float GetVolume(float currentVolume)
 		{
-			float randomVolume = min + (float) (random.NextDouble() * (max - min));
+			float randomVolumeDb = min + (float) (random.NextDouble() * (max - min));
 			switch (operation)
 			{
 				case XACTClip.XactEventOp.Replace:
-					return randomVolume;
+					return XACTCalculator.CalculateAmplitudeRatio(randomVolumeDb);
 				case XACTClip.XactEventOp.Add:
-					return currentVolume + randomVolume;
+					return XACTCalculator.CalculateAmplitudeRatio(
+						XACTCalculator.CalculateDecibels(currentVolume) +
+						randomVolumeDb);
 				default:
 					return currentVolume;
 			}

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -1209,7 +1209,8 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (INTERNAL_volumeVariationAdd && currentLoop > 0)
 			{
-				result.Volume = prevVolume.Value + XACTCalculator.CalculateAmplitudeRatio(
+				result.Volume = XACTCalculator.CalculateAmplitudeRatio(
+					XACTCalculator.CalculateDecibels(prevVolume.Value) + 
 					random.NextDouble() *
 					(INTERNAL_maxVolume - INTERNAL_minVolume) +
 					INTERNAL_minVolume

--- a/src/Audio/XACTInternal.cs
+++ b/src/Audio/XACTInternal.cs
@@ -30,9 +30,14 @@ namespace Microsoft.Xna.Framework.Audio
 			) / 100.0;
 		}
 
-		public static float CalculateAmplitudeRatio(double decibel)
+		public static double CalculateDecibels(float amplitudeRatio)
 		{
-			return (float) Math.Pow(10, decibel / 20.0);
+			return 20*Math.Log10(amplitudeRatio);
+		}
+
+		public static float CalculateAmplitudeRatio(double decibels)
+		{
+		  return (float) Math.Pow(10, decibels / 20.0);
 		}
 
 		public static float CalculateVolume(byte binaryValue)


### PR DESCRIPTION
After I got all the event types plumbed in I noticed that the volume calculations did not match XACT when add mode was used. I noticed this on the looping with variation.  This fixes that.  The event version most likely suffers from the same issue, so I'll be pushing an additional commit soon.