### PR TITLE
Use DeadSounds as a queue for sounds that need to be stopped.

### DIFF
--- a/src/FrameworkDispatcher.cs
+++ b/src/FrameworkDispatcher.cs
@@ -34,10 +34,14 @@ namespace Microsoft.Xna.Framework
 			/* Updates the status of various framework components
 			 * (such as power state and media), and raises related events.
 			 */
-			foreach (SoundEffectInstance sound in DeadSounds)
-			{
-				sound.Stop(true);
-			}
+            while (true) {
+                var count = DeadSounds.Count;
+                if (count == 0)
+                    break;
+                count--;
+                DeadSounds[count].Stop(true);
+                DeadSounds.RemoveAt(count);
+            }
 			foreach (DynamicSoundEffectInstance stream in Streams)
 			{
 				stream.Update();


### PR DESCRIPTION
Works around ConcurrentModificationException
Works around sounds getting stopped every update tick after first time the sound got added.
(Is there an issue here that if two copies of the sound are started with a few seconds offset, that stopping one doesn't cancel the other?)