### PR TITLE
Allow .NET 4.0 projects to reference FNA.Core

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<PropertyGroup>


### PR DESCRIPTION
Multi-targeting will help where library developers want to support both variants in a single assembly.