### PR TITLE
Make threadsafe FrameworkDispatcher.EnqueueSoundEffectInstanceStop

### DIFF
--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -481,7 +481,7 @@ namespace Microsoft.Xna.Framework.Audio
 		{
 			FAudio.FAudioSourceVoice_Stop(handle, 0, 0);
 			State = SoundState.Stopped;
-			FrameworkDispatcher.DeadSounds.Enqueue(this);
+			FrameworkDispatcher.EnqueueSoundEffectInstanceStop(this);
 		}
 
 		private unsafe void SetPanMatrixCoefficients()


### PR DESCRIPTION
Use SpinLock  to protect the DeadSounds when accessing from multiple threads.
Using a SpinLock to avoid yielding the very latency sensitive mixer thread.