### PR TITLE
Fix TitleLocation.Path regression

### DIFF
--- a/src/TitleLocation.cs
+++ b/src/TitleLocation.cs
@@ -19,18 +19,29 @@ namespace Microsoft.Xna.Framework
 
 		public static string Path
 		{
-			get;
-			private set;
+			get
+			{
+				/* This property was previously prepared with the help
+				 * of a class (static) constructor and a private setter.
+				 * 
+				 * Unfortunately, it caused issues when the game reflected
+				 * into TitleLocation.Path before FNAPlatform had a chance
+				 * to initialize the platform, which itself requires the path.
+				 * 
+				 * This "lazy property" fixes the issue.
+				 * -ade
+				 */
+				if (INTERNAL_Path != null)
+					return INTERNAL_Path;
+				return INTERNAL_Path = FNAPlatform.GetBaseDirectory();
+			}
 		}
 
 		#endregion
 
-		#region Static Constructor
+		#region Private Static Fields
 
-		static TitleLocation()
-		{
-			Path = FNAPlatform.GetBaseDirectory();
-		}
+		private static string INTERNAL_Path;
 
 		#endregion
 	}


### PR DESCRIPTION
Setting up `TitleLocation.Path` using a static constructor introduced a regression on games reflecting into `TitleLocation.Path` before` FNAPlatform` has been set up:

- Game reflects into `TitleLocation.Path`
- `TitleLocation` class constrctor calls `FNAPlatform.GetBaseDirectory`
- `FNAPlatform` class constructor runs
- `FNAPlatform` sets `GetBaseDirectory`
- `FNAPlatform` calls `ProgramInit`
- `ProgramInit` uses `TitleLocation.Path`
- `ProgramInit` receives uninitialized Path (== null)
- `ProgramInit` throws exception

The game in question is "Fusion: Genesis".

This "lazy property" fixes the issue while maintaining compatibility with all existing and future `TitleLocation.Path` usages.