### PR TITLE
Fix X360TexUtil fail if !SupportsS3tc and add (untested) X360 Dxt1 / Dxt5 swap

### DIFF
--- a/src/Content/ContentReaders/Texture2DReader.cs
+++ b/src/Content/ContentReaders/Texture2DReader.cs
@@ -136,11 +136,60 @@ namespace Microsoft.Xna.Framework.Content
 					continue;
 				}
 
+				// Swap the image data if required.
+				if (reader.platform == 'x')
+				{
+					if (	surfaceFormat == SurfaceFormat.Color ||
+						surfaceFormat == SurfaceFormat.ColorBgraEXT	)
+					{
+						if (levelData == null)
+						{
+							levelData = reader.ReadBytes(levelDataSizeInBytes);
+						}
+						levelData = X360TexUtil.SwapColor(
+							levelData
+						);
+					}
+					else if (surfaceFormat == SurfaceFormat.Dxt1		)
+					{
+						if (levelData == null)
+						{
+							levelData = reader.ReadBytes(levelDataSizeInBytes);
+						}
+						levelData = X360TexUtil.SwapDxt1(
+							levelData, width, height
+						);
+					}
+					else if (surfaceFormat == SurfaceFormat.Dxt3		)
+					{
+						if (levelData == null)
+						{
+							levelData = reader.ReadBytes(levelDataSizeInBytes);
+						}
+						levelData = X360TexUtil.SwapDxt3(
+							levelData, width, height
+						);
+					}
+					else if (surfaceFormat == SurfaceFormat.Dxt5		)
+					{
+						if (levelData == null)
+						{
+							levelData = reader.ReadBytes(levelDataSizeInBytes);
+						}
+						levelData = X360TexUtil.SwapDxt5(
+							levelData, width, height
+						);
+					}
+				}
+
 				// Convert the image data if required
 				if (	surfaceFormat == SurfaceFormat.Dxt1 &&
 					!reader.GraphicsDevice.GLDevice.SupportsDxt1	)
 				{
-						levelData = reader.ReadBytes(levelDataSizeInBytes);
+						if (levelData == null)
+						{
+							levelData = reader.ReadBytes(levelDataSizeInBytes);
+						}
 						levelData = DxtUtil.DecompressDxt1(
 							levelData,
 							levelWidth,
@@ -150,7 +199,10 @@ namespace Microsoft.Xna.Framework.Content
 				else if (	surfaceFormat == SurfaceFormat.Dxt3 &&
 						!reader.GraphicsDevice.GLDevice.SupportsS3tc	)
 				{
-						levelData = reader.ReadBytes(levelDataSizeInBytes);
+						if (levelData == null)
+						{
+							levelData = reader.ReadBytes(levelDataSizeInBytes);
+						}
 						levelData = DxtUtil.DecompressDxt3(
 							levelData,
 							levelWidth,
@@ -160,32 +212,15 @@ namespace Microsoft.Xna.Framework.Content
 				else if (	surfaceFormat == SurfaceFormat.Dxt5 &&
 						!reader.GraphicsDevice.GLDevice.SupportsS3tc	)
 				{
-						levelData = reader.ReadBytes(levelDataSizeInBytes);
+						if (levelData == null)
+						{
+							levelData = reader.ReadBytes(levelDataSizeInBytes);
+						}
 						levelData = DxtUtil.DecompressDxt5(
 							levelData,
 							levelWidth,
 							levelHeight
 						);
-				}
-
-				// Swap the image data if required.
-				if (reader.platform == 'x')
-				{
-					if (	surfaceFormat == SurfaceFormat.Color ||
-						surfaceFormat == SurfaceFormat.ColorBgraEXT)
-					{
-						levelData = reader.ReadBytes(levelDataSizeInBytes);
-						levelData = X360TexUtil.SwapColor(
-							levelData
-						);
-					}
-					else if (surfaceFormat == SurfaceFormat.Dxt3)
-					{
-						levelData = reader.ReadBytes(levelDataSizeInBytes);
-						levelData = X360TexUtil.SwapDxt3(
-							levelData
-						);
-					}
 				}
 
 				if (	levelData == null &&


### PR DESCRIPTION
It seems like Dxt1, Dxt3 and Dxt5 store their data in 16 bit "chunks" (at least Dxt3 does) and I actually _swapped the compressed data. It simply worked out of sheer luck._

This PR fixes the X360 Dxt3 swapper if `!reader.GraphicsDevice.GLDevice.SupportsS3tc` and adds Dxt1 and Dxt5 swappers, based on the assumption that all data is stored in 16 bit "chunks." 2 byte sized pairs need to be swapped in Dxt3.

This was only tested with X360 Dxt3 textures. I've thus added `SwapEndian` for `ushort`, `uint` and `ulong` to X360TexUtil as preparation if the "16 bit chunks" assumption turns out to be incorrect for Dxt1 / Dxt5.

I could've kept the existing Dxt3 swapping method and theoretically could've reused it for Dxt1 / Dxt5, but it didn't offer any sort of explanation on what's actually going on.