### PR TITLE
Fix typo in BoundingSphere.Contains()

### DIFF
--- a/src/BoundingSphere.cs
+++ b/src/BoundingSphere.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Xna.Framework
 			{
 				return ContainmentType.Disjoint;
 			}
-			else if (sqDistance <= (Radius * sphere.Radius) * (Radius - sphere.Radius))
+			else if (sqDistance <= (Radius - sphere.Radius) * (Radius - sphere.Radius))
 			{
 				return ContainmentType.Contains;
 			}


### PR DESCRIPTION
Consider this test case:

```csharp
var sphere1 = new BoundingSphere(new Vector3(0, 0, 0), 100f);
var sphere2 = new BoundingSphere(new Vector3(100f, 0, 0), 10f);

var contains = sphere1.Contains(sphere2);
```

The value of `contains` should be `ContainmentType.Intersects` but is actually`ContainmentType.Contains` as a result of the typo which is corrected in this PR.