### PR TITLE
Add ContentReader.platform internal field; Attempt to convert X360 Tex2Ds

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -157,6 +157,7 @@
 		<Compile Include="src\Graphics\DirectionalLight.cs" />
 		<Compile Include="src\Graphics\DisplayMode.cs" />
 		<Compile Include="src\Graphics\DisplayModeCollection.cs" />
+		<Compile Include="src\Graphics\X360TexUtil.cs" />
 		<Compile Include="src\Graphics\DxtUtil.cs" />
 		<Compile Include="src\Graphics\Effect\Effect.cs" />
 		<Compile Include="src\Graphics\Effect\EffectAnnotation.cs" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -225,6 +225,7 @@
     <Compile Include="src\Graphics\DirectionalLight.cs" />
     <Compile Include="src\Graphics\DisplayMode.cs" />
     <Compile Include="src\Graphics\DisplayModeCollection.cs" />
+    <Compile Include="src\Graphics\X360TexUtil.cs" />
     <Compile Include="src\Graphics\DxtUtil.cs" />
     <Compile Include="src\Graphics\Effect\Effect.cs" />
     <Compile Include="src\Graphics\Effect\EffectAnnotation.cs" />

--- a/src/Content/ContentManager.cs
+++ b/src/Content/ContentManager.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Xna.Framework.Content
 				targetPlatformIdentifiers.Contains((char) xnbHeader[3]) )
 			{
 				using (BinaryReader xnbReader = new BinaryReader(stream))
-				using (ContentReader reader = GetContentReaderFromXnb(assetName, ref stream, xnbReader, recordDisposableObject))
+				using (ContentReader reader = GetContentReaderFromXnb(assetName, ref stream, xnbReader, (char) xnbHeader[3], recordDisposableObject))
 				{
 					result = reader.ReadAsset<T>();
 					GraphicsResource resource = result as GraphicsResource;
@@ -456,7 +456,7 @@ namespace Microsoft.Xna.Framework.Content
 
 		#region Private Methods
 
-		private ContentReader GetContentReaderFromXnb(string originalAssetName, ref Stream stream, BinaryReader xnbReader, Action<IDisposable> recordDisposableObject)
+		private ContentReader GetContentReaderFromXnb(string originalAssetName, ref Stream stream, BinaryReader xnbReader, char platform, Action<IDisposable> recordDisposableObject)
 		{
 			byte version = xnbReader.ReadByte();
 			byte flags = xnbReader.ReadByte();
@@ -544,6 +544,7 @@ namespace Microsoft.Xna.Framework.Content
 					graphicsDeviceService.GraphicsDevice,
 					originalAssetName,
 					version,
+					platform,
 					recordDisposableObject
 				);
 			}
@@ -555,6 +556,7 @@ namespace Microsoft.Xna.Framework.Content
 					graphicsDeviceService.GraphicsDevice,
 					originalAssetName,
 					version,
+					platform,
 					recordDisposableObject
 				);
 			}

--- a/src/Content/ContentReader.cs
+++ b/src/Content/ContentReader.cs
@@ -44,6 +44,18 @@ namespace Microsoft.Xna.Framework.Content
 
 		#endregion
 
+		#region Public Properties, FNA Extensions
+
+		public char PlatformEXT
+		{
+			get
+			{
+				return platform;
+			}
+		}
+
+		#endregion
+
 		#region Internal Properties
 
 		internal ContentTypeReader[] TypeReaders
@@ -68,6 +80,7 @@ namespace Microsoft.Xna.Framework.Content
 
 		internal int version;
 		internal int sharedResourceCount;
+		internal char platform;
 
 		#endregion
 
@@ -91,6 +104,7 @@ namespace Microsoft.Xna.Framework.Content
 			GraphicsDevice graphicsDevice,
 			string assetName,
 			int version,
