### PR TITLE
Don't process a new play wave event if we are already stopping.

### DIFF
--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -1248,7 +1248,11 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public override void Apply(Cue cue, XACTClip track, float elapsedTime)
 		{
-			cue.PlayWave(this);
+			// Only actually play if we are not in the process of stopping.
+			if (!cue.IsStopping)
+			{
+				cue.PlayWave(this);
+			}
 			Played = true;
 		}
 	}


### PR DESCRIPTION
If a cue is stopped before a play event has triggered, it shouldn't trigger while the cue is going through the stopping and stop states.