### PR TITLE
Added rewind to the start of the stream at the Texture2D.FromStream

### DIFF
--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -337,6 +337,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public static Texture2D FromStream(GraphicsDevice graphicsDevice, Stream stream)
 		{
+			if (stream.CanSeek)
+			{
+				stream.Seek(0, SeekOrigin.Begin);
+			}
+
 			// Read the image data from the stream
 			int width, height;
 			byte[] pixels;


### PR DESCRIPTION
Right now, following code doesnt work in the FNA:
```c#
            using (var memoryStream = new MemoryStream())
            {
                using (var fileStream = File.OpenRead("d:\\temp\\default_uiskin.png"))
                {
                    fileStream.CopyTo(memoryStream);
                }

                _texture = Texture2D.FromStream(GraphicsDevice, memoryStream);
            }
```
Because memoryStream points to the end just before Texture2D.FromStream call.
While same code works well in the XNA.
This PR makes FNA work same as XNA.