### PR TITLE
Attack/Release RPC

### DIFF
--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -748,26 +748,25 @@ namespace Microsoft.Xna.Framework.Audio
 			for (int i = 0; i < INTERNAL_instancePool.Count; i += 1)
 			{
 				/* The final volume should be the combination of the
-				 * authored volume, category volume, RPC/Event volumes, and fade.
+				 * authored volume, category volume, RPC Track volume, 
+				 * Event volumes, and fade.
 				 */
 				INTERNAL_instancePool[i].Volume = XACTCalculator.CalculateAmplitudeRatio(
 					INTERNAL_instanceVolumes[i] +
-					rpcVolume +
-					INTERNAL_rpcTrackVolumes[i] +
+					(i == 0 ? rpcVolume : INTERNAL_rpcTrackVolumes[i-1]) +
 					eventVolume
 				) * INTERNAL_category.INTERNAL_volume.Value * fadePerc;
 
 				/* The final pitch should be the combination of the
-				 * authored pitch and RPC/Event pitch results.
+				 * authored pitch, RPC Track pitch, and Event pitch.
 				 *
 				 * XACT uses -1200 to 1200 (+/- 12 semitones),
 				 * XNA uses -1.0f to 1.0f (+/- 1 octave).
 				 */
 				INTERNAL_instancePool[i].Pitch = (
 					INTERNAL_instancePitches[i] +
-					rpcPitch +
-					eventPitch +
-					INTERNAL_rpcTrackPitches[i]
+					(i == 0 ? rpcPitch : INTERNAL_rpcTrackPitches[i-1]) +
+					eventPitch
 				) / 1200.0f;
 
 				/* The final filter is determined by the instance's filter type,

--- a/src/Audio/CueData.cs
+++ b/src/Audio/CueData.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 	internal class XACTSound
 	{
-		private XACTClip[] INTERNAL_clips;
+		internal XACTClip[] INTERNAL_clips;
 
 		public double Volume
 		{

--- a/src/Audio/XACTInternal.cs
+++ b/src/Audio/XACTInternal.cs
@@ -222,6 +222,8 @@ namespace Microsoft.Xna.Framework.Audio
 			Points = rpcPoints;
 		}
 
+		public RPCPoint LastPoint { get { return Points[Points.Length - 1]; } }
+
 		public float CalculateRPC(float varInput)
 		{
 			// Min/Max


### PR DESCRIPTION
Adds support for Attack and Release RPC curves targeting multiple tracks.

There are some interesting XACT observations with this:
- PlayWave "Play Release" options which map to Break Loop flags in the XACT files don't directly interact with the way RPC release curves work.  Break Loop appears to indicate that the sample should be terminated at the next loop boundary not whether to play release RPC curves.
- Only RPC Release Curves attached to the Volume parameter impact the release characteristics.  For example if only the Pitch parameter were addressed, it would not extend the sound.