### PR TITLE
Add support for input of multiple character

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -752,9 +752,9 @@ namespace Microsoft.Xna.Framework
 							text = System.Text.Encoding.UTF8.GetString(bytes);
 						}
 
-						if (text.Length > 0)
+						for (var index = 0; index < text.Length; index++)
 						{
-							TextInputEXT.OnTextInput(text[0]);
+							TextInputEXT.OnTextInput(text[index]);
 						}
 					}
 


### PR DESCRIPTION
Input methods sometimes have multiple characters inputted.
However, FNA currently can only capture the first character of a group.
By using a for-loop, FNA will be able to receive multiple characters given by IME.