### PR TITLE
Fix issue with rpc track volumes.

### DIFF
--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -748,26 +748,25 @@ namespace Microsoft.Xna.Framework.Audio
 			for (int i = 0; i < INTERNAL_instancePool.Count; i += 1)
 			{
 				/* The final volume should be the combination of the
-				 * authored volume, category volume, RPC/Event volumes, and fade.
+				 * authored volume, category volume, RPC Track volume, 
+				 * Event volumes, and fade.
 				 */
 				INTERNAL_instancePool[i].Volume = XACTCalculator.CalculateAmplitudeRatio(
 					INTERNAL_instanceVolumes[i] +
-					rpcVolume +
-					INTERNAL_rpcTrackVolumes[i] +
+					(i == 0 ? rpcVolume : INTERNAL_rpcTrackVolumes[i-1]) +
 					eventVolume
 				) * INTERNAL_category.INTERNAL_volume.Value * fadePerc;
 
 				/* The final pitch should be the combination of the
-				 * authored pitch and RPC/Event pitch results.
+				 * authored pitch, RPC Track pitch, and Event pitch.
 				 *
 				 * XACT uses -1200 to 1200 (+/- 12 semitones),
 				 * XNA uses -1.0f to 1.0f (+/- 1 octave).
 				 */
 				INTERNAL_instancePool[i].Pitch = (
 					INTERNAL_instancePitches[i] +
-					rpcPitch +
-					eventPitch +
-					INTERNAL_rpcTrackPitches[i]
+					(i == 0 ? rpcPitch : INTERNAL_rpcTrackPitches[i-1]) +
+					eventPitch
 				) / 1200.0f;
 
 				/* The final filter is determined by the instance's filter type,


### PR DESCRIPTION
Once I added support for Attack/Release RPCs I had a test case with volume attack and release targeting two separate tracks within a single sound.  The first track had an attack from -96db  up to 0db over 2 sec, with a release from 0db down to -96db over 2 seconds as well.  The second track was similar but the duration for both the attack and release was 8 seconds.

FACT did not behave correctly, instead it applied the 2 second attack/release to track 2 instead of track 1.

Looking through the code it appears that FACT uses rcpVolume for "simple" sounds, that is sounds with a single track.  Additional tracks (2 and up) are then stored as overflow in an array INTERNAL_rpcTrackVolumes[].  The code is littered with multiplex/demultiplex patterns to navigate this atypical data structure. Simplifying this is another endeavor, but it appeared that what was missing was the multiplexing of the RPC track volume across rpcVolume and INTERNAL_rpcTrackVolumes[].

Addition of this correctly produced the 2 sec attack/release on track 1 and the 8 sec attack/release on track 2.

I have not explicitly tested it, but by a similar argument, the application of pitch need the same operation.