### PR TITLE
fix openbsd and freebsd library names

### DIFF
--- a/FNA.dll.config
+++ b/FNA.dll.config
@@ -2,15 +2,18 @@
 <configuration>
 	<dllmap dll="SDL2.dll" os="windows" target="SDL2.dll"/>
 	<dllmap dll="SDL2.dll" os="osx" target="libSDL2-2.0.0.dylib"/>
-	<dllmap dll="SDL2.dll" os="linux,freebsd,openbsd,netbsd" target="libSDL2-2.0.so.0"/>
+	<dllmap dll="SDL2.dll" os="linux,freebsd,netbsd" target="libSDL2-2.0.so.0"/>
+	<dllmap dll="SDL2.dll" os="openbsd" target="libSDL2.so.0"/>
 
 	<dllmap dll="SDL2_image.dll" os="windows" target="SDL2_image.dll"/>
 	<dllmap dll="SDL2_image.dll" os="osx" target="libSDL2_image-2.0.0.dylib"/>
-	<dllmap dll="SDL2_image.dll" os="linux,freebsd,openbsd,netbsd" target="libSDL2_image-2.0.so.0"/>
+	<dllmap dll="SDL2_image.dll" os="linux,freebsd,netbsd" target="libSDL2_image-2.0.so.0"/>
+	<dllmap dll="SDL2_image.dll" os="openbsd" target="libSDL2_image.so.0"/>
 
 	<dllmap dll="soft_oal.dll" os="windows" target="soft_oal.dll"/>
 	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib"/>
-	<dllmap dll="soft_oal.dll" os="linux,freebsd,openbsd,netbsd" target="libopenal.so.1"/>
+	<dllmap dll="soft_oal.dll" os="linux,freebsd,netbsd" target="libopenal.so.1"/>
+	<dllmap dll="soft_oal.dll" os="openbsd" target="libopenal.so"/>
 
 	<dllmap dll="MojoShader.dll" os="windows" target="MojoShader.dll"/>
 	<dllmap dll="MojoShader.dll" os="osx" target="libmojoshader.dylib"/>
@@ -18,7 +21,8 @@
 
 	<dllmap dll="libvorbisfile.dll" os="windows" target="libvorbisfile.dll"/>
 	<dllmap dll="libvorbisfile.dll" os="osx" target="libvorbisfile.3.dylib"/>
-	<dllmap dll="libvorbisfile.dll" os="linux,freebsd,openbsd,netbsd" target="libvorbisfile.so.3"/>
+	<dllmap dll="libvorbisfile.dll" os="linux,freebsd,netbsd" target="libvorbisfile.so.3"/>
+	<dllmap dll="libvorbisfile.dll" os="openbsd" target="libvorbisfile.so"/>
 
 	<dllmap dll="libtheorafile.dll" os="windows" target="libtheorafile.dll"/>
 	<dllmap dll="libtheorafile.dll" os="osx" target="libtheorafile.dylib"/>

--- a/FNA.dll.config
+++ b/FNA.dll.config
@@ -13,7 +13,7 @@
 	<dllmap dll="soft_oal.dll" os="windows" target="soft_oal.dll"/>
 	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib"/>
 	<dllmap dll="soft_oal.dll" os="linux,freebsd,netbsd" target="libopenal.so.1"/>
-	<dllmap dll="soft_oal.dll" os="openbsd" target="libopenal.so"/>
+	<dllmap dll="soft_oal.dll" os="freebsd,openbsd" target="libopenal.so"/>
 
 	<dllmap dll="MojoShader.dll" os="windows" target="MojoShader.dll"/>
 	<dllmap dll="MojoShader.dll" os="osx" target="libmojoshader.dylib"/>

--- a/FNA.dll.config
+++ b/FNA.dll.config
@@ -13,7 +13,7 @@
 	<dllmap dll="soft_oal.dll" os="windows" target="soft_oal.dll"/>
 	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib"/>
 	<dllmap dll="soft_oal.dll" os="linux,freebsd,netbsd" target="libopenal.so.1"/>
-	<dllmap dll="soft_oal.dll" os="freebsd,openbsd" target="libopenal.so"/>
+	<dllmap dll="soft_oal.dll" os="openbsd" target="libopenal.so"/>
 
 	<dllmap dll="MojoShader.dll" os="windows" target="MojoShader.dll"/>
 	<dllmap dll="MojoShader.dll" os="osx" target="libmojoshader.dylib"/>


### PR DESCRIPTION
Sigh, these *BSD always coming up with their own rules ;-)

Explanation:

* OpenBSD doesn't use the `-2.0` for SDL2 and related libs
* major for libopenal and libvorbisfile that is available is different, but per testing compatible. The way I've been successfully working with it is to leave the major out of the config and let the dynamic linker link it to the available one. I know this is not ideal, but the best I can come up with in a situation where using bundled libraries is essentially out of the question.
* freebsd's libopenal major is listed as 0, would also suggest leaving out the version here
* I wasn't able to find `.so` in netbsd's plist. I don't run it myself, so I can't just look for an explanation. I've started asking around and if I find out how netbsd can be included, I'll let you know.

Ok?