### PR TITLE
ExternalReferenceReader.TargetType is null in XNA

### DIFF
--- a/src/Content/ContentReaders/ExternalReferenceReader.cs
+++ b/src/Content/ContentReaders/ExternalReferenceReader.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Xna.Framework.Content
 	{
 		#region Public Constructor
 
-		public ExternalReferenceReader() : base(typeof(object))
+		public ExternalReferenceReader() : base(null)
 		{
 		}
 

--- a/src/Content/ContentTypeReaderManager.cs
+++ b/src/Content/ContentTypeReaderManager.cs
@@ -213,7 +213,10 @@ namespace Microsoft.Xna.Framework.Content
 						}
 					}
 
-					contentReaders.Add(newReaders[i].TargetType, newReaders[i]);
+					if (newReaders[i].TargetType != null)
+					{
+						contentReaders.Add(newReaders[i].TargetType, newReaders[i]);
+					}
 
 					/* I think the next 4 bytes refer to the "Version" of the type reader,
 					 * although it always seems to be zero.


### PR DESCRIPTION
It's "legal" for games to list / use `ExternalReferenceReader` more than once in a single XNB.

FNA fails because `contentReaders.Add(newReaders[i].TargetType, newReaders[i]);` in `ContentTypeReaderManager.LoadAssetReaders` fails if a mapping for the target type already exists.

While debugging the issue, I noticed that when using XNA, `ExternalReferenceReader.TargetType` is null and that `ContentTypeReaderManager.GetTypeReader(typeof(object))` doesn't return the reader. 

Sample code:
```cs
Type t_ExternalReferenceReader = typeof(ContentTypeReader).Assembly.GetType("Microsoft.Xna.Framework.Content.ExternalReferenceReader");
Type target = ((ContentTypeReader) Activator.CreateInstance(t_ExternalReferenceReader)).TargetType;
Console.WriteLine($"ExternalReferenceReader.TargetType: {target} (== null: {target == null})");
```

Output using XNA:
```
ExternalReferenceReader.TargetType:  (== null: True)
```

Output using FNA:
```
ExternalReferenceReader.TargetType: System.Object (== null: False)
```