### PR TITLE
Refactoring of OpenGL devices

### DIFF
--- a/FNA.csproj
+++ b/FNA.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -194,13 +194,13 @@
     <Compile Include="src\DisplayOrientation.cs" />
     <Compile Include="src\DrawableGameComponent.cs" />
     <Compile Include="src\FNALoggerEXT.cs" />
+    <Compile Include="src\FNAPlatform\BaseOpenGLDevice.cs" />
     <Compile Include="src\FNAPlatform\FNAPlatform.cs" />
     <Compile Include="src\FNAPlatform\FNAWindow.cs" />
     <Compile Include="src\FNAPlatform\IGLDevice.cs" />
     <Compile Include="src\FNAPlatform\ModernGLDevice.cs" />
     <Compile Include="src\FNAPlatform\ModernGLDevice_GL.cs" />
     <Compile Include="src\FNAPlatform\OpenGLDevice.cs" />
-    <Compile Include="src\FNAPlatform\OpenGLDevice_GL.cs" />
     <Compile Include="src\FNAPlatform\SDL2_FNAPlatform.cs" />
     <Compile Include="src\FrameworkDispatcher.cs" />
     <Compile Include="src\Game.cs" />

--- a/src/FNAPlatform/BaseOpenGLDevice.cs
+++ b/src/FNAPlatform/BaseOpenGLDevice.cs
@@ -17,8 +17,28 @@ using SDL2;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	internal partial class OpenGLDevice : IGLDevice
+	internal class BaseOpenGLDevice
 	{
+		#region Fields
+
+		protected bool useES3;
+		protected bool useCoreProfile;
+		protected bool supportsMultisampling;
+		protected bool supportsFauxBackbuffer;
+		protected bool supportsBaseVertex;
+
+		#endregion
+
+		#region Properties
+
+		public bool SupportsHardwareInstancing
+		{
+			get;
+			protected set;
+		}
+
+		#endregion
+
 		#region Private OpenGL Entry Points
 
 		internal enum GLenum : int
@@ -221,9 +241,9 @@ namespace Microsoft.Xna.Framework.Graphics
 		/* BEGIN GET FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate IntPtr GetString(GLenum pname);
-		private GetString INTERNAL_glGetString;
-		private string glGetString(GLenum pname)
+		public delegate IntPtr GetString(GLenum pname);
+		public GetString INTERNAL_glGetString;
+		public string glGetString(GLenum pname)
 		{
 			unsafe
 			{
@@ -232,196 +252,196 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GetIntegerv(GLenum pname, out int param);
-		private GetIntegerv glGetIntegerv;
+		public delegate void GetIntegerv(GLenum pname, out int param);
+		public GetIntegerv glGetIntegerv;
 
 		/* END GET FUNCTIONS */
 
 		/* BEGIN ENABLE/DISABLE FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void Enable(GLenum cap);
-		private Enable glEnable;
+		public delegate void Enable(GLenum cap);
+		public Enable glEnable;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void Disable(GLenum cap);
-		private Disable glDisable;
+		public delegate void Disable(GLenum cap);
+		public Disable glDisable;
 
 		/* END ENABLE/DISABLE FUNCTIONS */
 
 		/* BEGIN VIEWPORT/SCISSOR FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void G_Viewport(
+		public delegate void G_Viewport(
 			int x,
 			int y,
 			int width,
 			int height
 		);
-		private G_Viewport glViewport;
+		public G_Viewport glViewport;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DepthRange(
+		public delegate void DepthRange(
 			double near_val,
 			double far_val
 		);
-		private DepthRange glDepthRange;
+		public DepthRange glDepthRange;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DepthRangef(
+		public delegate void DepthRangef(
 			float near_val,
 			float far_val
 		);
-		private DepthRangef glDepthRangef;
+		public DepthRangef glDepthRangef;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void Scissor(
+		public delegate void Scissor(
 			int x,
 			int y,
 			int width,
 			int height
 		);
-		private Scissor glScissor;
+		public Scissor glScissor;
 
 		/* END VIEWPORT/SCISSOR FUNCTIONS */
 
 		/* BEGIN BLEND STATE FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BlendColor(
+		public delegate void BlendColor(
 			float red,
 			float green,
 			float blue,
 			float alpha
 		);
-		private BlendColor glBlendColor;
+		public BlendColor glBlendColor;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BlendFuncSeparate(
+		public delegate void BlendFuncSeparate(
 			GLenum srcRGB,
 			GLenum dstRGB,
 			GLenum srcAlpha,
 			GLenum dstAlpha
 		);
-		private BlendFuncSeparate glBlendFuncSeparate;
+		public BlendFuncSeparate glBlendFuncSeparate;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BlendEquationSeparate(
+		public delegate void BlendEquationSeparate(
 			GLenum modeRGB,
 			GLenum modeAlpha
 		);
-		private BlendEquationSeparate glBlendEquationSeparate;
+		public BlendEquationSeparate glBlendEquationSeparate;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ColorMask(
+		public delegate void ColorMask(
 			bool red,
 			bool green,
 			bool blue,
 			bool alpha
 		);
-		private ColorMask glColorMask;
+		public ColorMask glColorMask;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ColorMaski(
+		public delegate void ColorMaski(
 			uint buf,
 			bool red,
 			bool green,
 			bool blue,
 			bool alpha
 		);
-		private ColorMaski glColorMaski;
+		public ColorMaski glColorMaski;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void SampleMaski(uint maskNumber, uint mask);
-		private SampleMaski glSampleMaski;
+		public delegate void SampleMaski(uint maskNumber, uint mask);
+		public SampleMaski glSampleMaski;
 
 		/* END BLEND STATE FUNCTIONS */
 
 		/* BEGIN DEPTH/STENCIL STATE FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DepthMask(bool flag);
-		private DepthMask glDepthMask;
+		public delegate void DepthMask(bool flag);
+		public DepthMask glDepthMask;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DepthFunc(GLenum func);
-		private DepthFunc glDepthFunc;
+		public delegate void DepthFunc(GLenum func);
+		public DepthFunc glDepthFunc;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilMask(int mask);
-		private StencilMask glStencilMask;
+		public delegate void StencilMask(int mask);
+		public StencilMask glStencilMask;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilFuncSeparate(
+		public delegate void StencilFuncSeparate(
 			GLenum face,
 			GLenum func,
 			int reference,
 			int mask
 		);
-		private StencilFuncSeparate glStencilFuncSeparate;
+		public StencilFuncSeparate glStencilFuncSeparate;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilOpSeparate(
+		public delegate void StencilOpSeparate(
 			GLenum face,
 			GLenum sfail,
 			GLenum dpfail,
 			GLenum dppass
 		);
-		private StencilOpSeparate glStencilOpSeparate;
+		public StencilOpSeparate glStencilOpSeparate;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilFunc(
+		public delegate void StencilFunc(
 			GLenum fail,
 			int reference,
 			int mask
 		);
-		private StencilFunc glStencilFunc;
+		public StencilFunc glStencilFunc;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilOp(
+		public delegate void StencilOp(
 			GLenum fail,
 			GLenum zfail,
 			GLenum zpass
 		);
-		private StencilOp glStencilOp;
+		public StencilOp glStencilOp;
 
 		/* END DEPTH/STENCIL STATE FUNCTIONS */
 
 		/* BEGIN RASTERIZER STATE FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void FrontFace(GLenum mode);
-		private FrontFace glFrontFace;
+		public delegate void FrontFace(GLenum mode);
+		public FrontFace glFrontFace;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void PolygonMode(GLenum face, GLenum mode);
-		private PolygonMode glPolygonMode;
+		public delegate void PolygonMode(GLenum face, GLenum mode);
+		public PolygonMode glPolygonMode;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void PolygonOffset(float factor, float units);
-		private PolygonOffset glPolygonOffset;
+		public delegate void PolygonOffset(float factor, float units);
+		public PolygonOffset glPolygonOffset;
 
 		/* END RASTERIZER STATE FUNCTIONS */
 
 		/* BEGIN TEXTURE FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenTextures(int n, out uint textures);
-		private GenTextures glGenTextures;
+		public delegate void GenTextures(int n, out uint textures);
+		public GenTextures glGenTextures;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteTextures(
+		public delegate void DeleteTextures(
 			int n,
 			ref uint textures
 		);
-		private DeleteTextures glDeleteTextures;
+		public DeleteTextures glDeleteTextures;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void G_BindTexture(GLenum target, uint texture);
-		private G_BindTexture glBindTexture;
+		public delegate void G_BindTexture(GLenum target, uint texture);
+		public G_BindTexture glBindTexture;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void TexImage2D(
+		public delegate void TexImage2D(
 			GLenum target,
 			int level,
 			int internalFormat,
@@ -432,10 +452,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			GLenum type,
 			IntPtr pixels
 		);
-		private TexImage2D glTexImage2D;
+		public TexImage2D glTexImage2D;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void TexSubImage2D(
+		public delegate void TexSubImage2D(
 			GLenum target,
 			int level,
 			int xoffset,
@@ -446,10 +466,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			GLenum type,
 			IntPtr pixels
 		);
-		private TexSubImage2D glTexSubImage2D;
+		public TexSubImage2D glTexSubImage2D;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void CompressedTexImage2D(
+		public delegate void CompressedTexImage2D(
 			GLenum target,
 			int level,
 			int internalFormat,
@@ -459,10 +479,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			int imageSize,
 			IntPtr pixels
 		);
-		private CompressedTexImage2D glCompressedTexImage2D;
+		public CompressedTexImage2D glCompressedTexImage2D;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void CompressedTexSubImage2D(
+		public delegate void CompressedTexSubImage2D(
 			GLenum target,
 			int level,
 			int xoffset,
@@ -473,10 +493,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			int imageSize,
 			IntPtr pixels
 		);
-		private CompressedTexSubImage2D glCompressedTexSubImage2D;
+		public CompressedTexSubImage2D glCompressedTexSubImage2D;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void TexImage3D(
+		public delegate void TexImage3D(
 			GLenum target,
 			int level,
 			int internalFormat,
@@ -488,10 +508,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			GLenum type,
 			IntPtr pixels
 		);
-		private TexImage3D glTexImage3D;
+		public TexImage3D glTexImage3D;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void TexSubImage3D(
+		public delegate void TexSubImage3D(
 			GLenum target,
 			int level,
 			int xoffset,
@@ -504,127 +524,127 @@ namespace Microsoft.Xna.Framework.Graphics
 			GLenum type,
 			IntPtr pixels
 		);
-		private TexSubImage3D glTexSubImage3D;
+		public TexSubImage3D glTexSubImage3D;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GetTexImage(
+		public delegate void GetTexImage(
 			GLenum target,
 			int level,
 			GLenum format,
 			GLenum type,
 			IntPtr pixels
 		);
-		private GetTexImage glGetTexImage;
+		public GetTexImage glGetTexImage;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void TexParameteri(
+		public delegate void TexParameteri(
 			GLenum target,
 			GLenum pname,
 			int param
 		);
-		private TexParameteri glTexParameteri;
+		public TexParameteri glTexParameteri;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void TexParameterf(
+		public delegate void TexParameterf(
 			GLenum target,
 			GLenum pname,
 			float param
 		);
-		private TexParameterf glTexParameterf;
+		public TexParameterf glTexParameterf;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ActiveTexture(GLenum texture);
-		private ActiveTexture glActiveTexture;
+		public delegate void ActiveTexture(GLenum texture);
+		public ActiveTexture glActiveTexture;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void PixelStorei(GLenum pname, int param);
-		private PixelStorei glPixelStorei;
+		public delegate void PixelStorei(GLenum pname, int param);
+		public PixelStorei glPixelStorei;
 
 		/* END TEXTURE FUNCTIONS */
 
 		/* BEGIN BUFFER FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenBuffers(int n, out uint buffers);
-		private GenBuffers glGenBuffers;
+		public delegate void GenBuffers(int n, out uint buffers);
+		public GenBuffers glGenBuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteBuffers(
+		public delegate void DeleteBuffers(
 			int n,
 			ref uint buffers
 		);
-		private DeleteBuffers glDeleteBuffers;
+		public DeleteBuffers glDeleteBuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BindBuffer(GLenum target, uint buffer);
-		private BindBuffer glBindBuffer;
+		public delegate void BindBuffer(GLenum target, uint buffer);
+		public BindBuffer glBindBuffer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BufferData(
+		public delegate void BufferData(
 			GLenum target,
 			IntPtr size,
 			IntPtr data,
 			GLenum usage
 		);
-		private BufferData glBufferData;
+		public BufferData glBufferData;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BufferSubData(
+		public delegate void BufferSubData(
 			GLenum target,
 			IntPtr offset,
 			IntPtr size,
 			IntPtr data
 		);
-		private BufferSubData glBufferSubData;
+		public BufferSubData glBufferSubData;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GetBufferSubData(
+		public delegate void GetBufferSubData(
 			GLenum target,
 			IntPtr offset,
 			IntPtr size,
 			IntPtr data
 		);
-		private GetBufferSubData glGetBufferSubData;
+		public GetBufferSubData glGetBufferSubData;
 
 		/* END BUFFER FUNCTIONS */
 
 		/* BEGIN CLEAR FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ClearColor(
+		public delegate void ClearColor(
 			float red,
 			float green,
 			float blue,
 			float alpha
 		);
-		private ClearColor glClearColor;
+		public ClearColor glClearColor;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ClearDepth(double depth);
-		private ClearDepth glClearDepth;
+		public delegate void ClearDepth(double depth);
+		public ClearDepth glClearDepth;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ClearDepthf(float depth);
-		private ClearDepthf glClearDepthf;
+		public delegate void ClearDepthf(float depth);
+		public ClearDepthf glClearDepthf;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ClearStencil(int s);
-		private ClearStencil glClearStencil;
+		public delegate void ClearStencil(int s);
+		public ClearStencil glClearStencil;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void G_Clear(GLenum mask);
-		private G_Clear glClear;
+		public delegate void G_Clear(GLenum mask);
+		public G_Clear glClear;
 
 		/* END CLEAR FUNCTIONS */
 
 		/* BEGIN FRAMEBUFFER FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawBuffers(int n, IntPtr bufs);
-		private DrawBuffers glDrawBuffers;
+		public delegate void DrawBuffers(int n, IntPtr bufs);
+		public DrawBuffers glDrawBuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ReadPixels(
+		public delegate void ReadPixels(
 			int x,
 			int y,
 			int width,
@@ -633,54 +653,54 @@ namespace Microsoft.Xna.Framework.Graphics
 			GLenum type,
 			IntPtr pixels
 		);
-		private ReadPixels glReadPixels;
+		public ReadPixels glReadPixels;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenerateMipmap(GLenum target);
-		private GenerateMipmap glGenerateMipmap;
+		public delegate void GenerateMipmap(GLenum target);
+		public GenerateMipmap glGenerateMipmap;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenFramebuffers(
+		public delegate void GenFramebuffers(
 			int n,
 			out uint framebuffers
 		);
-		private GenFramebuffers glGenFramebuffers;
+		public GenFramebuffers glGenFramebuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteFramebuffers(
+		public delegate void DeleteFramebuffers(
 			int n,
 			ref uint framebuffers
 		);
-		private DeleteFramebuffers glDeleteFramebuffers;
+		public DeleteFramebuffers glDeleteFramebuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void G_BindFramebuffer(
+		public delegate void G_BindFramebuffer(
 			GLenum target,
 			uint framebuffer
 		);
-		private G_BindFramebuffer glBindFramebuffer;
+		public G_BindFramebuffer glBindFramebuffer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void FramebufferTexture2D(
+		public delegate void FramebufferTexture2D(
 			GLenum target,
 			GLenum attachment,
 			GLenum textarget,
 			uint texture,
 			int level
 		);
-		private FramebufferTexture2D glFramebufferTexture2D;
+		public FramebufferTexture2D glFramebufferTexture2D;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void FramebufferRenderbuffer(
+		public delegate void FramebufferRenderbuffer(
 			GLenum target,
 			GLenum attachment,
 			GLenum renderbuffertarget,
 			uint renderbuffer
 		);
-		private FramebufferRenderbuffer glFramebufferRenderbuffer;
+		public FramebufferRenderbuffer glFramebufferRenderbuffer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BlitFramebuffer(
+		public delegate void BlitFramebuffer(
 			int srcX0,
 			int srcY0,
 			int srcX1,
@@ -692,54 +712,54 @@ namespace Microsoft.Xna.Framework.Graphics
 			GLenum mask,
 			GLenum filter
 		);
-		private BlitFramebuffer glBlitFramebuffer;
+		public BlitFramebuffer glBlitFramebuffer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenRenderbuffers(
+		public delegate void GenRenderbuffers(
 			int n,
 			out uint renderbuffers
 		);
-		private GenRenderbuffers glGenRenderbuffers;
+		public GenRenderbuffers glGenRenderbuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteRenderbuffers(
+		public delegate void DeleteRenderbuffers(
 			int n,
 			ref uint renderbuffers
 		);
-		private DeleteRenderbuffers glDeleteRenderbuffers;
+		public DeleteRenderbuffers glDeleteRenderbuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BindRenderbuffer(
+		public delegate void BindRenderbuffer(
 			GLenum target,
 			uint renderbuffer
 		);
-		private BindRenderbuffer glBindRenderbuffer;
+		public BindRenderbuffer glBindRenderbuffer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void RenderbufferStorage(
+		public delegate void RenderbufferStorage(
 			GLenum target,
 			GLenum internalformat,
 			int width,
 			int height
 		);
-		private RenderbufferStorage glRenderbufferStorage;
+		public RenderbufferStorage glRenderbufferStorage;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void RenderbufferStorageMultisample(
+		public delegate void RenderbufferStorageMultisample(
 			GLenum target,
 			int samples,
 			GLenum internalformat,
 			int width,
 			int height
 		);
-		private RenderbufferStorageMultisample glRenderbufferStorageMultisample;
+		public RenderbufferStorageMultisample glRenderbufferStorageMultisample;
 
 		/* END FRAMEBUFFER FUNCTIONS */
 
 		/* BEGIN VERTEX ATTRIBUTE FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void VertexAttribPointer(
+		public delegate void VertexAttribPointer(
 			int index,
 			int size,
 			GLenum type,
@@ -747,39 +767,39 @@ namespace Microsoft.Xna.Framework.Graphics
 			int stride,
 			IntPtr pointer
 		);
-		private VertexAttribPointer glVertexAttribPointer;
+		public VertexAttribPointer glVertexAttribPointer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void VertexAttribDivisor(
+		public delegate void VertexAttribDivisor(
 			int index,
 			int divisor
 		);
-		private VertexAttribDivisor glVertexAttribDivisor;
+		public VertexAttribDivisor glVertexAttribDivisor;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void EnableVertexAttribArray(int index);
-		private EnableVertexAttribArray glEnableVertexAttribArray;
+		public delegate void EnableVertexAttribArray(int index);
+		public EnableVertexAttribArray glEnableVertexAttribArray;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DisableVertexAttribArray(int index);
-		private DisableVertexAttribArray glDisableVertexAttribArray;
+		public delegate void DisableVertexAttribArray(int index);
+		public DisableVertexAttribArray glDisableVertexAttribArray;
 
 		/* END VERTEX ATTRIBUTE FUNCTIONS */
 
 		/* BEGIN DRAWING FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawElementsInstanced(
+		public delegate void DrawElementsInstanced(
 			GLenum mode,
 			int count,
 			GLenum type,
 			IntPtr indices,
 			int instanceCount
 		);
-		private DrawElementsInstanced glDrawElementsInstanced;
+		public DrawElementsInstanced glDrawElementsInstanced;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawRangeElements(
+		public delegate void DrawRangeElements(
 			GLenum mode,
 			int start,
 			int end,
@@ -787,10 +807,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			GLenum type,
 			IntPtr indices
 		);
-		private DrawRangeElements glDrawRangeElements;
+		public DrawRangeElements glDrawRangeElements;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawElementsInstancedBaseVertex(
+		public delegate void DrawElementsInstancedBaseVertex(
 			GLenum mode,
 			int count,
 			GLenum type,
@@ -798,10 +818,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			int instanceCount,
 			int baseVertex
 		);
-		private DrawElementsInstancedBaseVertex glDrawElementsInstancedBaseVertex;
+		public DrawElementsInstancedBaseVertex glDrawElementsInstancedBaseVertex;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawRangeElementsBaseVertex(
+		public delegate void DrawRangeElementsBaseVertex(
 			GLenum mode,
 			int start,
 			int end,
@@ -810,61 +830,61 @@ namespace Microsoft.Xna.Framework.Graphics
 			IntPtr indices,
 			int baseVertex
 		);
-		private DrawRangeElementsBaseVertex glDrawRangeElementsBaseVertex;
+		public DrawRangeElementsBaseVertex glDrawRangeElementsBaseVertex;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawElements(
+		public delegate void DrawElements(
 			GLenum mode,
 			int count,
 			GLenum type,
 			IntPtr indices
 		);
-		private DrawElements glDrawElements;
+		public DrawElements glDrawElements;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawArrays(
+		public delegate void DrawArrays(
 			GLenum mode,
 			int first,
 			int count
 		);
-		private DrawArrays glDrawArrays;
+		public DrawArrays glDrawArrays;
 
 		/* END DRAWING FUNCTIONS */
 
 		/* BEGIN QUERY FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenQueries(int n, out uint ids);
-		private GenQueries glGenQueries;
+		public delegate void GenQueries(int n, out uint ids);
+		public GenQueries glGenQueries;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteQueries(int n, ref uint ids);
-		private DeleteQueries glDeleteQueries;
+		public delegate void DeleteQueries(int n, ref uint ids);
+		public DeleteQueries glDeleteQueries;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BeginQuery(GLenum target, uint id);
-		private BeginQuery glBeginQuery;
+		public delegate void BeginQuery(GLenum target, uint id);
+		public BeginQuery glBeginQuery;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void EndQuery(GLenum target);
-		private EndQuery glEndQuery;
+		public delegate void EndQuery(GLenum target);
+		public EndQuery glEndQuery;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GetQueryObjectuiv(
+		public delegate void GetQueryObjectuiv(
 			uint id,
 			GLenum pname,
 			out uint param
 		);
-		private GetQueryObjectuiv glGetQueryObjectuiv;
+		public GetQueryObjectuiv glGetQueryObjectuiv;
 
 		/* END QUERY FUNCTIONS */
 
 		/* BEGIN 3.2 CORE PROFILE FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate IntPtr GetStringi(GLenum pname, uint index);
-		private GetStringi INTERNAL_glGetStringi;
-		private string glGetStringi(GLenum pname, uint index)
+		public delegate IntPtr GetStringi(GLenum pname, uint index);
+		public GetStringi INTERNAL_glGetStringi;
+		public string glGetStringi(GLenum pname, uint index)
 		{
 			unsafe
 			{
@@ -873,16 +893,16 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenVertexArrays(int n, out uint arrays);
-		private GenVertexArrays glGenVertexArrays;
+		public delegate void GenVertexArrays(int n, out uint arrays);
+		public GenVertexArrays glGenVertexArrays;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteVertexArrays(int n, ref uint arrays);
-		private DeleteVertexArrays glDeleteVertexArrays;
+		public delegate void DeleteVertexArrays(int n, ref uint arrays);
+		public DeleteVertexArrays glDeleteVertexArrays;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BindVertexArray(uint array);
-		private BindVertexArray glBindVertexArray;
+		public delegate void BindVertexArray(uint array);
+		public BindVertexArray glBindVertexArray;
 
 		/* END 3.2 CORE PROFILE FUNCTIONS */
 
@@ -890,14 +910,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		/* BEGIN DEBUG OUTPUT FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DebugMessageCallback(
+		public delegate void DebugMessageCallback(
 			IntPtr debugCallback,
 			IntPtr userParam
 		);
-		private DebugMessageCallback glDebugMessageCallback;
+		public DebugMessageCallback glDebugMessageCallback;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DebugMessageControl(
+		public delegate void DebugMessageControl(
 			GLenum source,
 			GLenum type,
 			GLenum severity,
@@ -905,11 +925,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			IntPtr ids, // const GLuint*
 			bool enabled
 		);
-		private DebugMessageControl glDebugMessageControl;
+		public DebugMessageControl glDebugMessageControl;
 
 		// ARB_debug_output/KHR_debug callback
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DebugProc(
+		public delegate void DebugProc(
 			GLenum source,
 			GLenum type,
 			uint id,
@@ -918,8 +938,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			IntPtr message, // const GLchar*
 			IntPtr userParam // const GLvoid*
 		);
-		private DebugProc DebugCall = DebugCallback;
-		private static void DebugCallback(
+		public DebugProc DebugCall = DebugCallback;
+		public static void DebugCallback(
 			GLenum source,
 			GLenum type,
 			uint id,
@@ -950,12 +970,12 @@ namespace Microsoft.Xna.Framework.Graphics
 		/* BEGIN STRING MARKER FUNCTIONS */
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StringMarkerGREMEDY(int length, IntPtr chars);
-		private StringMarkerGREMEDY glStringMarkerGREMEDY;
+		public delegate void StringMarkerGREMEDY(int length, IntPtr chars);
+		public StringMarkerGREMEDY glStringMarkerGREMEDY;
 
 		/* END STRING MARKER FUNCTIONS */
 #endif
-		private void LoadGLGetString()
+		protected void LoadGLGetString()
 		{
 			try
 			{
@@ -970,7 +990,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		private void LoadGLEntryPoints(string driver)
+		protected void LoadGLEntryPoints(string driver)
 		{
 			string baseErrorString;
 			if (useES3)
@@ -1680,7 +1700,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 		}
 
-		private Delegate GetProcAddress(string name, Type type)
+		protected Delegate GetProcAddress(string name, Type type)
 		{
 			IntPtr addr = SDL.SDL_GL_GetProcAddress(name);
 			if (addr == IntPtr.Zero)
@@ -1704,7 +1724,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			return Marshal.GetDelegateForFunctionPointer(addr, type);
 		}
 
-		private void DrawRangeElementsNoBase(
+		public void DrawRangeElementsNoBase(
 			GLenum mode,
 			int start,
 			int end,
@@ -1723,7 +1743,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			);
 		}
 
-		private void DrawRangeElementsNoBaseUnchecked(
+		public void DrawRangeElementsNoBaseUnchecked(
 			GLenum mode,
 			int start,
 			int end,
@@ -1740,7 +1760,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			);
 		}
 
-		private void DrawRangeElementsUnchecked(
+		public void DrawRangeElementsUnchecked(
 			GLenum mode,
 			int start,
 			int end,
@@ -1756,7 +1776,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			);
 		}
 
-		private void DrawElementsInstancedNoBase(
+		public void DrawElementsInstancedNoBase(
 			GLenum mode,
 			int count,
 			GLenum type,
@@ -1773,22 +1793,22 @@ namespace Microsoft.Xna.Framework.Graphics
 			);
 		}
 
-		private void DepthRangeFloat(double near, double far)
+		public void DepthRangeFloat(double near, double far)
 		{
 			glDepthRangef((float) near, (float) far);
 		}
 
-		private void ClearDepthFloat(double depth)
+		public void ClearDepthFloat(double depth)
 		{
 			glClearDepthf((float) depth);
 		}
 
-		private void PolygonModeESError(GLenum face, GLenum mode)
+		public void PolygonModeESError(GLenum face, GLenum mode)
 		{
 			throw new NotSupportedException("glPolygonMode is not available in ES!");
 		}
 
-		private void GetTexImageESError(
+		public void GetTexImageESError(
 			GLenum target,
 			int level,
 			GLenum format,
@@ -1798,7 +1818,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			throw new NotSupportedException("glGetTexImage is not available in ES!");
 		}
 
-		private void GetBufferSubDataESError(
+		public void GetBufferSubDataESError(
 			GLenum target,
 			IntPtr offset,
 			IntPtr size,

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -49,7 +49,7 @@ using SDL2;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	internal partial class ModernGLDevice : IGLDevice
+	internal partial class ModernGLDevice : BaseOpenGLDevice, IGLDevice
 	{
 		#region OpenGL Texture Container Class
 
@@ -450,12 +450,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			private set;
 		}
 
-		public bool SupportsHardwareInstancing
-		{
-			get;
-			private set;
-		}
-
 		public int MaxTextureSlots
 		{
 			get;
@@ -530,7 +524,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Private Profile-specific Variables
 
-		private bool useCoreProfile;
 		private DepthFormat windowDepthFormat;
 		private uint vao;
 
@@ -3592,7 +3585,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			public static readonly GLenum[] TextureInternalFormat = new GLenum[]
 			{
 				GLenum.GL_RGBA8,				// SurfaceFormat.Color
-				GLenum.GL_RGB565,				// SurfaceFormat.Bgr565
+				(GLenum)ModernGLenum.GL_RGB565,	// SurfaceFormat.Bgr565
 				GLenum.GL_RGB5_A1,				// SurfaceFormat.Bgra5551
 				GLenum.GL_RGBA4,				// SurfaceFormat.Bgra4444
 				GLenum.GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,	// SurfaceFormat.Dxt1
@@ -3603,7 +3596,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				GLenum.GL_RGB10_A2_EXT,				// SurfaceFormat.Rgba1010102
 				GLenum.GL_RG16,					// SurfaceFormat.Rg32
 				GLenum.GL_RGBA16,				// SurfaceFormat.Rgba64
-				GLenum.GL_LUMINANCE8,				// SurfaceFormat.Alpha8
+				(GLenum)ModernGLenum.GL_LUMINANCE8,	// SurfaceFormat.Alpha8
 				GLenum.GL_R32F,					// SurfaceFormat.Single
 				GLenum.GL_RG32F,				// SurfaceFormat.Vector2
 				GLenum.GL_RGBA32F,				// SurfaceFormat.Vector4

--- a/src/FNAPlatform/ModernGLDevice_GL.cs
+++ b/src/FNAPlatform/ModernGLDevice_GL.cs
@@ -21,381 +21,13 @@ namespace Microsoft.Xna.Framework.Graphics
 	{
 		#region Private OpenGL Entry Points
 
-		internal enum GLenum : int
+		internal enum ModernGLenum : int
 		{
-			// Hint Enum Value
-			GL_DONT_CARE =				0x1100,
-			// 0/1
-			GL_ZERO =				0x0000,
-			GL_ONE =				0x0001,
-			// Types
-			GL_BYTE =				0x1400,
-			GL_UNSIGNED_BYTE =			0x1401,
-			GL_SHORT =				0x1402,
-			GL_UNSIGNED_SHORT =			0x1403,
-			GL_UNSIGNED_INT =			0x1405,
-			GL_FLOAT =				0x1406,
-			GL_HALF_FLOAT =				0x140B,
-			GL_UNSIGNED_SHORT_4_4_4_4_REV =		0x8365,
-			GL_UNSIGNED_SHORT_5_5_5_1_REV =		0x8366,
-			GL_UNSIGNED_INT_2_10_10_10_REV =	0x8368,
-			GL_UNSIGNED_SHORT_5_6_5 =		0x8363,
-			GL_UNSIGNED_INT_24_8 =			0x84FA,
-			// Strings
-			GL_VENDOR =				0x1F00,
-			GL_RENDERER =				0x1F01,
-			GL_VERSION =				0x1F02,
-			GL_EXTENSIONS =				0x1F03,
-			// Clear Mask
-			GL_COLOR_BUFFER_BIT =			0x4000,
-			GL_DEPTH_BUFFER_BIT =			0x0100,
-			GL_STENCIL_BUFFER_BIT =			0x0400,
-			// Enable Caps
-			GL_SCISSOR_TEST =			0x0C11,
-			GL_DEPTH_TEST =				0x0B71,
-			GL_STENCIL_TEST =			0x0B90,
-			// Polygons
-			GL_LINE =				0x1B01,
-			GL_FILL =				0x1B02,
-			GL_CW =					0x0900,
-			GL_CCW =				0x0901,
-			GL_FRONT =				0x0404,
-			GL_BACK =				0x0405,
-			GL_FRONT_AND_BACK =			0x0408,
-			GL_CULL_FACE =				0x0B44,
-			GL_POLYGON_OFFSET_FILL =		0x8037,
-			// Texture Type
-			GL_TEXTURE_2D =				0x0DE1,
-			GL_TEXTURE_3D =				0x806F,
-			GL_TEXTURE_CUBE_MAP =			0x8513,
-			GL_TEXTURE_CUBE_MAP_POSITIVE_X =	0x8515,
-			// Blend Mode
-			GL_BLEND =				0x0BE2,
-			GL_SRC_COLOR =				0x0300,
-			GL_ONE_MINUS_SRC_COLOR =		0x0301,
-			GL_SRC_ALPHA =				0x0302,
-			GL_ONE_MINUS_SRC_ALPHA =		0x0303,
-			GL_DST_ALPHA =				0x0304,
-			GL_ONE_MINUS_DST_ALPHA =		0x0305,
-			GL_DST_COLOR =				0x0306,
-			GL_ONE_MINUS_DST_COLOR =		0x0307,
-			GL_SRC_ALPHA_SATURATE =			0x0308,
-			GL_CONSTANT_COLOR =			0x8001,
-			GL_ONE_MINUS_CONSTANT_COLOR =		0x8002,
-			// Equations
-			GL_MIN =				0x8007,
-			GL_MAX =				0x8008,
-			GL_FUNC_ADD =				0x8006,
-			GL_FUNC_SUBTRACT =			0x800A,
-			GL_FUNC_REVERSE_SUBTRACT =		0x800B,
-			// Comparisons
-			GL_NEVER =				0x0200,
-			GL_LESS =				0x0201,
-			GL_EQUAL =				0x0202,
-			GL_LEQUAL =				0x0203,
-			GL_GREATER =				0x0204,
-			GL_NOTEQUAL =				0x0205,
-			GL_GEQUAL =				0x0206,
-			GL_ALWAYS =				0x0207,
-			// Stencil Operations
-			GL_INVERT =				0x150A,
-			GL_KEEP =				0x1E00,
-			GL_REPLACE =				0x1E01,
-			GL_INCR =				0x1E02,
-			GL_DECR =				0x1E03,
-			GL_INCR_WRAP =				0x8507,
-			GL_DECR_WRAP =				0x8508,
-			// Wrap Modes
-			GL_REPEAT =				0x2901,
-			GL_CLAMP_TO_EDGE =			0x812F,
-			GL_MIRRORED_REPEAT =			0x8370,
-			// Filters
-			GL_NEAREST =				0x2600,
-			GL_LINEAR =				0x2601,
-			GL_NEAREST_MIPMAP_NEAREST =		0x2700,
-			GL_NEAREST_MIPMAP_LINEAR =		0x2702,
-			GL_LINEAR_MIPMAP_NEAREST =		0x2701,
-			GL_LINEAR_MIPMAP_LINEAR =		0x2703,
-			// Attachments
-			GL_COLOR_ATTACHMENT0 =			0x8CE0,
-			GL_DEPTH_ATTACHMENT =			0x8D00,
-			GL_STENCIL_ATTACHMENT =			0x8D20,
-			GL_DEPTH_STENCIL_ATTACHMENT =		0x821A,
-			// Texture Formats
-			GL_RED =				0x1903,
-			GL_RGB =				0x1907,
-			GL_RGBA =				0x1908,
-			GL_LUMINANCE =				0x1909,
 			GL_LUMINANCE8 =				0x8040,
-			GL_RGBA8 =				0x8058,
-			GL_RGBA4 =				0x8056,
-			GL_RGB5_A1 =				0x8057,
-			GL_RGB10_A2_EXT =			0x8059,
-			GL_RGBA16 =				0x805B,
-			GL_BGRA =				0x80E1,
-			GL_DEPTH_COMPONENT16 =			0x81A5,
-			GL_DEPTH_COMPONENT24 =			0x81A6,
-			GL_RG =					0x8227,
-			GL_RG8 =				0x822B,
-			GL_RG16 =				0x822C,
-			GL_R16F =				0x822D,
-			GL_R32F =				0x822E,
-			GL_RG16F =				0x822F,
-			GL_RG32F =				0x8230,
-			GL_RGBA32F =				0x8814,
-			GL_RGBA16F =				0x881A,
-			GL_DEPTH24_STENCIL8 =			0x88F0,
-			GL_COMPRESSED_TEXTURE_FORMATS =		0x86A3,
-			GL_COMPRESSED_RGBA_S3TC_DXT1_EXT =	0x83F1,
-			GL_COMPRESSED_RGBA_S3TC_DXT3_EXT =	0x83F2,
-			GL_COMPRESSED_RGBA_S3TC_DXT5_EXT =	0x83F3,
 			GL_RGB565 =				0x8D62,
-			// Texture Internal Formats
-			GL_DEPTH_COMPONENT =			0x1902,
-			GL_DEPTH_STENCIL =			0x84F9,
-			// Textures
-			GL_TEXTURE_WRAP_S =			0x2802,
-			GL_TEXTURE_WRAP_T =			0x2803,
-			GL_TEXTURE_WRAP_R =			0x8072,
-			GL_TEXTURE_MAG_FILTER =			0x2800,
-			GL_TEXTURE_MIN_FILTER =			0x2801,
-			GL_TEXTURE_MAX_ANISOTROPY_EXT =		0x84FE,
-			GL_TEXTURE_BASE_LEVEL =			0x813C,
-			GL_TEXTURE_MAX_LEVEL =			0x813D,
-			GL_TEXTURE_LOD_BIAS =			0x8501,
-			GL_UNPACK_ALIGNMENT =			0x0CF5,
-			// Multitexture
-			GL_TEXTURE0 =				0x84C0,
-			GL_MAX_TEXTURE_IMAGE_UNITS =		0x8872,
-			GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS =	0x8B4C,
-			// Buffer objects
-			GL_ARRAY_BUFFER =			0x8892,
-			GL_ELEMENT_ARRAY_BUFFER =		0x8893,
-			GL_STREAM_DRAW =			0x88E0,
-			GL_STATIC_DRAW =			0x88E4,
-			GL_MAX_VERTEX_ATTRIBS =			0x8869,
-			// Render targets
-			GL_FRAMEBUFFER =			0x8D40,
-			GL_READ_FRAMEBUFFER =			0x8CA8,
-			GL_DRAW_FRAMEBUFFER =			0x8CA9,
-			GL_RENDERBUFFER =			0x8D41,
-			GL_MAX_DRAW_BUFFERS =			0x8824,
-			// Draw Primitives
-			GL_POINTS =				0x0000,
-			GL_LINES =				0x0001,
-			GL_LINE_STRIP =				0x0003,
-			GL_TRIANGLES =				0x0004,
-			GL_TRIANGLE_STRIP =			0x0005,
-			// Query Objects
-			GL_QUERY_RESULT =			0x8866,
-			GL_QUERY_RESULT_AVAILABLE =		0x8867,
-			GL_SAMPLES_PASSED =			0x8914,
-			// Multisampling
-			GL_MULTISAMPLE =			0x809D,
-			GL_MAX_SAMPLES =			0x8D57,
-			GL_SAMPLE_MASK =			0x8E51,
-			// 3.2 Core Profile
-			GL_NUM_EXTENSIONS =			0x821D,
-			// Source Enum Values
-			GL_DEBUG_SOURCE_API_ARB =		0x8246,
-			GL_DEBUG_SOURCE_WINDOW_SYSTEM_ARB =	0x8247,
-			GL_DEBUG_SOURCE_SHADER_COMPILER_ARB =	0x8248,
-			GL_DEBUG_SOURCE_THIRD_PARTY_ARB =	0x8249,
-			GL_DEBUG_SOURCE_APPLICATION_ARB =	0x824A,
-			GL_DEBUG_SOURCE_OTHER_ARB =		0x824B,
-			// Type Enum Values
-			GL_DEBUG_TYPE_ERROR_ARB =		0x824C,
-			GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR_ARB =	0x824D,
-			GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB =	0x824E,
-			GL_DEBUG_TYPE_PORTABILITY_ARB =		0x824F,
-			GL_DEBUG_TYPE_PERFORMANCE_ARB =		0x8250,
-			GL_DEBUG_TYPE_OTHER_ARB =		0x8251,
-			// Severity Enum Values
-			GL_DEBUG_SEVERITY_HIGH_ARB =		0x9146,
-			GL_DEBUG_SEVERITY_MEDIUM_ARB =		0x9147,
-			GL_DEBUG_SEVERITY_LOW_ARB =		0x9148,
-			GL_DEBUG_SEVERITY_NOTIFICATION_ARB =	0x826B
 		}
 
 		// Entry Points
-
-		/* BEGIN GET FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate IntPtr GetString(GLenum pname);
-		private GetString INTERNAL_glGetString;
-		private string glGetString(GLenum pname)
-		{
-			unsafe
-			{
-				return new string((sbyte*) INTERNAL_glGetString(pname));
-			}
-		}
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GetIntegerv(GLenum pname, out int param);
-		private GetIntegerv glGetIntegerv;
-
-		/* END GET FUNCTIONS */
-
-		/* BEGIN ENABLE/DISABLE FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void Enable(GLenum cap);
-		private Enable glEnable;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void Disable(GLenum cap);
-		private Disable glDisable;
-
-		/* END ENABLE/DISABLE FUNCTIONS */
-
-		/* BEGIN VIEWPORT/SCISSOR FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void G_Viewport(
-			int x,
-			int y,
-			int width,
-			int height
-		);
-		private G_Viewport glViewport;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DepthRange(
-			double near_val,
-			double far_val
-		);
-		private DepthRange glDepthRange;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void Scissor(
-			int x,
-			int y,
-			int width,
-			int height
-		);
-		private Scissor glScissor;
-
-		/* END VIEWPORT/SCISSOR FUNCTIONS */
-
-		/* BEGIN BLEND STATE FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BlendColor(
-			float red,
-			float green,
-			float blue,
-			float alpha
-		);
-		private BlendColor glBlendColor;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BlendFuncSeparate(
-			GLenum srcRGB,
-			GLenum dstRGB,
-			GLenum srcAlpha,
-			GLenum dstAlpha
-		);
-		private BlendFuncSeparate glBlendFuncSeparate;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BlendEquationSeparate(
-			GLenum modeRGB,
-			GLenum modeAlpha
-		);
-		private BlendEquationSeparate glBlendEquationSeparate;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ColorMask(
-			bool red,
-			bool green,
-			bool blue,
-			bool alpha
-		);
-		private ColorMask glColorMask;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ColorMaski(
-			uint buf,
-			bool red,
-			bool green,
-			bool blue,
-			bool alpha
-		);
-		private ColorMaski glColorMaski;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void SampleMaski(uint maskNumber, uint mask);
-		private SampleMaski glSampleMaski;
-
-		/* END BLEND STATE FUNCTIONS */
-
-		/* BEGIN DEPTH/STENCIL STATE FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DepthMask(bool flag);
-		private DepthMask glDepthMask;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DepthFunc(GLenum func);
-		private DepthFunc glDepthFunc;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilMask(int mask);
-		private StencilMask glStencilMask;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilFuncSeparate(
-			GLenum face,
-			GLenum func,
-			int reference,
-			int mask
-		);
-		private StencilFuncSeparate glStencilFuncSeparate;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilOpSeparate(
-			GLenum face,
-			GLenum sfail,
-			GLenum dpfail,
-			GLenum dppass
-		);
-		private StencilOpSeparate glStencilOpSeparate;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilFunc(
-			GLenum fail,
-			int reference,
-			int mask
-		);
-		private StencilFunc glStencilFunc;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StencilOp(
-			GLenum fail,
-			GLenum zfail,
-			GLenum zpass
-		);
-		private StencilOp glStencilOp;
-
-		/* END DEPTH/STENCIL STATE FUNCTIONS */
-
-		/* BEGIN RASTERIZER STATE FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void FrontFace(GLenum mode);
-		private FrontFace glFrontFace;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void PolygonMode(GLenum face, GLenum mode);
-		private PolygonMode glPolygonMode;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void PolygonOffset(float factor, float units);
-		private PolygonOffset glPolygonOffset;
-
-		/* END RASTERIZER STATE FUNCTIONS */
 
 		/* BEGIN TEXTURE FUNCTIONS */
 
@@ -406,13 +38,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			out uint textures
 		);
 		private CreateTextures glCreateTextures;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteTextures(
-			int n,
-			ref uint textures
-		);
-		private DeleteTextures glDeleteTextures;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 		private delegate void BindTextureUnit(int unit, uint texture);
@@ -546,10 +171,6 @@ namespace Microsoft.Xna.Framework.Graphics
 		);
 		private SamplerParameterf glSamplerParameterf;
 
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void PixelStorei(GLenum pname, int param);
-		private PixelStorei glPixelStorei;
-
 		/* END TEXTURE FUNCTIONS */
 
 		/* BEGIN BUFFER FUNCTIONS */
@@ -557,17 +178,6 @@ namespace Microsoft.Xna.Framework.Graphics
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 		private delegate void CreateBuffers(int n, out uint buffers);
 		private CreateBuffers glCreateBuffers;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteBuffers(
-			int n,
-			ref uint buffers
-		);
-		private DeleteBuffers glDeleteBuffers;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BindBuffer(GLenum target, uint buffer);
-		private BindBuffer glBindBuffer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 		private delegate void NamedBufferData(
@@ -598,44 +208,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		/* END BUFFER FUNCTIONS */
 
-		/* BEGIN CLEAR FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ClearColor(
-			float red,
-			float green,
-			float blue,
-			float alpha
-		);
-		private ClearColor glClearColor;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ClearDepth(double depth);
-		private ClearDepth glClearDepth;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ClearStencil(int s);
-		private ClearStencil glClearStencil;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void G_Clear(GLenum mask);
-		private G_Clear glClear;
-
-		/* END CLEAR FUNCTIONS */
-
 		/* BEGIN FRAMEBUFFER FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void ReadPixels(
-			int x,
-			int y,
-			int width,
-			int height,
-			GLenum format,
-			GLenum type,
-			IntPtr pixels
-		);
-		private ReadPixels glReadPixels;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 		private delegate void GenerateTextureMipmap(uint texture);
@@ -647,20 +220,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			out uint framebuffers
 		);
 		private CreateFramebuffers glCreateFramebuffers;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteFramebuffers(
-			int n,
-			ref uint framebuffers
-		);
-		private DeleteFramebuffers glDeleteFramebuffers;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void G_BindFramebuffer(
-			GLenum target,
-			uint framebuffer
-		);
-		private G_BindFramebuffer glBindFramebuffer;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 		private delegate void NamedFramebufferTexture(
@@ -723,13 +282,6 @@ namespace Microsoft.Xna.Framework.Graphics
 		private CreateRenderbuffers glCreateRenderbuffers;
 
 		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteRenderbuffers(
-			int n,
-			ref uint renderbuffers
-		);
-		private DeleteRenderbuffers glDeleteRenderbuffers;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 		private delegate void NamedRenderbufferStorage(
 			uint renderbuffer,
 			GLenum internalformat,
@@ -749,207 +301,6 @@ namespace Microsoft.Xna.Framework.Graphics
 		private NamedRenderbufferStorageMultisample glNamedRenderbufferStorageMultisample;
 
 		/* END FRAMEBUFFER FUNCTIONS */
-
-		/* BEGIN VERTEX ATTRIBUTE FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void VertexAttribPointer(
-			int index,
-			int size,
-			GLenum type,
-			bool normalized,
-			int stride,
-			IntPtr pointer
-		);
-		private VertexAttribPointer glVertexAttribPointer;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void VertexAttribDivisor(
-			int index,
-			int divisor
-		);
-		private VertexAttribDivisor glVertexAttribDivisor;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void EnableVertexAttribArray(int index);
-		private EnableVertexAttribArray glEnableVertexAttribArray;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DisableVertexAttribArray(int index);
-		private DisableVertexAttribArray glDisableVertexAttribArray;
-
-		/* END VERTEX ATTRIBUTE FUNCTIONS */
-
-		/* BEGIN DRAWING FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawRangeElements(
-			GLenum mode,
-			int start,
-			int end,
-			int count,
-			GLenum type,
-			IntPtr indices
-		);
-		private DrawRangeElements glDrawRangeElements;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawElementsInstancedBaseVertex(
-			GLenum mode,
-			int count,
-			GLenum type,
-			IntPtr indices,
-			int instanceCount,
-			int baseVertex
-		);
-		private DrawElementsInstancedBaseVertex glDrawElementsInstancedBaseVertex;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawRangeElementsBaseVertex(
-			GLenum mode,
-			int start,
-			int end,
-			int count,
-			GLenum type,
-			IntPtr indices,
-			int baseVertex
-		);
-		private DrawRangeElementsBaseVertex glDrawRangeElementsBaseVertex;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DrawArrays(
-			GLenum mode,
-			int first,
-			int count
-		);
-		private DrawArrays glDrawArrays;
-
-		/* END DRAWING FUNCTIONS */
-
-		/* BEGIN QUERY FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenQueries(int n, out uint ids);
-		private GenQueries glGenQueries;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteQueries(int n, ref uint ids);
-		private DeleteQueries glDeleteQueries;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BeginQuery(GLenum target, uint id);
-		private BeginQuery glBeginQuery;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void EndQuery(GLenum target);
-		private EndQuery glEndQuery;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GetQueryObjectuiv(
-			uint id,
-			GLenum pname,
-			out uint param
-		);
-		private GetQueryObjectuiv glGetQueryObjectuiv;
-
-		/* END QUERY FUNCTIONS */
-
-		/* BEGIN 3.2 CORE PROFILE FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate IntPtr GetStringi(GLenum pname, uint index);
-		private GetStringi INTERNAL_glGetStringi;
-		private string glGetStringi(GLenum pname, uint index)
-		{
-			unsafe
-			{
-				return new string((sbyte*) INTERNAL_glGetStringi(pname, index));
-			}
-		}
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void GenVertexArrays(int n, out uint arrays);
-		private GenVertexArrays glGenVertexArrays;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DeleteVertexArrays(int n, ref uint arrays);
-		private DeleteVertexArrays glDeleteVertexArrays;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void BindVertexArray(uint array);
-		private BindVertexArray glBindVertexArray;
-
-		/* END 3.2 CORE PROFILE FUNCTIONS */
-
-#if DEBUG
-		/* BEGIN DEBUG OUTPUT FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DebugMessageCallback(
-			IntPtr debugCallback,
-			IntPtr userParam
-		);
-		private DebugMessageCallback glDebugMessageCallbackARB;
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DebugMessageControl(
-			GLenum source,
-			GLenum type,
-			GLenum severity,
-			int count,
-			IntPtr ids, // const GLuint*
-			bool enabled
-		);
-		private DebugMessageControl glDebugMessageControlARB;
-
-		// ARB_debug_output callback
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void DebugProc(
-			GLenum source,
-			GLenum type,
-			uint id,
-			GLenum severity,
-			int length,
-			IntPtr message, // const GLchar*
-			IntPtr userParam // const GLvoid*
-		);
-		private DebugProc DebugCall = DebugCallback;
-		private static void DebugCallback(
-			GLenum source,
-			GLenum type,
-			uint id,
-			GLenum severity,
-			int length,
-			IntPtr message, // const GLchar*
-			IntPtr userParam // const GLvoid*
-		) {
-			string err = (
-				Marshal.PtrToStringAnsi(message) +
-				"\n\tSource: " +
-				source.ToString() +
-				"\n\tType: " +
-				type.ToString() +
-				"\n\tSeverity: " +
-				severity.ToString()
-			);
-			if (type == GLenum.GL_DEBUG_TYPE_ERROR_ARB)
-			{
-				FNALoggerEXT.LogError(err);
-				throw new InvalidOperationException(err);
-			}
-			FNALoggerEXT.LogWarn(err);
-		}
-
-		/* END DEBUG OUTPUT FUNCTIONS */
-
-		/* BEGIN STRING MARKER FUNCTIONS */
-
-		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
-		private delegate void StringMarkerGREMEDY(int length, IntPtr chars);
-		private StringMarkerGREMEDY glStringMarkerGREMEDY;
-
-		/* END STRING MARKER FUNCTIONS */
-#endif
 
 		private void LoadGLEntryPoints()
 		{
@@ -1301,15 +652,15 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			else
 			{
-				glDebugMessageCallbackARB = (DebugMessageCallback) Marshal.GetDelegateForFunctionPointer(
+				glDebugMessageCallback = (DebugMessageCallback) Marshal.GetDelegateForFunctionPointer(
 					messageCallback,
 					typeof(DebugMessageCallback)
 				);
-				glDebugMessageControlARB = (DebugMessageControl) Marshal.GetDelegateForFunctionPointer(
+				glDebugMessageControl = (DebugMessageControl) Marshal.GetDelegateForFunctionPointer(
 					messageControl,
 					typeof(DebugMessageControl)
 				);
-				glDebugMessageControlARB(
+				glDebugMessageControl(
 					GLenum.GL_DONT_CARE,
 					GLenum.GL_DONT_CARE,
 					GLenum.GL_DONT_CARE,
@@ -1317,23 +668,23 @@ namespace Microsoft.Xna.Framework.Graphics
 					IntPtr.Zero,
 					true
 				);
-				glDebugMessageControlARB(
+				glDebugMessageControl(
 					GLenum.GL_DONT_CARE,
-					GLenum.GL_DEBUG_TYPE_OTHER_ARB,
-					GLenum.GL_DEBUG_SEVERITY_LOW_ARB,
+					GLenum.GL_DEBUG_TYPE_OTHER,
+					GLenum.GL_DEBUG_SEVERITY_LOW,
 					0,
 					IntPtr.Zero,
 					false
 				);
-				glDebugMessageControlARB(
+				glDebugMessageControl(
 					GLenum.GL_DONT_CARE,
-					GLenum.GL_DEBUG_TYPE_OTHER_ARB,
-					GLenum.GL_DEBUG_SEVERITY_NOTIFICATION_ARB,
+					GLenum.GL_DEBUG_TYPE_OTHER,
+					GLenum.GL_DEBUG_SEVERITY_NOTIFICATION,
 					0,
 					IntPtr.Zero,
 					false
 				);
-				glDebugMessageCallbackARB(Marshal.GetFunctionPointerForDelegate(DebugCall), IntPtr.Zero);
+				glDebugMessageCallback(Marshal.GetFunctionPointerForDelegate(DebugCall), IntPtr.Zero);
 			}
 
 			/* GREMEDY_string_marker, for apitrace */

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -49,7 +49,7 @@ using SDL2;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	internal partial class OpenGLDevice : IGLDevice
+	internal class OpenGLDevice : BaseOpenGLDevice, IGLDevice
 	{
 		#region OpenGL Texture Container Class
 
@@ -457,12 +457,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			private set;
 		}
 
-		public bool SupportsHardwareInstancing
-		{
-			get;
-			private set;
-		}
-
 		public int MaxTextureSlots
 		{
 			get;
@@ -474,10 +468,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			get;
 			private set;
 		}
-
-		private bool supportsMultisampling;
-		private bool supportsFauxBackbuffer;
-		private bool supportsBaseVertex;
 
 		#endregion
 
@@ -541,8 +531,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Private Profile-specific Variables
 
-		private bool useES3;
-		private bool useCoreProfile;
 		private DepthFormat windowDepthFormat;
 		private uint vao;
 


### PR DESCRIPTION
Following up our discord discussion about adding ability to create effects in run-time from GLSL code. 
I've started up by performing small refactoring that would keep OpenGL API in one place.
As, right now, OpenGLDevice_GL.cs and ModernGLDevice_GL.cs declare almost similar OpenGL API. Basically ModernGLDevice_GL.cs is OpenGLDevice_GL.cs+some more API.
So I've renamed OpenGLDevice_GL.cs to BaseOpenGLDevice.cs and made OpenGLDevice and ModernOpenGLDevice inherit from BaseOpenGLDevice.
Then I've removed all OpenGL API from ModernGLDevice_GL.cs where IntelliSense has been warning about "hides inherited members".
Also I've made OpenGL API of BaseOpenGLDevice class public(keeping class itself internal), so it could be used inside the FNA.