### PR TITLE
Xbox 360 DXT3 and DXT5 texture swappers fixed

### DIFF
--- a/src/Graphics/X360TexUtil.cs
+++ b/src/Graphics/X360TexUtil.cs
@@ -163,43 +163,36 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		private static void SwapDxt1Block(BinaryReader imageReader, BinaryWriter imageWriter)
 		{
-			// Swap 2 shorts.
+			// Fix the following two big-endian words to litte-endian words.
 			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
 			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
 
-			// This seems to be two 16 bit values instead of a 32 bit table.
+			// Two words / 16 bit values instead of a 4 byte / 32 bit table.
 			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
 			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
 		}
 
 		private static void SwapDxt3Block(BinaryReader imageReader, BinaryWriter imageWriter)
 		{
-			// The DXT3 alpha data is actually already correct.
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
+			// Alpha data. 16 4-bit values, but written to / read from as 4 16-bit values.
+			// Somehow, that one test game I had worked just fine with this unchanged... -ade
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
 
 			SwapDxt1Block(imageReader, imageWriter);
 		}
 
 		private static void SwapDxt5Block(BinaryReader imageReader, BinaryWriter imageWriter)
 		{
-			// Alpha minimum and maximum.
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
+			// Alpha minimum and maximum. Two bytes, but handled internally as one word.
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
 
-			// This actually seems to be correct already.
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
-			imageWriter.Write(imageReader.ReadByte());
+			// Alpha indices. 16 3-bit values, but written to / read from as 3 16-bit values.
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
+			imageWriter.Write(SwapEndian(imageReader.ReadUInt16()));
 
 			SwapDxt1Block(imageReader, imageWriter);
 		}


### PR DESCRIPTION
The DXT5 swapper is fixed, tested with the textures in Terraria X360. Also based on Terraria X360, the DXT1 swapper currently built into FNA is already fully functional.

Unrelated to the DXT5 swapper but related to my previous pull request, I also had to fix the DXT3 swapper one last time:

>I just noticed that the DXT3 alpha data is already correct - I was really lucky with the initial "fix" to this issue (swapping everything as if everything's a big-endian word / short)!

I wasn't at home during the weekend, so I only took the last snapped screenshots for comparison purposes and "Mute Crimson" for testing. That game looks okay when leaving the DXT3 alpha data as is.

But when I came back home yesterday, I tested the new DXT3 swapper on my main PC and noticed that the textures in other games were broken again.

I'm sorry for not having tested it enough before committing. I've now tested the current DXT3 swapper with all games I can throw at it right now and it seems to work properly now.