### PR TITLE
Fix MemoryStream buffer privacy ambiguity

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -329,6 +329,7 @@
 		<Compile Include="src\TitleLocation.cs" />
 		<Compile Include="src\Utilities\AssemblyHelper.cs" />
 		<Compile Include="src\Utilities\FileHelpers.cs" />
+		<Compile Include="src\Utilities\FNAInternalExtensions.cs" />
 		<Compile Include="src\Vector2.cs" />
 		<Compile Include="src\Vector3.cs" />
 		<Compile Include="src\Vector4.cs" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -397,6 +397,7 @@
     <Compile Include="src\TitleLocation.cs" />
     <Compile Include="src\Utilities\AssemblyHelper.cs" />
     <Compile Include="src\Utilities\FileHelpers.cs" />
+    <Compile Include="src\Utilities\FNAInternalExtensions.cs" />
     <Compile Include="src\Vector2.cs" />
     <Compile Include="src\Vector3.cs" />
     <Compile Include="src\Vector4.cs" />

--- a/src/Content/ContentReaders/Texture2DReader.cs
+++ b/src/Content/ContentReaders/Texture2DReader.cs
@@ -239,31 +239,18 @@ namespace Microsoft.Xna.Framework.Content
 
 				int levelDataByteOffset = 0;
 				if (	levelData == null &&
-					reader.BaseStream is MemoryStream)
+					reader.BaseStream is MemoryStream &&
+					((MemoryStream) reader.BaseStream).TryGetBuffer(out levelData))
 				{
 					/* Ideally, we didn't have to perform any conversion or
 					 * unnecessary reading. Just throw the buffer directly
 					 * into SetData, skipping a redundant byte[] copy.
 					 */
-					try
-					{
-						levelData = ((MemoryStream) reader.BaseStream).GetBuffer();
-					}
-					catch (UnauthorizedAccessException)
-					{
-						// MemoryStream buffer isn't public, fall back to ReadBytes.
-					}
-					if (levelData != null)
-					{
-						/* Only set the offset and seek if we were able
-						 * to obtain the MemoryStream buffer.
-						 */
-						levelDataByteOffset = (int) reader.BaseStream.Seek(0, SeekOrigin.Current);
-						reader.BaseStream.Seek(
-							levelDataSizeInBytes,
-							SeekOrigin.Current
-						);
-					}
+					levelDataByteOffset = (int) reader.BaseStream.Seek(0, SeekOrigin.Current);
+					reader.BaseStream.Seek(
+						levelDataSizeInBytes,
+						SeekOrigin.Current
+					);
 				}
 				if (	levelData == null)
 				{

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -552,14 +552,28 @@ namespace Microsoft.Xna.Framework.Graphics
 				levels > 1,
 				format
 			);
+			
+			byte[] memoryStreamBuffer = null;
 			if (stream is MemoryStream)
