### PR TITLE
Prevent propagating MediaPlayer's Volume property to already disposed Songs

### DIFF
--- a/src/Media/Xiph/Song.cs
+++ b/src/Media/Xiph/Song.cs
@@ -112,7 +112,10 @@ namespace Microsoft.Xna.Framework.Media
 				 * We need to detach this source from the AL listener properties.
 				 * -flibit
 				 */
-				soundStream.Volume = value * (1.0f / SoundEffect.MasterVolume);
+				if (!IsDisposed) 
+				{
+					soundStream.Volume = value * (1.0f / SoundEffect.MasterVolume);
+				}
 			}
 		}
 


### PR DESCRIPTION
If you 

1. play a Song using MediaPlayer, 
2. stop this Song using MediaPlayer
3. dispose the Song / ContentManager
4. set the Volume property of MediaPlayer to any value

you get a NullReferenceException as the disposed song is still in the MediaPlayer's MediaQueue and the volume is propagated to every Song in the queue.