+			char platform,
 			Action<IDisposable> recordDisposableObject
 		) : base(stream) {
 			this.graphicsDevice = graphicsDevice;
@@ -98,6 +112,7 @@ namespace Microsoft.Xna.Framework.Content
 			this.contentManager = manager;
 			this.assetName = assetName;
 			this.version = version;
+			this.platform = platform;
 		}
 
 		#endregion

--- a/src/Content/ContentReader.cs
+++ b/src/Content/ContentReader.cs
@@ -44,18 +44,6 @@ namespace Microsoft.Xna.Framework.Content
 
 		#endregion
 
-		#region Public Properties, FNA Extensions
-
-		public char PlatformEXT
-		{
-			get
-			{
-				return platform;
-			}
-		}
-
-		#endregion
-
 		#region Internal Properties
 
 		internal ContentTypeReader[] TypeReaders

--- a/src/Content/ContentReaders/Texture2DReader.cs
+++ b/src/Content/ContentReaders/Texture2DReader.cs
@@ -168,99 +168,34 @@ namespace Microsoft.Xna.Framework.Content
 						);
 				}
 
-				byte[] fullData = null;
-				int fullDataStartIndex = 0;
-				if (levelData == null)
+				// Swap the image data if required.
+				if (reader.platform == 'x')
 				{
-					if (reader.BaseStream.GetType() == typeof(System.IO.MemoryStream))
+					if (surfaceFormat == SurfaceFormat.Color ||
+						surfaceFormat == SurfaceFormat.ColorBgraEXT)
 					{
-						/* If the ContentReader is backed by a
-						 * MemoryStream, we may need the complete
-						 * stream buffer sooner or later.
-						 */
-						fullData = (((System.IO.MemoryStream) (reader.BaseStream)).GetBuffer());
-						fullDataStartIndex = (int) reader.BaseStream.Position;
-						reader.BaseStream.Seek(
-							levelDataSizeInBytes,
-							System.IO.SeekOrigin.Current
+						levelData = reader.ReadBytes(levelDataSizeInBytes);
+						levelData = X360TexUtil.SwapColor(
+							levelData
 						);
 					}
-					else
+					else if (surfaceFormat == SurfaceFormat.Dxt3)
 					{
-						/* If the ContentReader is not backed by a
-						 * MemoryStream, we have to read the data in.
-						 */
 						levelData = reader.ReadBytes(levelDataSizeInBytes);
+						levelData = X360TexUtil.SwapDxt3(
+							levelData
+						);
 					}
 				}
 
-				if (reader.PlatformEXT == 'x')
+				if (	levelData == null &&
+					reader.BaseStream.GetType() != typeof(System.IO.MemoryStream)	)
 				{
-					byte[] levelDataSrc;
-					int offset;
-					int length;
-					if (levelData != null)
-					{
-						levelDataSrc = levelData;
-						offset = 0;
-						length = levelData.Length;
-					} else {
-						// We're dealing with a MemoryStream containing raw data.
-						levelDataSrc = fullData;
-						offset = fullDataStartIndex;
-						length = levelDataSizeInBytes;
-					}
-
-					// We may or may not need to fix the texture data.
-					byte[] levelDataDst = null;
-
-					unsafe
-					{
-						switch (surfaceFormat)
-						{
-							case SurfaceFormat.Color:
-							case SurfaceFormat.ColorBgraEXT:
-								levelDataDst = new byte[length];
-								for (int i = 0; i < length; i += 4)
-								{
-									levelDataDst[i + 0] = levelDataSrc[offset + i + 3];
-									levelDataDst[i + 1] = levelDataSrc[offset + i + 2];
-									levelDataDst[i + 2] = levelDataSrc[offset + i + 1];
-									levelDataDst[i + 3] = levelDataSrc[offset + i + 0];
-								}
-								break;
-
-							case SurfaceFormat.Dxt1:
-								// ???
-								break;
-
-							case SurfaceFormat.Dxt3:
-								levelDataDst = new byte[length];
-								for (int i = 0; i < length; i += 2)
-								{
-									levelDataDst[i + 0] = levelDataSrc[offset + i + 1];
-									levelDataDst[i + 1] = levelDataSrc[offset + i + 0];
-								}
-								break;
-
-							case SurfaceFormat.Dxt5:
-								// ???
-								break;
-
-							default:
-								// ???
-								break;
-						}
-
-					}
-
-					if (levelDataDst != null)
-					{
-						// We actually had to fix the data.
-						levelData = levelDataDst;
-					}
+					/* If the ContentReader is not backed by a
+					 * MemoryStream, we have to read the data in.
+					 */
+					levelData = reader.ReadBytes(levelDataSizeInBytes);
 				}
-
 				if (levelData != null)
 				{
 					/* If we had to convert the data, or get the data from a
@@ -278,9 +213,13 @@ namespace Microsoft.Xna.Framework.Content
 					texture.SetData<byte>(
 						level,
 						null,
-						fullData,
-						fullDataStartIndex,
+						(((System.IO.MemoryStream) (reader.BaseStream)).GetBuffer()),
+						(int) reader.BaseStream.Position,
 						levelDataSizeInBytes
+					);
+					reader.BaseStream.Seek(
+						levelDataSizeInBytes,
+						System.IO.SeekOrigin.Current
 					);
 				}
 

--- a/src/Graphics/X360TexUtil.cs
+++ b/src/Graphics/X360TexUtil.cs
@@ -1,0 +1,73 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2017 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+#region Using Statements
+using System.IO;
+#endregion
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	internal static class X360TexUtil
+	{
+		#region Internal Static Methods
+		internal static byte[] SwapColor(byte[] imageData)
+		{
+			using (MemoryStream imageStream = new MemoryStream(imageData))
+			{
+				return SwapColor(imageStream, imageData.Length);
+			}
+		}
+
+		internal static byte[] SwapColor(Stream imageStream, int imageLength)
+		{
+			byte[] imageData = new byte[imageLength];
+
+			using (BinaryReader imageReader = new BinaryReader(imageStream))
+			{
+				for (int i = 0; i < imageLength; i += sizeof(uint))
+				{
+					uint data = imageReader.ReadUInt32();
+					imageData[i + 0] = (byte) ((data >> 24) & 0xFF);
+					imageData[i + 1] = (byte) ((data >> 16) & 0xFF);
+					imageData[i + 2] = (byte) ((data >> 8)  & 0xFF);
+					imageData[i + 3] = (byte) ((data >> 0)  & 0xFF);
+				}
+			}
+
+			return imageData;
+		}
+
+		internal static byte[] SwapDxt3(byte[] imageData)
+		{
+			using (MemoryStream imageStream = new MemoryStream(imageData))
+			{
+				return SwapDxt3(imageStream, imageData.Length);
+			}
+		}
+
+		internal static byte[] SwapDxt3(Stream imageStream, int imageLength)
+		{
+			byte[] imageData = new byte[imageLength];
+
+			using (BinaryReader imageReader = new BinaryReader(imageStream))
+			{
+				for (int i = 0; i < imageLength; i += sizeof(ushort))
+				{
+					ushort data = imageReader.ReadUInt16();
+					imageData[i + 0] = (byte) ((data >> 8) & 0xFF);
+					imageData[i + 1] = (byte) ((data >> 0) & 0xFF);
+				}
+			}
+
+			return imageData;
+		}
+		#endregion
+
+	}
+}


### PR DESCRIPTION
This PR adds the `char ContentReader.PlatformEXT` property, which is the 4th "header" byte. It allows `ContentTypeReader`s to check the content platform and to handle the content accordingly.

It also adds basic support for `Color`, `ColorBgraExt` and `Dxt3` textures in X360 XNBs by swapping anything accordingly in `Texture2DReader` before `SetData`. This builds upon the above change.