+			{
+				try
+				{
+					memoryStreamBuffer = ((MemoryStream) stream).GetBuffer();
+				}
+				catch (UnauthorizedAccessException)
+				{
+					// MemoryStream buffer isn't public, fall back to ReadBytes.
+					memoryStreamBuffer = null;
+				}
+			}
+			if (memoryStreamBuffer != null)
 			{
 				for (int i = 0; i < levels; i += 1)
 				{
 					result.SetData(
 						i,
 						null,
-						((MemoryStream) stream).GetBuffer(),
+						memoryStreamBuffer,
 						(int) stream.Seek(0, SeekOrigin.Current),
 						levelSize
 					);

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -553,27 +553,16 @@ namespace Microsoft.Xna.Framework.Graphics
 				format
 			);
 			
-			byte[] memoryStreamBuffer = null;
-			if (stream is MemoryStream)
-			{
-				try
-				{
-					memoryStreamBuffer = ((MemoryStream) stream).GetBuffer();
-				}
-				catch (UnauthorizedAccessException)
-				{
-					// MemoryStream buffer isn't public, fall back to ReadBytes.
-					memoryStreamBuffer = null;
-				}
-			}
-			if (memoryStreamBuffer != null)
+			byte[] tex = null;
+			if (	stream is MemoryStream &&
+				((MemoryStream) stream).TryGetBuffer(out tex))
 			{
 				for (int i = 0; i < levels; i += 1)
 				{
 					result.SetData(
 						i,
 						null,
-						memoryStreamBuffer,
+						tex,
 						(int) stream.Seek(0, SeekOrigin.Current),
 						levelSize
 					);
@@ -591,7 +580,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				for (int i = 0; i < levels; i += 1)
 				{
-					byte[] tex = reader.ReadBytes(levelSize);
+					tex = reader.ReadBytes(levelSize);
 					result.SetData(
 						i,
 						null,

--- a/src/Utilities/FNAInternalExtensions.cs
+++ b/src/Utilities/FNAInternalExtensions.cs
@@ -1,0 +1,70 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2018 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.IO;
+using System.Reflection;
+#endregion
+
+namespace Microsoft.Xna.Framework
+{
+	internal static class FNAInternalExtensions
+	{
+
+		#region MemoryStream.TryGetBuffer Extension
+
+		private readonly static FieldInfo f_MemoryStream_Public =
+			// .NET
+			typeof(MemoryStream).GetField("_exposable", BindingFlags.NonPublic | BindingFlags.Instance) ??
+			// Old Mono
+			typeof(MemoryStream).GetField("allowGetBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
+
+		/// <summary>
+		/// Returns the array of unsigned bytes from which this stream was created.
+		/// The return value indicates whether the conversion succeeded.
+		/// This is similar to .NET 4.6's TryGetBuffer.
+		/// </summary>
+		/// <param name="stream">The stream to get the buffer from.</param>
+		/// <param name="buffer">The byte array from which this stream was created.</param>
+		/// <returns><b>true</b> if the conversion was successful; otherwise, <b>false</b>.</returns>
+		internal static bool TryGetBuffer(this MemoryStream stream, out byte[] buffer)
+		{
+			// Check if the buffer is public by reflecting into a known internal field.
+			if (f_MemoryStream_Public != null)
+			{
+				if ((bool) f_MemoryStream_Public.GetValue(stream))
+				{
+					buffer = stream.GetBuffer();
+					return true;
+				}
+				else
+				{
+					buffer = null;
+					return false;
+				}
+			}
+
+			// If no known field can be found, use a horribly slow try-catch instead.
+			try
+			{
+				buffer = stream.GetBuffer();
+				return true;
+			}
+			catch (UnauthorizedAccessException)
+			{
+				buffer = null;
+				return false;
+			}
+		}
+
+		#endregion
+
+	}
+}


### PR DESCRIPTION
FNA uses `MemoryStream.GetBuffer`, which causes issues when a game's `ContentManager.OpenStream` returns a `MemoryStream` with a private buffer.

This pull request changes the behavior in `Texture2DReader` and `Texture2D` to try `MemoryStream.GetBuffer` first. If it fails, it falls back to reading the stream's contents.

In `Texture2DReader` specifically, all codepaths now lead up to

```cs
texture.SetData(level, null, levelData, levelDataByteOffset, levelDataSizeInBytes);
```

with the `ReadBytes` fallback being used only if no conversion occurred and if the buffer wasn't successfully obtained beforehand.

`Texture2DReader` and `Texture2D` were the only places I've found where `MemoryStream.GetBuffer` is being used.

Edit: To clarify, the "ambiguity" (misassumption? I don't know what word fits this best 😅) stems from the fact that we always assumed that the passed `MemoryStream`'s buffer is public. While this is guaranteed when we're internally using a `MemoryStream` when f.e. decompressing, this assumption is incorrect for `MemoryStream`s provided by the game.