### PR TITLE
Texture from stream fix2

### DIFF
--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public static Texture2D FromStream(GraphicsDevice graphicsDevice, Stream stream)
 		{
-			if (stream.CanSeek)
+			if (stream.CanSeek && stream.Position == stream.Length)
 			{
 				stream.Seek(0, SeekOrigin.Begin);
 			}


### PR DESCRIPTION
This is small fix for #206.
Probably it's not good idea to rewind stream every time in the Texture2D.FromStream.
This fix does it only if the stream is at end.