### PR TITLE
Added ability to compile effects at runtime from GLSL

### DIFF
--- a/FNA.csproj
+++ b/FNA.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -202,6 +202,8 @@
     <Compile Include="src\FNAPlatform\OpenGLDevice.cs" />
     <Compile Include="src\FNAPlatform\OpenGLDevice_GL.cs" />
     <Compile Include="src\FNAPlatform\SDL2_FNAPlatform.cs" />
+    <Compile Include="src\FNAPlatform\ShaderGLDevice.cs" />
+    <Compile Include="src\FNAPlatform\ShaderGLDevice_GL.cs" />
     <Compile Include="src\FrameworkDispatcher.cs" />
     <Compile Include="src\Game.cs" />
     <Compile Include="src\GameComponent.cs" />
@@ -290,6 +292,7 @@
     <Compile Include="src\Graphics\ResourceDestroyedEventArgs.cs" />
     <Compile Include="src\Graphics\SamplerStateCollection.cs" />
     <Compile Include="src\Graphics\SetDataOptions.cs" />
+    <Compile Include="src\Graphics\Shader.cs" />
     <Compile Include="src\Graphics\SpriteBatch.cs" />
     <Compile Include="src\Graphics\SpriteEffects.cs" />
     <Compile Include="src\Graphics\SpriteFont.cs" />

--- a/src/FNAPlatform/ShaderGLDevice.cs
+++ b/src/FNAPlatform/ShaderGLDevice.cs
@@ -1,0 +1,4775 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2018 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+#region THREADED_GL Option
+// #define THREADED_GL
+/* Ah, so I see you've run into some issues with threaded GL...
+ *
+ * This class is designed to handle rendering coming from multiple threads, but
+ * if you're too wreckless with how many threads are calling the GL, this will
+ * hang.
+ *
+ * With THREADED_GL we instead allow you to run threaded rendering using
+ * multiple GL contexts. This is more flexible, but much more dangerous.
+ *
+ * Basically, if you have to enable this, you should feel very bad.
+ * -flibit
+ */
+#endregion
+
+#region DISABLE_THREADING Option
+// #define DISABLE_THREADING
+/* Perhaps you read the above option and thought to yourself:
+ * "Wow, only an idiot would need threads for their graphics code!"
+ *
+ * For those of you who are particularly well-behaved with your renderer and
+ * don't ever call anything on a thread at all, you can enable this define and
+ * cut out a _ton_ of garbage generation that's caused by our attempt to force
+ * things to the main thread.
+ *
+ * Enjoy the boost, you've earned it.
+ * -flibit
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+using SDL2;
+#endregion
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	internal partial class ShaderGLDevice : IGLDevice
+	{
+		#region OpenGL Texture Container Class
+
+		private class OpenGLTexture : IGLTexture
+		{
+			public uint Handle
+			{
+				get;
+				private set;
+			}
+
+			public GLenum Target
+			{
+				get;
+				private set;
+			}
+
+			public bool HasMipmaps
+			{
+				get;
+				private set;
+			}
+
+			public TextureAddressMode WrapS;
+			public TextureAddressMode WrapT;
+			public TextureAddressMode WrapR;
+			public TextureFilter Filter;
+			public float Anistropy;
+			public int MaxMipmapLevel;
+			public float LODBias;
+
+			public OpenGLTexture(
+				uint handle,
+				GLenum target,
+				int levelCount
+			) {
+				Handle = handle;
+				Target = target;
+				HasMipmaps = levelCount > 1;
+
+				WrapS = TextureAddressMode.Wrap;
+				WrapT = TextureAddressMode.Wrap;
+				WrapR = TextureAddressMode.Wrap;
+				Filter = TextureFilter.Linear;
+				Anistropy = 4.0f;
+				MaxMipmapLevel = 0;
+				LODBias = 0.0f;
+			}
+
+			// We can't set a SamplerState Texture to null, so use this.
+			private OpenGLTexture()
+			{
+				Handle = 0;
+				Target = GLenum.GL_TEXTURE_2D; // FIXME: Assumption! -flibit
+			}
+			public static readonly OpenGLTexture NullTexture = new OpenGLTexture();
+		}
+
+		#endregion
+
+		#region OpenGL Renderbuffer Container Class
+
+		private class OpenGLRenderbuffer : IGLRenderbuffer
+		{
+			public uint Handle
+			{
+				get;
+				private set;
+			}
+
+			public OpenGLRenderbuffer(uint handle)
+			{
+				Handle = handle;
+			}
+		}
+
+		#endregion
+
+		#region OpenGL Buffer Container Class
+
+		private class OpenGLBuffer : IGLBuffer
+		{
+			public uint Handle
+			{
+				get;
+				private set;
+			}
+
+			public IntPtr BufferSize
+			{
+				get;
+				private set;
+			}
+
+			public GLenum Dynamic
+			{
+				get;
+				private set;
+			}
+
+			public OpenGLBuffer(
+				uint handle,
+				IntPtr bufferSize,
+				GLenum dynamic
+			) {
+				Handle = handle;
+				BufferSize = bufferSize;
+				Dynamic = dynamic;
+			}
+
+			private OpenGLBuffer()
+			{
+				Handle = 0;
+			}
+			public static readonly OpenGLBuffer NullBuffer = new OpenGLBuffer();
+		}
+
+		#endregion
+
+		#region OpenGL Effect Container Class
+
+		private class OpenGLEffect : IGLEffect
+		{
+			public IntPtr EffectData
+			{
+				get;
+				private set;
+			}
+
+			public IntPtr GLEffectData
+			{
+				get;
+				private set;
+			}
+
+			public OpenGLEffect(IntPtr effect, IntPtr glEffect)
+			{
+				EffectData = effect;
+				GLEffectData = glEffect;
+			}
+		}
+
+		#endregion
+
+		#region OpenGL Query Container Class
+
+		private class OpenGLQuery : IGLQuery
+		{
+			public uint Handle
+			{
+				get;
+				private set;
+			}
+
+			public OpenGLQuery(uint handle)
+			{
+				Handle = handle;
+			}
+		}
+
+		#endregion
+
+		#region Blending State Variables
+
+		public Color BlendFactor
+		{
+			get
+			{
+				return blendColor;
+			}
+			set
+			{
+				if (value != blendColor)
+				{
+					blendColor = value;
+					glBlendColor(
+						blendColor.R / 255.0f,
+						blendColor.G / 255.0f,
+						blendColor.B / 255.0f,
+						blendColor.A / 255.0f
+					);
+				}
+			}
+		}
+
+		public int MultiSampleMask
+		{
+			get
+			{
+				return multisampleMask;
+			}
+			set
+			{
+				if (value != multisampleMask)
+				{
+					if (value == -1)
+					{
+						glDisable(GLenum.GL_SAMPLE_MASK);
+					}
+					else
+					{
+						if (multisampleMask == -1)
+						{
+							glEnable(GLenum.GL_SAMPLE_MASK);
+						}
+						// FIXME: index...? -flibit
+						glSampleMaski(0, (uint) value);
+					}
+					multisampleMask = value;
+				}
+			}
+		}
+
+		private bool alphaBlendEnable = false;
+		private Color blendColor = Color.Transparent;
+		private BlendFunction blendOp = BlendFunction.Add;
+		private BlendFunction blendOpAlpha = BlendFunction.Add;
+		private Blend srcBlend = Blend.One;
+		private Blend dstBlend = Blend.Zero;
+		private Blend srcBlendAlpha = Blend.One;
+		private Blend dstBlendAlpha = Blend.Zero;
+		private ColorWriteChannels colorWriteEnable = ColorWriteChannels.All;
+		private ColorWriteChannels colorWriteEnable1 = ColorWriteChannels.All;
+		private ColorWriteChannels colorWriteEnable2 = ColorWriteChannels.All;
+		private ColorWriteChannels colorWriteEnable3 = ColorWriteChannels.All;
+		private int multisampleMask = -1; // AKA 0xFFFFFFFF
+
+		#endregion
+
+		#region Depth State Variables
+
+		private bool zEnable = false;
+		private bool zWriteEnable = false;
+		private CompareFunction depthFunc = CompareFunction.Less;
+
+		#endregion
+
+		#region Stencil State Variables
+
+		public int ReferenceStencil
+		{
+			get
+			{
+				return stencilRef;
+			}
+			set
+			{
+				if (value != stencilRef)
+				{
+					stencilRef = value;
+					if (separateStencilEnable)
+					{
+						glStencilFuncSeparate(
+							GLenum.GL_FRONT,
+							XNAToGL.CompareFunc[(int) stencilFunc],
+							stencilRef,
+							stencilMask
+						);
+						glStencilFuncSeparate(
+							GLenum.GL_BACK,
+							XNAToGL.CompareFunc[(int) ccwStencilFunc],
+							stencilRef,
+							stencilMask
+						);
+					}
+					else
+					{
+						glStencilFunc(
+							XNAToGL.CompareFunc[(int) stencilFunc],
+							stencilRef,
+							stencilMask
+						);
+					}
+				}
+			}
+		}
+
+		private bool stencilEnable = false;
+		private int stencilWriteMask = -1; // AKA 0xFFFFFFFF, ugh -flibit
+		private bool separateStencilEnable = false;
+		private int stencilRef = 0;
+		private int stencilMask = -1; // AKA 0xFFFFFFFF, ugh -flibit
+		private CompareFunction stencilFunc = CompareFunction.Always;
+		private StencilOperation stencilFail = StencilOperation.Keep;
+		private StencilOperation stencilZFail = StencilOperation.Keep;
+		private StencilOperation stencilPass = StencilOperation.Keep;
+		private CompareFunction ccwStencilFunc = CompareFunction.Always;
+		private StencilOperation ccwStencilFail = StencilOperation.Keep;
+		private StencilOperation ccwStencilZFail = StencilOperation.Keep;
+		private StencilOperation ccwStencilPass = StencilOperation.Keep;
+
+		#endregion
+
+		#region Rasterizer State Variables
+
+		private bool scissorTestEnable = false;
+		private CullMode cullFrontFace = CullMode.None;
+		private FillMode fillMode = FillMode.Solid;
+		private float depthBias = 0.0f;
+		private float slopeScaleDepthBias = 0.0f;
+		private bool multiSampleEnable = true;
+
+		#endregion
+
+		#region Viewport State Variables
+
+		/* These two aren't actually empty rects by default in OpenGL,
+		 * but we don't _really_ know the starting window size, so
+		 * force apply this when the GraphicsDevice is initialized.
+		 * -flibit
+		 */
+		private Rectangle scissorRectangle =  new Rectangle(
+			0,
+			0,
+			0,
+			0
+		);
+		private Rectangle viewport = new Rectangle(
+			0,
+			0,
+			0,
+			0
+		);
+		private float depthRangeMin = 0.0f;
+		private float depthRangeMax = 1.0f;
+
+		#endregion
+
+		#region Texture Collection Variables
+
+		private OpenGLTexture[] Textures;
+
+		#endregion
+
+		#region Buffer Binding Cache Variables
+
+		private uint currentVertexBuffer = 0;
+		private uint currentIndexBuffer = 0;
+
+		// ld, or LastDrawn, effect/vertex attributes
+		private int ldBaseVertex = -1;
+		private VertexDeclaration ldVertexDeclaration = null;
+		private IntPtr ldPointer = IntPtr.Zero;
+		private IntPtr ldEffect = IntPtr.Zero;
+		private IntPtr ldTechnique = IntPtr.Zero;
+		private uint ldPass = 0;
+		private Shader ldShader = null;
+
+		#endregion
+
+		#region Render Target Cache Variables
+
+		private uint currentReadFramebuffer = 0;
+		private uint currentDrawFramebuffer = 0;
+		private uint targetFramebuffer = 0;
+		private uint resolveFramebufferRead = 0;
+		private uint resolveFramebufferDraw = 0;
+		private readonly uint[] currentAttachments;
+		private readonly GLenum[] currentAttachmentTypes;
+		private int currentDrawBuffers;
+		private readonly IntPtr drawBuffersArray;
+		private uint currentRenderbuffer;
+		private DepthFormat currentDepthStencilFormat;
+		private readonly uint[] attachments;
+		private readonly GLenum[] attachmentTypes;
+
+		#endregion
+
+		#region Clear Cache Variables
+
+		private Vector4 currentClearColor = new Vector4(0, 0, 0, 0);
+		private float currentClearDepth = 1.0f;
+		private int currentClearStencil = 0;
+
+		#endregion
+
+		#region Private OpenGL Context Variable
+
+		private IntPtr glContext;
+
+		#endregion
+
+		#region Faux-Backbuffer Variables
+
+		public IGLBackbuffer Backbuffer
+		{
+			get;
+			private set;
+		}
+
+		private GLenum backbufferScaleMode;
+
+		#endregion
+
+		#region OpenGL Device Capabilities
+
+		public bool SupportsDxt1
+		{
+			get;
+			private set;
+		}
+
+		public bool SupportsS3tc
+		{
+			get;
+			private set;
+		}
+
+		public int MaxTextureSlots
+		{
+			get;
+			private set;
+		}
+
+		public int MaxMultiSampleCount
+		{
+			get;
+			private set;
+		}
+
+		#endregion
+
+		#region Private Vertex Attribute Cache
+
+		private class VertexAttribute
+		{
+			public uint CurrentBuffer;
+			public IntPtr CurrentPointer;
+			public VertexElementFormat CurrentFormat;
+			public bool CurrentNormalized;
+			public int CurrentStride;
+			public VertexAttribute()
+			{
+				CurrentBuffer = 0;
+				CurrentPointer = IntPtr.Zero;
+				CurrentFormat = VertexElementFormat.Single;
+				CurrentNormalized = false;
+				CurrentStride = 0;
+			}
+		}
+		private VertexAttribute[] attributes;
+		private bool[] attributeEnabled;
+		private bool[] previousAttributeEnabled;
+		private int[] attributeDivisor;
+		private int[] previousAttributeDivisor;
+
+		#endregion
+
+		#region Private MojoShader Interop
+
+		private string shaderProfile;
+		private IntPtr shaderContext;
+
+		private IntPtr currentEffect = IntPtr.Zero;
+		private IntPtr currentTechnique = IntPtr.Zero;
+		private uint currentPass = 0;
+		private Shader currentShader = null;
+
+		private int flipViewport = 1;
+
+		private bool effectApplied = false;
+		private bool shaderApplied = false;
+
+		private static IntPtr glGetProcAddress(IntPtr name, IntPtr d)
+		{
+			return SDL.SDL_GL_GetProcAddress(name);
+		}
+		private static MojoShader.MOJOSHADER_glGetProcAddress GLGetProcAddress = glGetProcAddress;
+
+		#endregion
+
+		#region Private Graphics Object Disposal Queues
+
+		private ConcurrentQueue<IGLTexture> GCTextures = new ConcurrentQueue<IGLTexture>();
+		private ConcurrentQueue<IGLRenderbuffer> GCDepthBuffers = new ConcurrentQueue<IGLRenderbuffer>();
+		private ConcurrentQueue<IGLBuffer> GCVertexBuffers = new ConcurrentQueue<IGLBuffer>();
+		private ConcurrentQueue<IGLBuffer> GCIndexBuffers = new ConcurrentQueue<IGLBuffer>();
+		private ConcurrentQueue<IGLEffect> GCEffects = new ConcurrentQueue<IGLEffect>();
+		private ConcurrentQueue<IGLQuery> GCQueries = new ConcurrentQueue<IGLQuery>();
+
+		#endregion
+
+		#region Private Profile-specific Variables
+
+		private DepthFormat windowDepthFormat;
+		private uint vao;
+
+		#endregion
+
+		#region memcpy Export
+
+		/* This is used a lot for GetData/Read calls... -flibit */
+		[DllImport("msvcrt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void memcpy(IntPtr dst, IntPtr src, IntPtr len);
+
+		#endregion
+
+		#region Public Constructor
+
+		public ShaderGLDevice(
+			PresentationParameters presentationParameters,
+			GraphicsAdapter adapter
+		) {
+			// Create OpenGL context
+			glContext = SDL.SDL_GL_CreateContext(
+				presentationParameters.DeviceWindowHandle
+			);
+
+			// Check for a possible ES context
+			int flags;
+			int es3Flag = (int) SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_ES;
+			SDL.SDL_GL_GetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, out flags);
+			useES3 = (flags & es3Flag) == es3Flag;
+
+			// Check for a possible Core context
+			int coreFlag = (int) SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_CORE;
+			useCoreProfile = (flags & coreFlag) == coreFlag;
+
+			// Check the window's depth/stencil format
+			int depthSize, stencilSize;
+			SDL.SDL_GL_GetAttribute(SDL.SDL_GLattr.SDL_GL_DEPTH_SIZE, out depthSize);
+			SDL.SDL_GL_GetAttribute(SDL.SDL_GLattr.SDL_GL_STENCIL_SIZE, out stencilSize);
+			if (depthSize == 0 && stencilSize == 0)
+			{
+				windowDepthFormat = DepthFormat.None;
+			}
+			else if (depthSize == 16 && stencilSize == 0)
+			{
+				windowDepthFormat = DepthFormat.Depth16;
+			}
+			else if (depthSize == 24 && stencilSize == 0)
+			{
+				windowDepthFormat = DepthFormat.Depth24;
+			}
+			else if (depthSize == 24 && stencilSize == 8)
+			{
+				windowDepthFormat = DepthFormat.Depth24Stencil8;
+			}
+			else
+			{
+				throw new NotSupportedException("Unrecognized window depth/stencil format!");
+			}
+
+			// Init threaded GL crap where applicable
+			InitThreadedGL(
+				presentationParameters.DeviceWindowHandle
+			);
+
+			// Print GL information
+			LoadGLGetString();
+			string renderer = glGetString(GLenum.GL_RENDERER);
+			string version = glGetString(GLenum.GL_VERSION);
+			string vendor = glGetString(GLenum.GL_VENDOR);
+			FNALoggerEXT.LogInfo("IGLDevice: ShaderGLDevice");
+			FNALoggerEXT.LogInfo("OpenGL Device: " + renderer);
+			FNALoggerEXT.LogInfo("OpenGL Driver: " + version);
+			FNALoggerEXT.LogInfo("OpenGL Vendor: " + vendor);
+
+			// Initialize entry points
+			LoadGLEntryPoints(string.Format(
+				"Device: {0}\nDriver: {1}\nVendor: {2}",
+				renderer,
+				version,
+				vendor
+			));
+
+			shaderProfile = MojoShader.MOJOSHADER_glBestProfile(
+				GLGetProcAddress,
+				IntPtr.Zero,
+				null,
+				null,
+				IntPtr.Zero
+			);
+			shaderContext = MojoShader.MOJOSHADER_glCreateContext(
+				shaderProfile,
+				GLGetProcAddress,
+				IntPtr.Zero,
+				null,
+				null,
+				IntPtr.Zero
+			);
+			MojoShader.MOJOSHADER_glMakeContextCurrent(shaderContext);
+			FNALoggerEXT.LogInfo("MojoShader Profile: " + shaderProfile);
+
+			// Some users might want pixely upscaling...
+			backbufferScaleMode = Environment.GetEnvironmentVariable(
+				"FNA_OPENGL_BACKBUFFER_SCALE_NEAREST"
+			) == "1" ? GLenum.GL_NEAREST : GLenum.GL_LINEAR;
+
+			// Load the extension list, initialize extension-dependent components
+			string extensions;
+			if (useCoreProfile)
+			{
+				extensions = string.Empty;
+				int numExtensions;
+				glGetIntegerv(GLenum.GL_NUM_EXTENSIONS, out numExtensions);
+				for (uint i = 0; i < numExtensions; i += 1)
+				{
+					extensions += glGetStringi(GLenum.GL_EXTENSIONS, i) + " ";
+				}
+			}
+			else
+			{
+				extensions = glGetString(GLenum.GL_EXTENSIONS);
+			}
+			SupportsS3tc = (
+				extensions.Contains("GL_EXT_texture_compression_s3tc") ||
+				extensions.Contains("GL_OES_texture_compression_S3TC") ||
+				extensions.Contains("GL_EXT_texture_compression_dxt3") ||
+				extensions.Contains("GL_EXT_texture_compression_dxt5")
+			);
+			SupportsDxt1 = (
+				SupportsS3tc ||
+				extensions.Contains("GL_EXT_texture_compression_dxt1")
+			);
+
+			/* Check the max multisample count, override parameters if necessary */
+			int maxSamples = 0;
+			if (supportsMultisampling)
+			{
+				glGetIntegerv(GLenum.GL_MAX_SAMPLES, out maxSamples);
+			}
+			MaxMultiSampleCount = maxSamples;
+			presentationParameters.MultiSampleCount = Math.Min(
+				presentationParameters.MultiSampleCount,
+				MaxMultiSampleCount
+			);
+
+			// Initialize the faux-backbuffer
+			if (UseFauxBackbuffer(presentationParameters, adapter.CurrentDisplayMode))
+			{
+				if (!supportsFauxBackbuffer)
+				{
+					throw new NoSuitableGraphicsDeviceException(
+						"Your hardware does not support the faux-backbuffer!" +
+						"\n\nKeep the window/backbuffer resolution the same."
+					);
+				}
+				Backbuffer = new OpenGLBackbuffer(
+					this,
+					presentationParameters.BackBufferWidth,
+					presentationParameters.BackBufferHeight,
+					presentationParameters.DepthStencilFormat,
+					presentationParameters.MultiSampleCount
+				);
+			}
+			else
+			{
+				Backbuffer = new NullBackbuffer(
+					presentationParameters.BackBufferWidth,
+					presentationParameters.BackBufferHeight,
+					windowDepthFormat
+				);
+			}
+
+			// Initialize texture collection array
+			int numSamplers;
+			glGetIntegerv(GLenum.GL_MAX_TEXTURE_IMAGE_UNITS, out numSamplers);
+			numSamplers = Math.Min(
+				numSamplers,
+				GraphicsDevice.MAX_TEXTURE_SAMPLERS + GraphicsDevice.MAX_VERTEXTEXTURE_SAMPLERS
+			);
+			Textures = new OpenGLTexture[numSamplers];
+			for (int i = 0; i < numSamplers; i += 1)
+			{
+				Textures[i] = OpenGLTexture.NullTexture;
+			}
+			MaxTextureSlots = numSamplers;
+
+			// Initialize vertex attribute state arrays
+			int numAttributes;
+			glGetIntegerv(GLenum.GL_MAX_VERTEX_ATTRIBS, out numAttributes);
+			numAttributes = Math.Min(
+				numAttributes,
+				GraphicsDevice.MAX_VERTEX_ATTRIBUTES
+			);
+			attributes = new VertexAttribute[numAttributes];
+			attributeEnabled = new bool[numAttributes];
+			previousAttributeEnabled = new bool[numAttributes];
+			attributeDivisor = new int[numAttributes];
+			previousAttributeDivisor = new int[numAttributes];
+			for (int i = 0; i < numAttributes; i += 1)
+			{
+				attributes[i] = new VertexAttribute();
+				attributeEnabled[i] = false;
+				previousAttributeEnabled[i] = false;
+				attributeDivisor[i] = 0;
+				previousAttributeDivisor[i] = 0;
+			}
+
+			// Initialize render target FBO and state arrays
+			int numAttachments;
+			glGetIntegerv(GLenum.GL_MAX_DRAW_BUFFERS, out numAttachments);
+			numAttachments = Math.Min(
+				numAttachments,
+				GraphicsDevice.MAX_RENDERTARGET_BINDINGS
+			);
+			attachments = new uint[numAttachments];
+			attachmentTypes = new GLenum[numAttachments];
+			currentAttachments = new uint[numAttachments];
+			currentAttachmentTypes = new GLenum[numAttachments];
+			drawBuffersArray = Marshal.AllocHGlobal(sizeof(GLenum) * numAttachments);
+			unsafe
+			{
+				GLenum* dba = (GLenum*) drawBuffersArray;
+				for (int i = 0; i < numAttachments; i += 1)
+				{
+					currentAttachments[i] = 0;
+					currentAttachmentTypes[i] = GLenum.GL_TEXTURE_2D;
+					dba[i] = GLenum.GL_COLOR_ATTACHMENT0 + i;
+				}
+			}
+			currentDrawBuffers = 0;
+			currentRenderbuffer = 0;
+			currentDepthStencilFormat = DepthFormat.None;
+			glGenFramebuffers(1, out targetFramebuffer);
+			glGenFramebuffers(1, out resolveFramebufferRead);
+			glGenFramebuffers(1, out resolveFramebufferDraw);
+
+			// Generate and bind a VAO, to shut Core up
+			if (useCoreProfile)
+			{
+				glGenVertexArrays(1, out vao);
+				glBindVertexArray(vao);
+			}
+		}
+
+		#endregion
+
+		#region Dispose Method
+
+		public void Dispose()
+		{
+			if (useCoreProfile)
+			{
+				glBindVertexArray(0);
+				glDeleteVertexArrays(1, ref vao);
+			}
+			glDeleteFramebuffers(1, ref resolveFramebufferRead);
+			resolveFramebufferRead = 0;
+			glDeleteFramebuffers(1, ref resolveFramebufferDraw);
+			resolveFramebufferDraw = 0;
+			glDeleteFramebuffers(1, ref targetFramebuffer);
+			targetFramebuffer = 0;
+			if (Backbuffer is OpenGLBackbuffer)
+			{
+				(Backbuffer as OpenGLBackbuffer).Dispose();
+			}
+			Backbuffer = null;
+			Marshal.FreeHGlobal(drawBuffersArray);
+			MojoShader.MOJOSHADER_glMakeContextCurrent(IntPtr.Zero);
+			MojoShader.MOJOSHADER_glDestroyContext(shaderContext);
+
+#if THREADED_GL
+			SDL.SDL_GL_DeleteContext(BackgroundContext.context);
+#endif
+			SDL.SDL_GL_DeleteContext(glContext);
+		}
+
+		#endregion
+
+		#region Window Backbuffer Reset Method
+
+		public void ResetBackbuffer(
+			PresentationParameters presentationParameters,
+			GraphicsAdapter adapter,
+			bool renderTargetBound
+		) {
+			if (UseFauxBackbuffer(presentationParameters, adapter.CurrentDisplayMode))
+			{
+				if (Backbuffer is NullBackbuffer)
+				{
+					if (!supportsFauxBackbuffer)
+					{
+						throw new NoSuitableGraphicsDeviceException(
+							"Your hardware does not support the faux-backbuffer!" +
+							"\n\nKeep the window/backbuffer resolution the same."
+						);
+					}
+					Backbuffer = new OpenGLBackbuffer(
+						this,
+						presentationParameters.BackBufferWidth,
+						presentationParameters.BackBufferHeight,
+						presentationParameters.DepthStencilFormat,
+						presentationParameters.MultiSampleCount
+					);
+				}
+				else
+				{
+					Backbuffer.ResetFramebuffer(
+						presentationParameters,
+						renderTargetBound
+					);
+				}
+			}
+			else
+			{
+				if (Backbuffer is OpenGLBackbuffer)
+				{
+					(Backbuffer as OpenGLBackbuffer).Dispose();
+					Backbuffer = new NullBackbuffer(
+						presentationParameters.BackBufferWidth,
+						presentationParameters.BackBufferHeight,
+						windowDepthFormat
+					);
+				}
+				else
+				{
+					Backbuffer.ResetFramebuffer(
+						presentationParameters,
+						renderTargetBound
+					);
+				}
+			}
+		}
+
+		#endregion
+
+		#region Window SwapBuffers Method
+
+		public void SwapBuffers(
+			Rectangle? sourceRectangle,
+			Rectangle? destinationRectangle,
+			IntPtr overrideWindowHandle
+		) {
+			/* Only the faux-backbuffer supports presenting
+			 * specific regions given to Present().
+			 * -flibit
+			 */
+			if (Backbuffer is OpenGLBackbuffer)
+			{
+				int srcX, srcY, srcW, srcH;
+				int dstX, dstY, dstW, dstH;
+				if (sourceRectangle.HasValue)
+				{
+					srcX = sourceRectangle.Value.X;
+					srcY = sourceRectangle.Value.Y;
+					srcW = sourceRectangle.Value.Width;
+					srcH = sourceRectangle.Value.Height;
+				}
+				else
+				{
+					srcX = 0;
+					srcY = 0;
+					srcW = Backbuffer.Width;
+					srcH = Backbuffer.Height;
+				}
+				if (destinationRectangle.HasValue)
+				{
+					dstX = destinationRectangle.Value.X;
+					dstY = destinationRectangle.Value.Y;
+					dstW = destinationRectangle.Value.Width;
+					dstH = destinationRectangle.Value.Height;
+				}
+				else
+				{
+					dstX = 0;
+					dstY = 0;
+					SDL.SDL_GL_GetDrawableSize(
+						overrideWindowHandle,
+						out dstW,
+						out dstH
+					);
+				}
+
+				if (scissorTestEnable)
+				{
+					glDisable(GLenum.GL_SCISSOR_TEST);
+				}
+
+				if (	Backbuffer.MultiSampleCount > 0 &&
+					(srcX != dstX || srcY != dstY || srcW != dstW || srcH != dstH)	)
+				{
+					/* We have to resolve the renderbuffer to a texture first.
+					 * For whatever reason, we can't blit a multisample renderbuffer
+					 * to the backbuffer. Not sure why, but oh well.
+					 * -flibit
+					 */
+					OpenGLBackbuffer glBack = Backbuffer as OpenGLBackbuffer;
+					if (glBack.Texture == 0)
+					{
+						glGenTextures(1, out glBack.Texture);
+						glBindTexture(GLenum.GL_TEXTURE_2D, glBack.Texture);
+						glTexImage2D(
+							GLenum.GL_TEXTURE_2D,
+							0,
+							(int) GLenum.GL_RGBA,
+							glBack.Width,
+							glBack.Height,
+							0,
+							GLenum.GL_RGBA,
+							GLenum.GL_UNSIGNED_BYTE,
+							IntPtr.Zero
+						);
+						glBindTexture(Textures[0].Target, Textures[0].Handle);
+					}
+					BindFramebuffer(resolveFramebufferDraw);
+					glFramebufferTexture2D(
+						GLenum.GL_FRAMEBUFFER,
+						GLenum.GL_COLOR_ATTACHMENT0,
+						GLenum.GL_TEXTURE_2D,
+						glBack.Texture,
+						0
+					);
+					BindReadFramebuffer(glBack.Handle);
+					glBlitFramebuffer(
+						0, 0, glBack.Width, glBack.Height,
+						0, 0, glBack.Width, glBack.Height,
+						GLenum.GL_COLOR_BUFFER_BIT,
+						GLenum.GL_LINEAR
+					);
+					BindReadFramebuffer(resolveFramebufferDraw);
+				}
+				else
+				{
+					BindReadFramebuffer((Backbuffer as OpenGLBackbuffer).Handle);
+				}
+				BindDrawFramebuffer(0);
+
+				glBlitFramebuffer(
+					srcX, srcY, srcW, srcH,
+					dstX, dstY, dstW, dstH,
+					GLenum.GL_COLOR_BUFFER_BIT,
+					backbufferScaleMode
+				);
+
+				BindFramebuffer(0);
+
+				if (scissorTestEnable)
+				{
+					glEnable(GLenum.GL_SCISSOR_TEST);
+				}
+
+				SDL.SDL_GL_SwapWindow(
+					overrideWindowHandle
+				);
+
+				BindFramebuffer((Backbuffer as OpenGLBackbuffer).Handle);
+			}
+			else
+			{
+				// Nothing left to do, just swap!
+				SDL.SDL_GL_SwapWindow(
+					overrideWindowHandle
+				);
+			}
+
+#if !DISABLE_THREADING && !THREADED_GL
+			RunActions();
+#endif
+			IGLTexture gcTexture;
+			while (GCTextures.TryDequeue(out gcTexture))
+			{
+				DeleteTexture(gcTexture);
+			}
+			IGLRenderbuffer gcDepthBuffer;
+			while (GCDepthBuffers.TryDequeue(out gcDepthBuffer))
+			{
+				DeleteRenderbuffer(gcDepthBuffer);
+			}
+			IGLBuffer gcBuffer;
+			while (GCVertexBuffers.TryDequeue(out gcBuffer))
+			{
+				DeleteVertexBuffer(gcBuffer);
+			}
+			while (GCIndexBuffers.TryDequeue(out gcBuffer))
+			{
+				DeleteIndexBuffer(gcBuffer);
+			}
+			IGLEffect gcEffect;
+			while (GCEffects.TryDequeue(out gcEffect))
+			{
+				DeleteEffect(gcEffect);
+			}
+			IGLQuery gcQuery;
+			while (GCQueries.TryDequeue(out gcQuery))
+			{
+				DeleteQuery(gcQuery);
+			}
+		}
+
+		#endregion
+
+		#region GL Object Disposal Wrappers
+
+		public void AddDisposeTexture(IGLTexture texture)
+		{
+			if (IsOnMainThread())
+			{
+				DeleteTexture(texture);
+			}
+			else
+			{
+				GCTextures.Enqueue(texture);
+			}
+		}
+
+		public void AddDisposeRenderbuffer(IGLRenderbuffer renderbuffer)
+		{
+			if (IsOnMainThread())
+			{
+				DeleteRenderbuffer(renderbuffer);
+			}
+			else
+			{
+				GCDepthBuffers.Enqueue(renderbuffer);
+			}
+		}
+
+		public void AddDisposeVertexBuffer(IGLBuffer buffer)
+		{
+			if (IsOnMainThread())
+			{
+				DeleteVertexBuffer(buffer);
+			}
+			else
+			{
+				GCVertexBuffers.Enqueue(buffer);
+			}
+		}
+
+		public void AddDisposeIndexBuffer(IGLBuffer buffer)
+		{
+			if (IsOnMainThread())
+			{
+				DeleteIndexBuffer(buffer);
+			}
+			else
+			{
+				GCIndexBuffers.Enqueue(buffer);
+			}
+		}
+
+		public void AddDisposeEffect(IGLEffect effect)
+		{
+			if (IsOnMainThread())
+			{
+				DeleteEffect(effect);
+			}
+			else
+			{
+				GCEffects.Enqueue(effect);
+			}
+		}
+
+		public void AddDisposeQuery(IGLQuery query)
+		{
+			if (IsOnMainThread())
+			{
+				DeleteQuery(query);
+			}
+			else
+			{
+				GCQueries.Enqueue(query);
+			}
+		}
+
+		#endregion
+
+		#region String Marker Method
+
+		public void SetStringMarker(string text)
+		{
+#if DEBUG
+			IntPtr chars = Marshal.StringToHGlobalAnsi(text);
+			glStringMarkerGREMEDY(text.Length, chars);
+			Marshal.FreeHGlobal(chars);
+#endif
+		}
+
+		#endregion
+
+		#region Drawing Methods
+
+		public void DrawIndexedPrimitives(
+			PrimitiveType primitiveType,
+			int baseVertex,
+			int minVertexIndex,
+			int numVertices,
+			int startIndex,
+			int primitiveCount,
+			IndexBuffer indices
+		) {
+			// Bind the index buffer
+			BindIndexBuffer(indices.buffer);
+
+			// Draw!
+			glDrawRangeElementsBaseVertex(
+				XNAToGL.Primitive[(int) primitiveType],
+				minVertexIndex,
+				minVertexIndex + numVertices - 1,
+				XNAToGL.PrimitiveVerts(primitiveType, primitiveCount),
+				XNAToGL.IndexType[(int) indices.IndexElementSize],
+				(IntPtr) (startIndex * XNAToGL.IndexSize[(int) indices.IndexElementSize]),
+				baseVertex
+			);
+		}
+
+		public void DrawInstancedPrimitives(
+			PrimitiveType primitiveType,
+			int baseVertex,
+			int minVertexIndex,
+			int numVertices,
+			int startIndex,
+			int primitiveCount,
+			int instanceCount,
+			IndexBuffer indices
+		) {
+			// Note that minVertexIndex and numVertices are NOT used!
+
+			// Bind the index buffer
+			BindIndexBuffer(indices.buffer);
+
+			// Draw!
+			glDrawElementsInstancedBaseVertex(
+				XNAToGL.Primitive[(int) primitiveType],
+				XNAToGL.PrimitiveVerts(primitiveType, primitiveCount),
+				XNAToGL.IndexType[(int) indices.IndexElementSize],
+				(IntPtr) (startIndex * XNAToGL.IndexSize[(int) indices.IndexElementSize]),
+				instanceCount,
+				baseVertex
+			);
+		}
+
+		public void DrawPrimitives(
+			PrimitiveType primitiveType,
+			int vertexStart,
+			int primitiveCount
+		) {
+			// Draw!
+			glDrawArrays(
+				XNAToGL.Primitive[(int) primitiveType],
+				vertexStart,
+				XNAToGL.PrimitiveVerts(primitiveType, primitiveCount)
+			);
+		}
+
+		public void DrawUserIndexedPrimitives(
+			PrimitiveType primitiveType,
+			IntPtr vertexData,
+			int vertexOffset,
+			int numVertices,
+			IntPtr indexData,
+			int indexOffset,
+			IndexElementSize indexElementSize,
+			int primitiveCount
+		) {
+			// Unbind current index buffer.
+			BindIndexBuffer(OpenGLBuffer.NullBuffer);
+
+			// Draw!
+			glDrawRangeElements(
+				XNAToGL.Primitive[(int) primitiveType],
+				0,
+				numVertices - 1,
+				XNAToGL.PrimitiveVerts(primitiveType, primitiveCount),
+				XNAToGL.IndexType[(int) indexElementSize],
+				(IntPtr) (
+					indexData.ToInt64() +
+					(indexOffset * XNAToGL.IndexSize[(int) indexElementSize])
+				)
+			);
+		}
+
+		public void DrawUserPrimitives(
+			PrimitiveType primitiveType,
+			IntPtr vertexData,
+			int vertexOffset,
+			int primitiveCount
+		) {
+			// Draw!
+			glDrawArrays(
+				XNAToGL.Primitive[(int) primitiveType],
+				vertexOffset,
+				XNAToGL.PrimitiveVerts(primitiveType, primitiveCount)
+			);
+		}
+
+		#endregion
+
+		#region State Management Methods
+
+		public void SetViewport(Viewport vp, bool renderTargetBound)
+		{
+			// Flip viewport when target is not bound
+			if (!renderTargetBound)
+			{
+				vp.Y = Backbuffer.Height - vp.Y - vp.Height;
+			}
+
+			if (vp.Bounds != viewport)
+			{
+				viewport = vp.Bounds;
+				glViewport(
+					viewport.X,
+					viewport.Y,
+					viewport.Width,
+					viewport.Height
+				);
+			}
+
+			if (vp.MinDepth != depthRangeMin || vp.MaxDepth != depthRangeMax)
+			{
+				depthRangeMin = vp.MinDepth;
+				depthRangeMax = vp.MaxDepth;
+				glDepthRange((double) depthRangeMin, (double) depthRangeMax);
+			}
+		}
+
+		public void SetScissorRect(
+			Rectangle scissorRect,
+			bool renderTargetBound
+		) {
+			// Flip rectangle when target is not bound
+			if (!renderTargetBound)
+			{
+				scissorRect.Y = Backbuffer.Height - scissorRect.Y - scissorRect.Height;
+			}
+
+			if (scissorRect != scissorRectangle)
+			{
+				scissorRectangle = scissorRect;
+				glScissor(
+					scissorRectangle.X,
+					scissorRectangle.Y,
+					scissorRectangle.Width,
+					scissorRectangle.Height
+				);
+			}
+		}
+
+		public void SetBlendState(BlendState blendState)
+		{
+			bool newEnable = (
+				!(	blendState.ColorSourceBlend == Blend.One &&
+					blendState.ColorDestinationBlend == Blend.Zero &&
+					blendState.AlphaSourceBlend == Blend.One &&
+					blendState.AlphaDestinationBlend == Blend.Zero	)
+			);
+			if (newEnable != alphaBlendEnable)
+			{
+				alphaBlendEnable = newEnable;
+				ToggleGLState(GLenum.GL_BLEND, alphaBlendEnable);
+			}
+
+			if (alphaBlendEnable)
+			{
+				if (blendState.BlendFactor != blendColor)
+				{
+					blendColor = blendState.BlendFactor;
+					glBlendColor(
+						blendColor.R / 255.0f,
+						blendColor.G / 255.0f,
+						blendColor.B / 255.0f,
+						blendColor.A / 255.0f
+					);
+				}
+
+				if (	blendState.ColorSourceBlend != srcBlend ||
+					blendState.ColorDestinationBlend != dstBlend ||
+					blendState.AlphaSourceBlend != srcBlendAlpha ||
+					blendState.AlphaDestinationBlend != dstBlendAlpha	)
+				{
+					srcBlend = blendState.ColorSourceBlend;
+					dstBlend = blendState.ColorDestinationBlend;
+					srcBlendAlpha = blendState.AlphaSourceBlend;
+					dstBlendAlpha = blendState.AlphaDestinationBlend;
+					glBlendFuncSeparate(
+						XNAToGL.BlendMode[(int) srcBlend],
+						XNAToGL.BlendMode[(int) dstBlend],
+						XNAToGL.BlendMode[(int) srcBlendAlpha],
+						XNAToGL.BlendMode[(int) dstBlendAlpha]
+					);
+				}
+
+				if (	blendState.ColorBlendFunction != blendOp ||
+					blendState.AlphaBlendFunction != blendOpAlpha	)
+				{
+					blendOp = blendState.ColorBlendFunction;
+					blendOpAlpha = blendState.AlphaBlendFunction;
+					glBlendEquationSeparate(
+						XNAToGL.BlendEquation[(int) blendOp],
+						XNAToGL.BlendEquation[(int) blendOpAlpha]
+					);
+				}
+			}
+
+			if (blendState.ColorWriteChannels != colorWriteEnable)
+			{
+				colorWriteEnable = blendState.ColorWriteChannels;
+				glColorMask(
+					(colorWriteEnable & ColorWriteChannels.Red) != 0,
+					(colorWriteEnable & ColorWriteChannels.Green) != 0,
+					(colorWriteEnable & ColorWriteChannels.Blue) != 0,
+					(colorWriteEnable & ColorWriteChannels.Alpha) != 0
+				);
+			}
+			/* FIXME: So how exactly do we factor in
+			 * COLORWRITEENABLE for buffer 0? Do we just assume that
+			 * the default is just buffer 0, and all other calls
+			 * update the other write masks afterward? Or do we
+			 * assume that COLORWRITEENABLE only touches 0, and the
+			 * other 3 buffers are left alone unless we don't have
+			 * EXT_draw_buffers2?
+			 * -flibit
+			 */
+			if (blendState.ColorWriteChannels1 != colorWriteEnable1)
+			{
+				colorWriteEnable1 = blendState.ColorWriteChannels1;
+				glColorMaski(
+					1,
+					(colorWriteEnable1 & ColorWriteChannels.Red) != 0,
+					(colorWriteEnable1 & ColorWriteChannels.Green) != 0,
+					(colorWriteEnable1 & ColorWriteChannels.Blue) != 0,
+					(colorWriteEnable1 & ColorWriteChannels.Alpha) != 0
+				);
+			}
+			if (blendState.ColorWriteChannels2 != colorWriteEnable2)
+			{
+				colorWriteEnable2 = blendState.ColorWriteChannels2;
+				glColorMaski(
+					2,
+					(colorWriteEnable2 & ColorWriteChannels.Red) != 0,
+					(colorWriteEnable2 & ColorWriteChannels.Green) != 0,
+					(colorWriteEnable2 & ColorWriteChannels.Blue) != 0,
+					(colorWriteEnable2 & ColorWriteChannels.Alpha) != 0
+				);
+			}
+			if (blendState.ColorWriteChannels3 != colorWriteEnable3)
+			{
+				colorWriteEnable3 = blendState.ColorWriteChannels3;
+				glColorMaski(
+					3,
+					(colorWriteEnable3 & ColorWriteChannels.Red) != 0,
+					(colorWriteEnable3 & ColorWriteChannels.Green) != 0,
+					(colorWriteEnable3 & ColorWriteChannels.Blue) != 0,
+					(colorWriteEnable3 & ColorWriteChannels.Alpha) != 0
+				);
+			}
+
+			if (blendState.MultiSampleMask != multisampleMask)
+			{
+				if (blendState.MultiSampleMask == -1)
+				{
+					glDisable(GLenum.GL_SAMPLE_MASK);
+				}
+				else
+				{
+					if (multisampleMask == -1)
+					{
+						glEnable(GLenum.GL_SAMPLE_MASK);
+					}
+					// FIXME: index...? -flibit
+					glSampleMaski(0, (uint) blendState.MultiSampleMask);
+				}
+				multisampleMask = blendState.MultiSampleMask;
+			}
+		}
+
+		public void SetDepthStencilState(DepthStencilState depthStencilState)
+		{
+			if (depthStencilState.DepthBufferEnable != zEnable)
+			{
+				zEnable = depthStencilState.DepthBufferEnable;
+				ToggleGLState(GLenum.GL_DEPTH_TEST, zEnable);
+			}
+
+			if (zEnable)
+			{
+				if (depthStencilState.DepthBufferWriteEnable != zWriteEnable)
+				{
+					zWriteEnable = depthStencilState.DepthBufferWriteEnable;
+					glDepthMask(zWriteEnable);
+				}
+
+				if (depthStencilState.DepthBufferFunction != depthFunc)
+				{
+					depthFunc = depthStencilState.DepthBufferFunction;
+					glDepthFunc(XNAToGL.CompareFunc[(int) depthFunc]);
+				}
+			}
+
+			if (depthStencilState.StencilEnable != stencilEnable)
+			{
+				stencilEnable = depthStencilState.StencilEnable;
+				ToggleGLState(GLenum.GL_STENCIL_TEST, stencilEnable);
+			}
+
+			if (stencilEnable)
+			{
+				if (depthStencilState.StencilWriteMask != stencilWriteMask)
+				{
+					stencilWriteMask = depthStencilState.StencilWriteMask;
+					glStencilMask(stencilWriteMask);
+				}
+
+				// TODO: Can we split StencilFunc/StencilOp up nicely? -flibit
+				if (	depthStencilState.TwoSidedStencilMode != separateStencilEnable ||
+					depthStencilState.ReferenceStencil != stencilRef ||
+					depthStencilState.StencilMask != stencilMask ||
+					depthStencilState.StencilFunction != stencilFunc ||
+					depthStencilState.CounterClockwiseStencilFunction != ccwStencilFunc ||
+					depthStencilState.StencilFail != stencilFail ||
+					depthStencilState.StencilDepthBufferFail != stencilZFail ||
+					depthStencilState.StencilPass != stencilPass ||
+					depthStencilState.CounterClockwiseStencilFail != ccwStencilFail ||
+					depthStencilState.CounterClockwiseStencilDepthBufferFail != ccwStencilZFail ||
+					depthStencilState.CounterClockwiseStencilPass != ccwStencilPass	)
+				{
+					separateStencilEnable = depthStencilState.TwoSidedStencilMode;
+					stencilRef = depthStencilState.ReferenceStencil;
+					stencilMask = depthStencilState.StencilMask;
+					stencilFunc = depthStencilState.StencilFunction;
+					stencilFail = depthStencilState.StencilFail;
+					stencilZFail = depthStencilState.StencilDepthBufferFail;
+					stencilPass = depthStencilState.StencilPass;
+					if (separateStencilEnable)
+					{
+						ccwStencilFunc = depthStencilState.CounterClockwiseStencilFunction;
+						ccwStencilFail = depthStencilState.CounterClockwiseStencilFail;
+						ccwStencilZFail = depthStencilState.CounterClockwiseStencilDepthBufferFail;
+						ccwStencilPass = depthStencilState.CounterClockwiseStencilPass;
+						glStencilFuncSeparate(
+							GLenum.GL_FRONT,
+							XNAToGL.CompareFunc[(int) stencilFunc],
+							stencilRef,
+							stencilMask
+						);
+						glStencilFuncSeparate(
+							GLenum.GL_BACK,
+							XNAToGL.CompareFunc[(int) ccwStencilFunc],
+							stencilRef,
+							stencilMask
+						);
+						glStencilOpSeparate(
+							GLenum.GL_FRONT,
+							XNAToGL.GLStencilOp[(int) stencilFail],
+							XNAToGL.GLStencilOp[(int) stencilZFail],
+							XNAToGL.GLStencilOp[(int) stencilPass]
+						);
+						glStencilOpSeparate(
+							GLenum.GL_BACK,
+							XNAToGL.GLStencilOp[(int) ccwStencilFail],
+							XNAToGL.GLStencilOp[(int) ccwStencilZFail],
+							XNAToGL.GLStencilOp[(int) ccwStencilPass]
+						);
+					}
+					else
+					{
+						glStencilFunc(
+							XNAToGL.CompareFunc[(int) stencilFunc],
+							stencilRef,
+							stencilMask
+						);
+						glStencilOp(
+							XNAToGL.GLStencilOp[(int) stencilFail],
+							XNAToGL.GLStencilOp[(int) stencilZFail],
+							XNAToGL.GLStencilOp[(int) stencilPass]
+						);
+					}
+				}
+			}
+		}
+
+		public void ApplyRasterizerState(
+			RasterizerState rasterizerState,
+			bool renderTargetBound
+		) {
+			if (rasterizerState.ScissorTestEnable != scissorTestEnable)
+			{
+				scissorTestEnable = rasterizerState.ScissorTestEnable;
+				ToggleGLState(GLenum.GL_SCISSOR_TEST, scissorTestEnable);
+			}
+
+			CullMode actualMode;
+			if (renderTargetBound)
+			{
+				actualMode = rasterizerState.CullMode;
+			}
+			else
+			{
+				// When not rendering offscreen the faces change order.
+				if (rasterizerState.CullMode == CullMode.None)
+				{
+					actualMode = rasterizerState.CullMode;
+				}
+				else
+				{
+					actualMode = (
+						rasterizerState.CullMode == CullMode.CullClockwiseFace ?
+							CullMode.CullCounterClockwiseFace :
+							CullMode.CullClockwiseFace
+					);
+				}
+			}
+			if (actualMode != cullFrontFace)
+			{
+				if ((actualMode == CullMode.None) != (cullFrontFace == CullMode.None))
+				{
+					ToggleGLState(GLenum.GL_CULL_FACE, actualMode != CullMode.None);
+				}
+				cullFrontFace = actualMode;
+				if (cullFrontFace != CullMode.None)
+				{
+					glFrontFace(XNAToGL.FrontFace[(int) cullFrontFace]);
+				}
+			}
+
+			if (rasterizerState.FillMode != fillMode)
+			{
+				fillMode = rasterizerState.FillMode;
+				glPolygonMode(
+					GLenum.GL_FRONT_AND_BACK,
+					XNAToGL.GLFillMode[(int) fillMode]
+				);
+			}
+
+			// FIXME: Floating point equality comparisons used for speed -flibit
+			float realDepthBias = rasterizerState.DepthBias * XNAToGL.DepthBiasScale[
+				renderTargetBound ?
+					(int) currentDepthStencilFormat :
+					(int) Backbuffer.DepthFormat
+			];
+			if (	realDepthBias != depthBias ||
+				rasterizerState.SlopeScaleDepthBias != slopeScaleDepthBias	)
+			{
+				if (	realDepthBias == 0.0f &&
+					rasterizerState.SlopeScaleDepthBias == 0.0f)
+				{
+					// We're changing to disabled bias, disable!
+					glDisable(GLenum.GL_POLYGON_OFFSET_FILL);
+				}
+				else
+				{
+					if (depthBias == 0.0f && slopeScaleDepthBias == 0.0f)
+					{
+						// We're changing away from disabled bias, enable!
+						glEnable(GLenum.GL_POLYGON_OFFSET_FILL);
+					}
+					glPolygonOffset(
+						rasterizerState.SlopeScaleDepthBias,
+						realDepthBias
+					);
+				}
+				depthBias = realDepthBias;
+				slopeScaleDepthBias = rasterizerState.SlopeScaleDepthBias;
+			}
+
+			/* If you're reading this, you have a user with broken MSAA!
+			 * Here's the deal: On all modern drivers this should work,
+			 * but there was a period of time where, for some reason,
+			 * IHVs all took a nap and decided that they didn't have to
+			 * respect GL_MULTISAMPLE toggles. A couple sources:
+			 *
+			 * https://developer.apple.com/library/content/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_fsaa/opengl_fsaa.html
+			 *
+			 * https://www.opengl.org/discussion_boards/showthread.php/172025-glDisable(GL_MULTISAMPLE)-has-no-effect
+			 *
+			 * So yeah. Have em update their driver. If they're on Intel,
+			 * tell them to install Linux. Yes, really.
+			 * -flibit
+			 */
+			if (rasterizerState.MultiSampleAntiAlias != multiSampleEnable)
+			{
+				multiSampleEnable = rasterizerState.MultiSampleAntiAlias;
+				ToggleGLState(GLenum.GL_MULTISAMPLE, multiSampleEnable);
+			}
+		}
+
+		public void VerifySampler(int index, Texture texture, SamplerState sampler)
+		{
+			if (texture == null)
+			{
+				if (Textures[index] != OpenGLTexture.NullTexture)
+				{
+					if (index != 0)
+					{
+						glActiveTexture(GLenum.GL_TEXTURE0 + index);
+					}
+					glBindTexture(Textures[index].Target, 0);
+					if (index != 0)
+					{
+						// Keep this state sane. -flibit
+						glActiveTexture(GLenum.GL_TEXTURE0);
+					}
+					Textures[index] = OpenGLTexture.NullTexture;
+				}
+				return;
+			}
+
+			OpenGLTexture tex = texture.texture as OpenGLTexture;
+
+			if (	tex == Textures[index] &&
+				sampler.AddressU == tex.WrapS &&
+				sampler.AddressV == tex.WrapT &&
+				sampler.AddressW == tex.WrapR &&
+				sampler.Filter == tex.Filter &&
+				sampler.MaxAnisotropy == tex.Anistropy &&
+				sampler.MaxMipLevel == tex.MaxMipmapLevel &&
+				sampler.MipMapLevelOfDetailBias == tex.LODBias	)
+			{
+				// Nothing's changing, forget it.
+				return;
+			}
+
+			// Set the active texture slot
+			if (index != 0)
+			{
+				glActiveTexture(GLenum.GL_TEXTURE0 + index);
+			}
+
+			// Bind the correct texture
+			if (tex != Textures[index])
+			{
+				if (tex.Target != Textures[index].Target)
+				{
+					// If we're changing targets, unbind the old texture first!
+					glBindTexture(Textures[index].Target, 0);
+				}
+				glBindTexture(tex.Target, tex.Handle);
+				Textures[index] = tex;
+			}
+
+			// Apply the sampler states to the GL texture
+			if (sampler.AddressU != tex.WrapS)
+			{
+				tex.WrapS = sampler.AddressU;
+				glTexParameteri(
+					tex.Target,
+					GLenum.GL_TEXTURE_WRAP_S,
+					XNAToGL.Wrap[(int) tex.WrapS]
+				);
+			}
+			if (sampler.AddressV != tex.WrapT)
+			{
+				tex.WrapT = sampler.AddressV;
+				glTexParameteri(
+					tex.Target,
+					GLenum.GL_TEXTURE_WRAP_T,
+					XNAToGL.Wrap[(int) tex.WrapT]
+				);
+			}
+			if (sampler.AddressW != tex.WrapR)
+			{
+				tex.WrapR = sampler.AddressW;
+				glTexParameteri(
+					tex.Target,
+					GLenum.GL_TEXTURE_WRAP_R,
+					XNAToGL.Wrap[(int) tex.WrapR]
+				);
+			}
+			if (	sampler.Filter != tex.Filter ||
+				sampler.MaxAnisotropy != tex.Anistropy	)
+			{
+				tex.Filter = sampler.Filter;
+				tex.Anistropy = sampler.MaxAnisotropy;
+				glTexParameteri(
+					tex.Target,
+					GLenum.GL_TEXTURE_MAG_FILTER,
+					XNAToGL.MagFilter[(int) tex.Filter]
+				);
+				glTexParameteri(
+					tex.Target,
+					GLenum.GL_TEXTURE_MIN_FILTER,
+					tex.HasMipmaps ?
+						XNAToGL.MinMipFilter[(int) tex.Filter] :
+						XNAToGL.MinFilter[(int) tex.Filter]
+				);
+				glTexParameterf(
+					tex.Target,
+					GLenum.GL_TEXTURE_MAX_ANISOTROPY_EXT,
+					(tex.Filter == TextureFilter.Anisotropic) ?
+						Math.Max(tex.Anistropy, 1.0f) :
+						1.0f
+				);
+			}
+			if (sampler.MaxMipLevel != tex.MaxMipmapLevel)
+			{
+				tex.MaxMipmapLevel = sampler.MaxMipLevel;
+				glTexParameteri(
+					tex.Target,
+					GLenum.GL_TEXTURE_BASE_LEVEL,
+					tex.MaxMipmapLevel
+				);
+			}
+			if (sampler.MipMapLevelOfDetailBias != tex.LODBias && !useES3)
+			{
+				tex.LODBias = sampler.MipMapLevelOfDetailBias;
+				glTexParameterf(
+					tex.Target,
+					GLenum.GL_TEXTURE_LOD_BIAS,
+					tex.LODBias
+				);
+			}
+
+			if (index != 0)
+			{
+				// Keep this state sane. -flibit
+				glActiveTexture(GLenum.GL_TEXTURE0);
+			}
+		}
+
+		#endregion
+
+		#region Effect Methods
+
+		public IGLEffect CreateEffect(byte[] effectCode)
+		{
+			IntPtr effect = IntPtr.Zero;
+			IntPtr glEffect = IntPtr.Zero;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			effect = MojoShader.MOJOSHADER_parseEffect(
+				shaderProfile,
+				effectCode,
+				(uint) effectCode.Length,
+				null,
+				0,
+				null,
+				0,
+				null,
+				null,
+				IntPtr.Zero
+			);
+
+#if DEBUG
+			unsafe
+			{
+				MojoShader.MOJOSHADER_effect *effectPtr = (MojoShader.MOJOSHADER_effect*) effect;
+				MojoShader.MOJOSHADER_error* err = (MojoShader.MOJOSHADER_error*) effectPtr->errors;
+				for (int i = 0; i < effectPtr->error_count; i += 1)
+				{
+					// From the SDL2# LPToUtf8StringMarshaler
+					byte* endPtr = (byte*) err[i].error;
+					while (*endPtr != 0)
+					{
+						endPtr++;
+					}
+					byte[] bytes = new byte[endPtr - (byte*) err[i].error];
+					Marshal.Copy(err[i].error, bytes, 0, bytes.Length);
+
+					FNALoggerEXT.LogError(
+						"MOJOSHADER_parseEffect Error: " +
+						System.Text.Encoding.UTF8.GetString(bytes)
+					);
+				}
+			}
+#endif
+
+			glEffect = MojoShader.MOJOSHADER_glCompileEffect(effect);
+			if (glEffect == IntPtr.Zero)
+			{
+				throw new InvalidOperationException(
+					MojoShader.MOJOSHADER_glGetError()
+				);
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return new OpenGLEffect(effect, glEffect);
+		}
+
+		private void DeleteEffect(IGLEffect effect)
+		{
+			var asShader = effect as Shader;
+			if (asShader != null)
+			{
+				DeleteShader(asShader);
+			}
+			else
+			{
+				// Ordinary effect
+				IntPtr glEffectData = (effect as OpenGLEffect).GLEffectData;
+				if (glEffectData == currentEffect)
+				{
+					MojoShader.MOJOSHADER_glEffectEndPass(currentEffect);
+					MojoShader.MOJOSHADER_glEffectEnd(currentEffect);
+					currentEffect = IntPtr.Zero;
+					currentTechnique = IntPtr.Zero;
+					currentPass = 0;
+				}
+				MojoShader.MOJOSHADER_glDeleteEffect(glEffectData);
+				MojoShader.MOJOSHADER_freeEffect(effect.EffectData);
+			}
+		}
+
+		public IGLEffect CloneEffect(IGLEffect cloneSource)
+		{
+			IntPtr effect = IntPtr.Zero;
+			IntPtr glEffect = IntPtr.Zero;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			effect = MojoShader.MOJOSHADER_cloneEffect(cloneSource.EffectData);
+			glEffect = MojoShader.MOJOSHADER_glCompileEffect(effect);
+			if (glEffect == IntPtr.Zero)
+			{
+				throw new InvalidOperationException(
+					MojoShader.MOJOSHADER_glGetError()
+				);
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return new OpenGLEffect(effect, glEffect);
+		}
+
+		public void ApplyEffect(
+			IGLEffect effect,
+			IntPtr technique,
+			uint pass,
+			IntPtr stateChanges
+		) {
+			if (currentShader != null)
+			{
+				glUseProgram(0);
+				currentShader = null;
+			}
+
+			effectApplied = true;
+			IntPtr glEffectData = (effect as OpenGLEffect).GLEffectData;
+			if (glEffectData == currentEffect)
+			{
+				if (technique == currentTechnique && pass == currentPass)
+				{
+					MojoShader.MOJOSHADER_glEffectCommitChanges(currentEffect);
+					return;
+				}
+				MojoShader.MOJOSHADER_glEffectEndPass(currentEffect);
+				MojoShader.MOJOSHADER_glEffectBeginPass(currentEffect, pass);
+				currentTechnique = technique;
+				currentPass = pass;
+				return;
+			}
+			else if (currentEffect != IntPtr.Zero)
+			{
+				MojoShader.MOJOSHADER_glEffectEndPass(currentEffect);
+				MojoShader.MOJOSHADER_glEffectEnd(currentEffect);
+			}
+			uint whatever;
+			MojoShader.MOJOSHADER_glEffectBegin(
+				glEffectData,
+				out whatever,
+				0,
+				stateChanges
+			);
+			MojoShader.MOJOSHADER_glEffectBeginPass(
+				glEffectData,
+				pass
+			);
+			currentEffect = glEffectData;
+			currentTechnique = technique;
+			currentPass = pass;
+		}
+
+		public void BeginPassRestore(IGLEffect effect, IntPtr stateChanges)
+		{
+			IntPtr glEffectData = (effect as OpenGLEffect).GLEffectData;
+			uint whatever;
+			MojoShader.MOJOSHADER_glEffectBegin(
+				glEffectData,
+				out whatever,
+				1,
+				stateChanges
+			);
+			MojoShader.MOJOSHADER_glEffectBeginPass(
+				glEffectData,
+				0
+			);
+			effectApplied = true;
+		}
+
+		public void EndPassRestore(IGLEffect effect)
+		{
+			IntPtr glEffectData = (effect as OpenGLEffect).GLEffectData;
+			MojoShader.MOJOSHADER_glEffectEndPass(glEffectData);
+			MojoShader.MOJOSHADER_glEffectEnd(glEffectData);
+			effectApplied = true;
+		}
+
+		public void ApplyShader(Shader shader)
+		{
+			if (currentEffect != IntPtr.Zero)
+			{
+				MojoShader.MOJOSHADER_glEffectEndPass(currentEffect);
+				MojoShader.MOJOSHADER_glEffectEnd(currentEffect);
+				currentEffect = IntPtr.Zero;
+				currentTechnique = IntPtr.Zero;
+				currentPass = 0;
+			}
+
+			currentShader = shader;
+//			glUseProgram(shader.ProgramHandle);
+			shaderApplied = true;
+		}
+
+		#endregion
+
+		#region glVertexAttribPointer/glVertexAttribDivisor Methods
+
+		public void ApplyVertexAttributes(
+			VertexBufferBinding[] bindings,
+			int numBindings,
+			bool bindingsUpdated,
+			int baseVertex
+		) {
+			var isShader = currentShader != null;
+
+			if (supportsBaseVertex)
+			{
+				baseVertex = 0;
+			}
+
+			if (bindingsUpdated ||
+				baseVertex != ldBaseVertex ||
+				currentEffect != ldEffect ||
+				currentTechnique != ldTechnique ||
+				currentPass != ldPass ||
+				effectApplied ||
+				currentShader != ldShader ||
+				shaderApplied)
+			{
+				/* There's this weird case where you can have multiple vertbuffers,
+				 * but they will have overlapping attributes. It seems like the
+				 * first buffer gets priority, so start with the last one so the
+				 * first buffer's attributes are what's bound at the end.
+				 * -flibit
+				 */
+				for (int i = numBindings - 1; i >= 0; i -= 1)
+				{
+					BindVertexBuffer(bindings[i].VertexBuffer.buffer);
+					VertexDeclaration vertexDeclaration = bindings[i].VertexBuffer.VertexDeclaration;
+					IntPtr basePtr = (IntPtr) (
+						vertexDeclaration.VertexStride *
+						(bindings[i].VertexOffset + baseVertex)
+					);
+					foreach (VertexElement element in vertexDeclaration.elements)
+					{
+						int attribLoc = -1;
+						if (!isShader)
+						{
+							attribLoc = MojoShader.MOJOSHADER_glGetVertexAttribLocation(
+								XNAToGL.VertexAttribUsage[(int)element.VertexElementUsage],
+								element.UsageIndex
+							);
+							if (attribLoc == -1)
+							{
+								// Stream not in use!
+								continue;
+							}
+						} else
+						{
+							if (!currentShader.AttributesLocations.TryGetValue(element.VertexElementUsage, out attribLoc))
+							{
+								// Stream not in use!
+								continue;
+							}
+						}
+						attributeEnabled[attribLoc] = true;
+						VertexAttribute attr = attributes[attribLoc];
+						uint buffer = (bindings[i].VertexBuffer.buffer as OpenGLBuffer).Handle;
+						IntPtr ptr = basePtr + element.Offset;
+						VertexElementFormat format = element.VertexElementFormat;
+						bool normalized = XNAToGL.VertexAttribNormalized(element);
+						if (	attr.CurrentBuffer != buffer ||
+							attr.CurrentPointer != ptr ||
+							attr.CurrentFormat != element.VertexElementFormat ||
+							attr.CurrentNormalized != normalized ||
+							attr.CurrentStride != vertexDeclaration.VertexStride	)
+						{
+							glVertexAttribPointer(
+								attribLoc,
+								XNAToGL.VertexAttribSize[(int) format],
+								XNAToGL.VertexAttribType[(int) format],
+								normalized,
+								vertexDeclaration.VertexStride,
+								ptr
+							);
+							attr.CurrentBuffer = buffer;
+							attr.CurrentPointer = ptr;
+							attr.CurrentFormat = format;
+							attr.CurrentNormalized = normalized;
+							attr.CurrentStride = vertexDeclaration.VertexStride;
+						}
+						if (SupportsHardwareInstancing)
+						{
+							attributeDivisor[attribLoc] = bindings[i].InstanceFrequency;
+						}
+					}
+				}
+				FlushGLVertexAttributes();
+
+				ldBaseVertex = baseVertex;
+				ldEffect = currentEffect;
+				ldTechnique = currentTechnique;
+				ldPass = currentPass;
+				effectApplied = false;
+				ldVertexDeclaration = null;
+				ldPointer = IntPtr.Zero;
+				ldShader = currentShader;
+				shaderApplied = false;
+			}
+
+			if (!isShader)
+			{
+				MojoShader.MOJOSHADER_glProgramReady();
+				MojoShader.MOJOSHADER_glProgramViewportFlip(flipViewport);
+			}
+		}
+
+		public void ApplyVertexAttributes(
+			VertexDeclaration vertexDeclaration,
+			IntPtr ptr,
+			int vertexOffset
+		) {
+			var isShader = currentShader != null;
+
+			BindVertexBuffer(OpenGLBuffer.NullBuffer);
+			IntPtr basePtr = ptr + (vertexDeclaration.VertexStride * vertexOffset);
+
+			if (vertexDeclaration != ldVertexDeclaration ||
+				basePtr != ldPointer ||
+				currentEffect != ldEffect ||
+				currentTechnique != ldTechnique ||
+				currentPass != ldPass ||
+				effectApplied ||
+				currentShader != ldShader ||
+				shaderApplied)
+			{
+				foreach (VertexElement element in vertexDeclaration.elements)
+				{
+					int attribLoc = -1;
+					if (!isShader)
+					{
+						attribLoc = MojoShader.MOJOSHADER_glGetVertexAttribLocation(
+							XNAToGL.VertexAttribUsage[(int)element.VertexElementUsage],
+							element.UsageIndex
+						);
+						if (attribLoc == -1)
+						{
+							// Stream not in use!
+							continue;
+						}
+					}
+					else
+					{
+						if (!currentShader.AttributesLocations.TryGetValue(element.VertexElementUsage, out attribLoc))
+						{
+							// Stream not in use!
+							continue;
+						}
+					}
+					attributeEnabled[attribLoc] = true;
+					VertexAttribute attr = attributes[attribLoc];
+					IntPtr finalPtr = basePtr + element.Offset;
+					bool normalized = XNAToGL.VertexAttribNormalized(element);
+					if (	attr.CurrentBuffer != 0 ||
+						attr.CurrentPointer != finalPtr ||
+						attr.CurrentFormat != element.VertexElementFormat ||
+						attr.CurrentNormalized != normalized ||
+						attr.CurrentStride != vertexDeclaration.VertexStride	)
+					{
+						glVertexAttribPointer(
+							attribLoc,
+							XNAToGL.VertexAttribSize[(int) element.VertexElementFormat],
+							XNAToGL.VertexAttribType[(int) element.VertexElementFormat],
+							normalized,
+							vertexDeclaration.VertexStride,
+							finalPtr
+						);
+						attr.CurrentBuffer = 0;
+						attr.CurrentPointer = finalPtr;
+						attr.CurrentFormat = element.VertexElementFormat;
+						attr.CurrentNormalized = normalized;
+						attr.CurrentStride = vertexDeclaration.VertexStride;
+					}
+					attributeDivisor[attribLoc] = 0;
+				}
+				FlushGLVertexAttributes();
+
+				ldVertexDeclaration = vertexDeclaration;
+				ldPointer = ptr;
+				ldEffect = currentEffect;
+				ldTechnique = currentTechnique;
+				ldPass = currentPass;
+				effectApplied = false;
+				ldBaseVertex = -1;
+				ldShader = currentShader;
+				shaderApplied = false;
+			}
+
+			if (!isShader)
+			{
+				MojoShader.MOJOSHADER_glProgramReady();
+				MojoShader.MOJOSHADER_glProgramViewportFlip(flipViewport);
+			}
+		}
+
+		private void FlushGLVertexAttributes()
+		{
+			for (int i = 0; i < attributes.Length; i += 1)
+			{
+				if (attributeEnabled[i])
+				{
+					attributeEnabled[i] = false;
+					if (!previousAttributeEnabled[i])
+					{
+						glEnableVertexAttribArray(i);
+						previousAttributeEnabled[i] = true;
+					}
+				}
+				else if (previousAttributeEnabled[i])
+				{
+					glDisableVertexAttribArray(i);
+					previousAttributeEnabled[i] = false;
+				}
+
+				int divisor = attributeDivisor[i];
+				if (divisor != previousAttributeDivisor[i])
+				{
+					glVertexAttribDivisor(i, divisor);
+					previousAttributeDivisor[i] = divisor;
+				}
+			}
+		}
+
+		#endregion
+
+		#region glGenBuffers Methods
+
+		public IGLBuffer GenVertexBuffer(
+			bool dynamic,
+			int vertexCount,
+			int vertexStride
+		) {
+			OpenGLBuffer result = null;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			uint handle;
+			glGenBuffers(1, out handle);
+
+			result = new OpenGLBuffer(
+				handle,
+				(IntPtr) (vertexStride * vertexCount),
+				dynamic ? GLenum.GL_STREAM_DRAW : GLenum.GL_STATIC_DRAW
+			);
+
+			BindVertexBuffer(result);
+			glBufferData(
+				GLenum.GL_ARRAY_BUFFER,
+				result.BufferSize,
+				IntPtr.Zero,
+				result.Dynamic
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return result;
+		}
+
+		public IGLBuffer GenIndexBuffer(
+			bool dynamic,
+			int indexCount,
+			IndexElementSize indexElementSize
+		) {
+			OpenGLBuffer result = null;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			uint handle;
+			glGenBuffers(1, out handle);
+
+			result = new OpenGLBuffer(
+				handle,
+				(IntPtr) (indexCount * XNAToGL.IndexSize[(int) indexElementSize]),
+				dynamic ? GLenum.GL_STREAM_DRAW : GLenum.GL_STATIC_DRAW
+			);
+
+			BindIndexBuffer(result);
+			glBufferData(
+				GLenum.GL_ELEMENT_ARRAY_BUFFER,
+				result.BufferSize,
+				IntPtr.Zero,
+				result.Dynamic
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return result;
+		}
+
+		#endregion
+
+		#region glBindBuffer Methods
+
+		private void BindVertexBuffer(IGLBuffer buffer)
+		{
+			uint handle = (buffer as OpenGLBuffer).Handle;
+			if (handle != currentVertexBuffer)
+			{
+				glBindBuffer(GLenum.GL_ARRAY_BUFFER, handle);
+				currentVertexBuffer = handle;
+			}
+		}
+
+		private void BindIndexBuffer(IGLBuffer buffer)
+		{
+			uint handle = (buffer as OpenGLBuffer).Handle;
+			if (handle != currentIndexBuffer)
+			{
+				glBindBuffer(GLenum.GL_ELEMENT_ARRAY_BUFFER, handle);
+				currentIndexBuffer = handle;
+			}
+		}
+
+		#endregion
+
+		#region glSetBufferData Methods
+
+		public void SetVertexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int dataLength,
+			SetDataOptions options
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			BindVertexBuffer(buffer);
+
+			if (options == SetDataOptions.Discard)
+			{
+				glBufferData(
+					GLenum.GL_ARRAY_BUFFER,
+					buffer.BufferSize,
+					IntPtr.Zero,
+					(buffer as OpenGLBuffer).Dynamic
+				);
+			}
+
+			glBufferSubData(
+				GLenum.GL_ARRAY_BUFFER,
+				(IntPtr) offsetInBytes,
+				(IntPtr) dataLength,
+				data
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		public void SetIndexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int dataLength,
+			SetDataOptions options
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			BindIndexBuffer(buffer);
+
+			if (options == SetDataOptions.Discard)
+			{
+				glBufferData(
+					GLenum.GL_ELEMENT_ARRAY_BUFFER,
+					buffer.BufferSize,
+					IntPtr.Zero,
+					(buffer as OpenGLBuffer).Dynamic
+				);
+			}
+
+			glBufferSubData(
+				GLenum.GL_ELEMENT_ARRAY_BUFFER,
+				(IntPtr) offsetInBytes,
+				(IntPtr) dataLength,
+				data
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		#endregion
+
+		#region glGetBufferData Methods
+
+		public void GetVertexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes,
+			int vertexStride
+		) {
+			IntPtr cpy;
+			bool useStagingBuffer = elementSizeInBytes < vertexStride;
+			if (useStagingBuffer)
+			{
+				cpy = Marshal.AllocHGlobal(elementCount * vertexStride);
+			}
+			else
+			{
+				cpy = data + (startIndex * elementSizeInBytes);
+			}
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			BindVertexBuffer(buffer);
+
+			glGetBufferSubData(
+				GLenum.GL_ARRAY_BUFFER,
+				(IntPtr) offsetInBytes,
+				(IntPtr) (elementCount * vertexStride),
+				cpy
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			if (useStagingBuffer)
+			{
+				IntPtr src = cpy;
+				IntPtr dst = data + (startIndex * elementSizeInBytes);
+				for (int i = 0; i < elementCount; i += 1)
+				{
+					memcpy(dst, src, (IntPtr) elementSizeInBytes);
+					dst += elementSizeInBytes;
+					src += vertexStride;
+				}
+				Marshal.FreeHGlobal(cpy);
+			}
+		}
+
+		public void GetIndexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			BindIndexBuffer(buffer);
+
+			glGetBufferSubData(
+				GLenum.GL_ELEMENT_ARRAY_BUFFER,
+				(IntPtr) offsetInBytes,
+				(IntPtr) (elementCount * elementSizeInBytes),
+				data + (startIndex * elementSizeInBytes)
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		#endregion
+
+		#region glDeleteBuffers Methods
+
+		private void DeleteVertexBuffer(IGLBuffer buffer)
+		{
+			uint handle = (buffer as OpenGLBuffer).Handle;
+			if (handle == currentVertexBuffer)
+			{
+				glBindBuffer(GLenum.GL_ARRAY_BUFFER, 0);
+				currentVertexBuffer = 0;
+			}
+			for (int i = 0; i < attributes.Length; i += 1)
+			{
+				if (handle == attributes[i].CurrentBuffer)
+				{
+					// Force the next vertex attrib update!
+					attributes[i].CurrentBuffer = uint.MaxValue;
+				}
+			}
+			glDeleteBuffers(1, ref handle);
+		}
+
+		private void DeleteIndexBuffer(IGLBuffer buffer)
+		{
+			uint handle = (buffer as OpenGLBuffer).Handle;
+			if (handle == currentIndexBuffer)
+			{
+				glBindBuffer(GLenum.GL_ELEMENT_ARRAY_BUFFER, 0);
+				currentIndexBuffer = 0;
+			}
+			glDeleteBuffers(1, ref handle);
+		}
+
+		#endregion
+
+		#region glCreateTexture Methods
+
+		private OpenGLTexture CreateTexture(
+			GLenum target,
+			int levelCount
+		) {
+			uint handle;
+			glGenTextures(1, out handle);
+			OpenGLTexture result = new OpenGLTexture(
+				handle,
+				target,
+				levelCount
+			);
+			BindTexture(result);
+			glTexParameteri(
+				result.Target,
+				GLenum.GL_TEXTURE_WRAP_S,
+				XNAToGL.Wrap[(int) result.WrapS]
+			);
+			glTexParameteri(
+				result.Target,
+				GLenum.GL_TEXTURE_WRAP_T,
+				XNAToGL.Wrap[(int) result.WrapT]
+			);
+			glTexParameteri(
+				result.Target,
+				GLenum.GL_TEXTURE_WRAP_R,
+				XNAToGL.Wrap[(int) result.WrapR]
+			);
+			glTexParameteri(
+				result.Target,
+				GLenum.GL_TEXTURE_MAG_FILTER,
+				XNAToGL.MagFilter[(int) result.Filter]
+			);
+			glTexParameteri(
+				result.Target,
+				GLenum.GL_TEXTURE_MIN_FILTER,
+				result.HasMipmaps ?
+					XNAToGL.MinMipFilter[(int) result.Filter] :
+					XNAToGL.MinFilter[(int) result.Filter]
+			);
+			glTexParameterf(
+				result.Target,
+				GLenum.GL_TEXTURE_MAX_ANISOTROPY_EXT,
+				(result.Filter == TextureFilter.Anisotropic) ? Math.Max(result.Anistropy, 1.0f) : 1.0f
+			);
+			glTexParameteri(
+				result.Target,
+				GLenum.GL_TEXTURE_BASE_LEVEL,
+				result.MaxMipmapLevel
+			);
+			if (!useES3)
+			{
+				glTexParameterf(
+					result.Target,
+					GLenum.GL_TEXTURE_LOD_BIAS,
+					result.LODBias
+				);
+			}
+			return result;
+		}
+
+		public IGLTexture CreateTexture2D(
+			SurfaceFormat format,
+			int width,
+			int height,
+			int levelCount
+		) {
+			OpenGLTexture result = null;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			result = CreateTexture(
+				GLenum.GL_TEXTURE_2D,
+				levelCount
+			);
+
+			GLenum glFormat = XNAToGL.TextureFormat[(int) format];
+			GLenum glInternalFormat = XNAToGL.TextureInternalFormat[(int) format];
+			if (glFormat == GLenum.GL_COMPRESSED_TEXTURE_FORMATS)
+			{
+				for (int i = 0; i < levelCount; i += 1)
+				{
+					int levelWidth = Math.Max(width >> i, 1);
+					int levelHeight = Math.Max(height >> i, 1);
+					glCompressedTexImage2D(
+						GLenum.GL_TEXTURE_2D,
+						i,
+						(int) glInternalFormat,
+						levelWidth,
+						levelHeight,
+						0,
+						((levelWidth + 3) / 4) * ((levelHeight + 3) / 4) * Texture.GetFormatSize(format),
+						IntPtr.Zero
+					);
+				}
+			}
+			else
+			{
+				GLenum glType = XNAToGL.TextureDataType[(int) format];
+				for (int i = 0; i < levelCount; i += 1)
+				{
+					glTexImage2D(
+						GLenum.GL_TEXTURE_2D,
+						i,
+						(int) glInternalFormat,
+						Math.Max(width >> i, 1),
+						Math.Max(height >> i, 1),
+						0,
+						glFormat,
+						glType,
+						IntPtr.Zero
+					);
+				}
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return result;
+		}
+
+		public IGLTexture CreateTexture3D(
+			SurfaceFormat format,
+			int width,
+			int height,
+			int depth,
+			int levelCount
+		) {
+			OpenGLTexture result = null;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			result = CreateTexture(
+				GLenum.GL_TEXTURE_3D,
+				levelCount
+			);
+
+			GLenum glFormat = XNAToGL.TextureFormat[(int) format];
+			GLenum glInternalFormat = XNAToGL.TextureInternalFormat[(int) format];
+			GLenum glType = XNAToGL.TextureDataType[(int) format];
+			for (int i = 0; i < levelCount; i += 1)
+			{
+				glTexImage3D(
+					GLenum.GL_TEXTURE_3D,
+					i,
+					(int) glInternalFormat,
+					Math.Max(width >> i, 1),
+					Math.Max(height >> i, 1),
+					Math.Max(depth >> i, 1),
+					0,
+					glFormat,
+					glType,
+					IntPtr.Zero
+				);
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return result;
+		}
+
+		public IGLTexture CreateTextureCube(
+			SurfaceFormat format,
+			int size,
+			int levelCount
+		) {
+			OpenGLTexture result = null;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			result = CreateTexture(
+				GLenum.GL_TEXTURE_CUBE_MAP,
+				levelCount
+			);
+
+			GLenum glFormat = XNAToGL.TextureFormat[(int) format];
+			GLenum glInternalFormat = XNAToGL.TextureInternalFormat[(int) format];
+			if (glFormat == GLenum.GL_COMPRESSED_TEXTURE_FORMATS)
+			{
+				for (int i = 0; i < 6; i += 1)
+				{
+					for (int l = 0; l < levelCount; l += 1)
+					{
+						int levelSize = Math.Max(size >> l, 1);
+						glCompressedTexImage2D(
+							GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + i,
+							l,
+							(int) glInternalFormat,
+							levelSize,
+							levelSize,
+							0,
+							((levelSize + 3) / 4) * ((levelSize + 3) / 4) * Texture.GetFormatSize(format),
+							IntPtr.Zero
+						);
+					}
+				}
+			}
+			else
+			{
+				GLenum glType = XNAToGL.TextureDataType[(int) format];
+				for (int i = 0; i < 6; i += 1)
+				{
+					for (int l = 0; l < levelCount; l += 1)
+					{
+						int levelSize = Math.Max(size >> l, 1);
+						glTexImage2D(
+							GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + i,
+							l,
+							(int) glInternalFormat,
+							levelSize,
+							levelSize,
+							0,
+							glFormat,
+							glType,
+							IntPtr.Zero
+						);
+					}
+				}
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return result;
+		}
+
+		#endregion
+
+		#region glTexSubImage Methods
+
+		public void SetTextureData2D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int x,
+			int y,
+			int w,
+			int h,
+			int level,
+			IntPtr data,
+			int dataLength
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+			BindTexture(texture);
+
+			GLenum glFormat = XNAToGL.TextureFormat[(int) format];
+			if (glFormat == GLenum.GL_COMPRESSED_TEXTURE_FORMATS)
+			{
+				/* Note that we're using glInternalFormat, not glFormat.
+				 * In this case, they should actually be the same thing,
+				 * but we use glFormat somewhat differently for
+				 * compressed textures.
+				 * -flibit
+				 */
+				glCompressedTexSubImage2D(
+					GLenum.GL_TEXTURE_2D,
+					level,
+					x,
+					y,
+					w,
+					h,
+					XNAToGL.TextureInternalFormat[(int) format],
+					dataLength,
+					data
+				);
+			}
+			else
+			{
+				// Set pixel alignment to match texel size in bytes
+				int packSize = Texture.GetFormatSize(format);
+				if (packSize != 4)
+				{
+					glPixelStorei(
+						GLenum.GL_UNPACK_ALIGNMENT,
+						packSize
+					);
+				}
+
+				glTexSubImage2D(
+					GLenum.GL_TEXTURE_2D,
+					level,
+					x,
+					y,
+					w,
+					h,
+					glFormat,
+					XNAToGL.TextureDataType[(int) format],
+					data
+				);
+
+				// Keep this state sane -flibit
+				if (packSize != 4)
+				{
+					glPixelStorei(
+						GLenum.GL_UNPACK_ALIGNMENT,
+						4
+					);
+				}
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		public void SetTextureData3D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int level,
+			int left,
+			int top,
+			int right,
+			int bottom,
+			int front,
+			int back,
+			IntPtr data,
+			int dataLength
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+			BindTexture(texture);
+
+			glTexSubImage3D(
+				GLenum.GL_TEXTURE_3D,
+				level,
+				left,
+				top,
+				front,
+				right - left,
+				bottom - top,
+				back - front,
+				XNAToGL.TextureFormat[(int) format],
+				XNAToGL.TextureDataType[(int) format],
+				data
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		public void SetTextureDataCube(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int xOffset,
+			int yOffset,
+			int width,
+			int height,
+			CubeMapFace cubeMapFace,
+			int level,
+			IntPtr data,
+			int dataLength
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+			BindTexture(texture);
+
+			GLenum glFormat = XNAToGL.TextureFormat[(int) format];
+			if (glFormat == GLenum.GL_COMPRESSED_TEXTURE_FORMATS)
+			{
+				/* Note that we're using glInternalFormat, not glFormat.
+				 * In this case, they should actually be the same thing,
+				 * but we use glFormat somewhat differently for
+				 * compressed textures.
+				 * -flibit
+				 */
+				glCompressedTexSubImage2D(
+					GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + (int) cubeMapFace,
+					level,
+					xOffset,
+					yOffset,
+					width,
+					height,
+					XNAToGL.TextureInternalFormat[(int) format],
+					dataLength,
+					data
+				);
+			}
+			else
+			{
+				glTexSubImage2D(
+					GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + (int) cubeMapFace,
+					level,
+					xOffset,
+					yOffset,
+					width,
+					height,
+					glFormat,
+					XNAToGL.TextureDataType[(int) format],
+					data
+				);
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		public void SetTextureData2DPointer(
+			Texture2D texture,
+			IntPtr ptr
+		) {
+			BindTexture(texture.texture);
+			// Set pixel alignment to match texel size in bytes
+			int packSize = Texture.GetFormatSize(texture.Format);
+			if (packSize != 4)
+			{
+				glPixelStorei(
+					GLenum.GL_UNPACK_ALIGNMENT,
+					packSize
+				);
+			}
+			glTexSubImage2D(
+				GLenum.GL_TEXTURE_2D,
+				0,
+				0,
+				0,
+				texture.Width,
+				texture.Height,
+				XNAToGL.TextureFormat[(int) texture.Format],
+				XNAToGL.TextureDataType[(int) texture.Format],
+				ptr
+			);
+			// Keep this state sane -flibit
+			if (packSize != 4)
+			{
+				glPixelStorei(GLenum.GL_UNPACK_ALIGNMENT, 4);
+			}
+		}
+
+		#endregion
+
+		#region glGetTexImage Methods
+
+		public void GetTextureData2D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int width,
+			int height,
+			int level,
+			int subX,
+			int subY,
+			int subW,
+			int subH,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			if (level == 0 && ReadTargetIfApplicable(
+				texture,
+				width,
+				height,
+				level,
+				data,
+				subX,
+				subY,
+				subW,
+				subH
+			)) {
+				return;
+			}
+
+			BindTexture(texture);
+			GLenum glFormat = XNAToGL.TextureFormat[(int) format];
+			if (glFormat == GLenum.GL_COMPRESSED_TEXTURE_FORMATS)
+			{
+				throw new NotImplementedException("GetData, CompressedTexture");
+			}
+			else if (subX == 0 && subY == 0 && subW == width && subH == height)
+			{
+				// Just throw the whole texture into the user array.
+				glGetTexImage(
+					GLenum.GL_TEXTURE_2D,
+					level,
+					glFormat,
+					XNAToGL.TextureDataType[(int) format],
+					data
+				);
+			}
+			else
+			{
+				// Get the whole texture...
+				IntPtr texData = Marshal.AllocHGlobal(width * height * elementSizeInBytes);
+				glGetTexImage(
+					GLenum.GL_TEXTURE_2D,
+					level,
+					glFormat,
+					XNAToGL.TextureDataType[(int) format],
+					texData
+				);
+
+				// Now, blit the rect region into the user array.
+				int curPixel = -1;
+				for (int row = subY; row < subY + subH; row += 1)
+				{
+					for (int col = subX; col < subX + subW; col += 1)
+					{
+						curPixel += 1;
+						if (curPixel < startIndex)
+						{
+							// If we're not at the start yet, just keep going...
+							continue;
+						}
+						if (curPixel > elementCount)
+						{
+							// If we're past the end, we're done!
+							return;
+						}
+						// FIXME: Can we copy via pitch instead, or something? -flibit
+						memcpy(
+							data + ((curPixel - startIndex) * elementSizeInBytes),
+							texData + (((row * width) + col) * elementSizeInBytes),
+							(IntPtr) elementSizeInBytes
+						);
+					}
+				}
+				Marshal.FreeHGlobal(texData);
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		public void GetTextureData3D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int left,
+			int top,
+			int front,
+			int right,
+			int bottom,
+			int back,
+			int level,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+			throw new NotImplementedException();
+		}
+
+		public void GetTextureDataCube(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int size,
+			CubeMapFace cubeMapFace,
+			int level,
+			int subX,
+			int subY,
+			int subW,
+			int subH,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			BindTexture(texture);
+			GLenum glFormat = XNAToGL.TextureFormat[(int) format];
+			if (glFormat == GLenum.GL_COMPRESSED_TEXTURE_FORMATS)
+			{
+				throw new NotImplementedException("GetData, CompressedTexture");
+			}
+			else if (subX == 0 && subY == 0 && subW == size && subH == size)
+			{
+				// Just throw the whole texture into the user array.
+				glGetTexImage(
+					GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + (int) cubeMapFace,
+					level,
+					glFormat,
+					XNAToGL.TextureDataType[(int) format],
+					data
+				);
+			}
+			else
+			{
+				// Get the whole texture...
+				IntPtr texData = Marshal.AllocHGlobal(size * size * elementSizeInBytes);
+				glGetTexImage(
+					GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + (int) cubeMapFace,
+					level,
+					glFormat,
+					XNAToGL.TextureDataType[(int) format],
+					texData
+				);
+
+				// Now, blit the rect region into the user array.
+				int curPixel = -1;
+				for (int row = subY; row < subY + subH; row += 1)
+				{
+					for (int col = subX; col < subX + subW; col += 1)
+					{
+						curPixel += 1;
+						if (curPixel < startIndex)
+						{
+							// If we're not at the start yet, just keep going...
+							continue;
+						}
+						if (curPixel > elementCount)
+						{
+							// If we're past the end, we're done!
+							return;
+						}
+						// FIXME: Can we copy via pitch instead, or something? -flibit
+						memcpy(
+							data + ((curPixel - startIndex) * elementSizeInBytes),
+							texData + (((row * size) + col) * elementSizeInBytes),
+							(IntPtr) elementSizeInBytes
+						);
+					}
+				}
+				Marshal.FreeHGlobal(texData);
+			}
+
+#if !DISABLE_THREADING
+			});
+#endif
+		}
+
+		#endregion
+
+		#region glBindTexture Method
+
+		private void BindTexture(IGLTexture texture)
+		{
+			OpenGLTexture tex = texture as OpenGLTexture;
+			if (tex.Target != Textures[0].Target)
+			{
+				glBindTexture(Textures[0].Target, 0);
+			}
+			if (tex != Textures[0])
+			{
+				glBindTexture(
+					tex.Target,
+					tex.Handle
+				);
+			}
+			Textures[0] = tex;
+		}
+
+		#endregion
+
+		#region glDeleteTexture Method
+
+		private void DeleteTexture(IGLTexture texture)
+		{
+			uint handle = (texture as OpenGLTexture).Handle;
+			for (int i = 0; i < currentAttachments.Length; i += 1)
+			{
+				if (handle == currentAttachments[i])
+				{
+					// Force an attachment update, this no longer exists!
+					currentAttachments[i] = uint.MaxValue;
+				}
+			}
+			glDeleteTextures(1, ref handle);
+		}
+
+		#endregion
+
+		#region glReadPixels Methods
+
+		public void ReadBackbuffer(
+			IntPtr data,
+			int dataLen,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes,
+			int subX,
+			int subY,
+			int subW,
+			int subH
+		) {
+			/* FIXME: Right now we're expecting one of the following:
+			 * - byte[]
+			 * - int[]
+			 * - uint[]
+			 * - Color[]
+			 * Anything else will freak out because we're using
+			 * color backbuffers. Maybe check this out when adding
+			 * support for more backbuffer types!
+			 * -flibit
+			 */
+
+			if (startIndex > 0 || elementCount != (dataLen / elementSizeInBytes))
+			{
+				throw new NotImplementedException(
+					"ReadBackbuffer startIndex/elementCount"
+				);
+			}
+
+			uint prevReadBuffer = currentReadFramebuffer;
+
+			if (Backbuffer.MultiSampleCount > 0)
+			{
+				// We have to resolve the renderbuffer to a texture first.
+				uint prevDrawBuffer = currentDrawFramebuffer;
+
+				OpenGLBackbuffer glBack = Backbuffer as OpenGLBackbuffer;
+				if (glBack.Texture == 0)
+				{
+					glGenTextures(1, out glBack.Texture);
+					glBindTexture(GLenum.GL_TEXTURE_2D, glBack.Texture);
+					glTexImage2D(
+						GLenum.GL_TEXTURE_2D,
+						0,
+						(int) GLenum.GL_RGBA,
+						glBack.Width,
+						glBack.Height,
+						0,
+						GLenum.GL_RGBA,
+						GLenum.GL_UNSIGNED_BYTE,
+						IntPtr.Zero
+					);
+					glBindTexture(Textures[0].Target, Textures[0].Handle);
+				}
+				BindFramebuffer(resolveFramebufferDraw);
+				glFramebufferTexture2D(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_COLOR_ATTACHMENT0,
+					GLenum.GL_TEXTURE_2D,
+					glBack.Texture,
+					0
+				);
+				BindReadFramebuffer(glBack.Handle);
+				glBlitFramebuffer(
+					0, 0, glBack.Width, glBack.Height,
+					0, 0, glBack.Width, glBack.Height,
+					GLenum.GL_COLOR_BUFFER_BIT,
+					GLenum.GL_LINEAR
+				);
+				BindDrawFramebuffer(prevDrawBuffer);
+				BindReadFramebuffer(resolveFramebufferDraw);
+			}
+			else
+			{
+				BindReadFramebuffer(
+					(Backbuffer is OpenGLBackbuffer) ?
+						(Backbuffer as OpenGLBackbuffer).Handle :
+						0
+				);
+			}
+
+			glReadPixels(
+				subX,
+				subY,
+				subW,
+				subH,
+				GLenum.GL_RGBA,
+				GLenum.GL_UNSIGNED_BYTE,
+				data
+			);
+
+			BindReadFramebuffer(prevReadBuffer);
+
+			// Now we get to do a software-based flip! Yes, really! -flibit
+			int pitch = subW * 4;
+			IntPtr temp = Marshal.AllocHGlobal(pitch);
+			for (int row = 0; row < subH / 2; row += 1)
+			{
+				// Top to temp, bottom to top, temp to bottom
+				memcpy(temp, data + (row * pitch), (IntPtr) pitch);
+				memcpy(data + (row * pitch), data + ((subH - row - 1) * pitch), (IntPtr) pitch);
+				memcpy(data + ((subH - row - 1) * pitch), temp, (IntPtr) pitch);
+			}
+			Marshal.FreeHGlobal(temp);
+		}
+
+		/// <summary>
+		/// Attempts to read the texture data directly from the FBO using glReadPixels
+		/// </summary>
+		/// <typeparam name="T">Texture data type</typeparam>
+		/// <param name="texture">The texture to read from</param>
+		/// <param name="width">The texture width</param>
+		/// <param name="height">The texture height</param>
+		/// <param name="level">The texture level</param>
+		/// <param name="data">The texture data array</param>
+		/// <param name="rect">The portion of the image to read from</param>
+		/// <returns>True if we successfully read the texture data</returns>
+		private bool ReadTargetIfApplicable(
+			IGLTexture texture,
+			int width,
+			int height,
+			int level,
+			IntPtr data,
+			int subX,
+			int subY,
+			int subW,
+			int subH
+		) {
+			bool texUnbound = (	currentDrawBuffers != 1 ||
+						currentAttachments[0] != (texture as OpenGLTexture).Handle	);
+			if (texUnbound && !useES3)
+			{
+				return false;
+			}
+
+			uint prevReadBuffer = currentReadFramebuffer;
+			uint prevWriteBuffer = currentDrawFramebuffer;
+			if (texUnbound)
+			{
+				BindFramebuffer(resolveFramebufferRead);
+				glFramebufferTexture2D(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_COLOR_ATTACHMENT0,
+					GLenum.GL_TEXTURE_2D,
+					(texture as OpenGLTexture).Handle,
+					level
+				);
+			}
+			else
+			{
+				BindReadFramebuffer(targetFramebuffer);
+			}
+
+			/* glReadPixels should be faster than reading
+			 * back from the render target if we are already bound.
+			 */
+			glReadPixels(
+				subX,
+				subY,
+				subW,
+				subH,
+				GLenum.GL_RGBA, // FIXME: Assumption!
+				GLenum.GL_UNSIGNED_BYTE,
+				data
+			);
+
+			if (texUnbound)
+			{
+				if (prevReadBuffer == prevWriteBuffer)
+				{
+					BindFramebuffer(prevReadBuffer);
+				}
+				else
+				{
+					BindReadFramebuffer(prevReadBuffer);
+					BindDrawFramebuffer(prevWriteBuffer);
+				}
+			}
+			else
+			{
+				BindReadFramebuffer(prevReadBuffer);
+			}
+			return true;
+		}
+
+		#endregion
+
+		#region RenderTarget->Texture Method
+
+		public void ResolveTarget(RenderTargetBinding target)
+		{
+			if ((target.RenderTarget as IRenderTarget).MultiSampleCount > 0)
+			{
+				uint prevBuffer = currentDrawFramebuffer;
+
+				// Set up the texture framebuffer
+				GLenum textureTarget;
+				int width, height;
+				if (target.RenderTarget is RenderTarget2D)
+				{
+					textureTarget = GLenum.GL_TEXTURE_2D;
+					Texture2D target2D = (target.RenderTarget as Texture2D);
+					width = target2D.Width;
+					height = target2D.Height;
+				}
+				else
+				{
+					textureTarget = GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + (int) target.CubeMapFace;
+					TextureCube targetCube = (target.RenderTarget as TextureCube);
+					width = targetCube.Size;
+					height = targetCube.Size;
+				}
+				BindFramebuffer(resolveFramebufferDraw);
+				glFramebufferTexture2D(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_COLOR_ATTACHMENT0,
+					textureTarget,
+					(target.RenderTarget.texture as OpenGLTexture).Handle,
+					0
+				);
+
+				// Set up the renderbuffer framebuffer
+				BindFramebuffer(resolveFramebufferRead);
+				glFramebufferRenderbuffer(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_COLOR_ATTACHMENT0,
+					GLenum.GL_RENDERBUFFER,
+					((target.RenderTarget as IRenderTarget).ColorBuffer as OpenGLRenderbuffer).Handle
+				);
+
+				// Blit!
+				if (scissorTestEnable)
+				{
+					glDisable(GLenum.GL_SCISSOR_TEST);
+				}
+				BindDrawFramebuffer(resolveFramebufferDraw);
+				glBlitFramebuffer(
+					0, 0, width, height,
+					0, 0, width, height,
+					GLenum.GL_COLOR_BUFFER_BIT,
+					GLenum.GL_LINEAR
+				);
+				if (scissorTestEnable)
+				{
+					glEnable(GLenum.GL_SCISSOR_TEST);
+				}
+
+				BindFramebuffer(prevBuffer);
+			}
+
+			// If the target has mipmaps, regenerate them now
+			if (target.RenderTarget.LevelCount > 1)
+			{
+				OpenGLTexture prevTex = Textures[0];
+				BindTexture(target.RenderTarget.texture);
+				glGenerateMipmap((target.RenderTarget.texture as OpenGLTexture).Target);
+				BindTexture(prevTex);
+			}
+		}
+
+		#endregion
+
+		#region Framebuffer Methods
+
+		private void BindFramebuffer(uint handle)
+		{
+			if (	currentReadFramebuffer != handle &&
+				currentDrawFramebuffer != handle	)
+			{
+				glBindFramebuffer(
+					GLenum.GL_FRAMEBUFFER,
+					handle
+				);
+				currentReadFramebuffer = handle;
+				currentDrawFramebuffer = handle;
+			}
+			else if (currentReadFramebuffer != handle)
+			{
+				BindReadFramebuffer(handle);
+			}
+			else if (currentDrawFramebuffer != handle)
+			{
+				BindDrawFramebuffer(handle);
+			}
+		}
+
+		private void BindReadFramebuffer(uint handle)
+		{
+			if (handle == currentReadFramebuffer)
+			{
+				return;
+			}
+
+			glBindFramebuffer(
+				GLenum.GL_READ_FRAMEBUFFER,
+				handle
+			);
+
+			currentReadFramebuffer = handle;
+		}
+
+		private void BindDrawFramebuffer(uint handle)
+		{
+			if (handle == currentDrawFramebuffer)
+			{
+				return;
+			}
+
+			glBindFramebuffer(
+				GLenum.GL_DRAW_FRAMEBUFFER,
+				handle
+			);
+
+			currentDrawFramebuffer = handle;
+		}
+
+		#endregion
+
+		#region Renderbuffer Methods
+
+		public IGLRenderbuffer GenRenderbuffer(
+			int width,
+			int height,
+			SurfaceFormat format,
+			int multiSampleCount
+		) {
+			uint handle = 0;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			glGenRenderbuffers(1, out handle);
+			glBindRenderbuffer(
+				GLenum.GL_RENDERBUFFER,
+				handle
+			);
+			if (multiSampleCount > 0)
+			{
+				glRenderbufferStorageMultisample(
+					GLenum.GL_RENDERBUFFER,
+					multiSampleCount,
+					XNAToGL.TextureInternalFormat[(int) format],
+					width,
+					height
+				);
+			}
+			else
+			{
+				glRenderbufferStorage(
+					GLenum.GL_RENDERBUFFER,
+					XNAToGL.TextureInternalFormat[(int) format],
+					width,
+					height
+				);
+			}
+			glBindRenderbuffer(
+				GLenum.GL_RENDERBUFFER,
+				0
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return new OpenGLRenderbuffer(handle);
+		}
+
+		public IGLRenderbuffer GenRenderbuffer(
+			int width,
+			int height,
+			DepthFormat format,
+			int multiSampleCount
+		) {
+			uint handle = 0;
+
+#if !DISABLE_THREADING
+			ForceToMainThread(() => {
+#endif
+
+			glGenRenderbuffers(1, out handle);
+			glBindRenderbuffer(
+				GLenum.GL_RENDERBUFFER,
+				handle
+			);
+			if (multiSampleCount > 0)
+			{
+				glRenderbufferStorageMultisample(
+					GLenum.GL_RENDERBUFFER,
+					multiSampleCount,
+					XNAToGL.DepthStorage[(int) format],
+					width,
+					height
+				);
+			}
+			else
+			{
+				glRenderbufferStorage(
+					GLenum.GL_RENDERBUFFER,
+					XNAToGL.DepthStorage[(int) format],
+					width,
+					height
+				);
+			}
+			glBindRenderbuffer(
+				GLenum.GL_RENDERBUFFER,
+				0
+			);
+
+#if !DISABLE_THREADING
+			});
+#endif
+
+			return new OpenGLRenderbuffer(handle);
+		}
+
+		private void DeleteRenderbuffer(IGLRenderbuffer renderbuffer)
+		{
+			uint handle = (renderbuffer as OpenGLRenderbuffer).Handle;
+
+			// Check color attachments
+			for (int i = 0; i < currentAttachments.Length; i += 1)
+			{
+				if (handle == currentAttachments[i])
+				{
+					// Force an attachment update, this no longer exists!
+					currentAttachments[i] = uint.MaxValue;
+				}
+			}
+
+			// Check depth/stencil attachment
+			if (handle == currentRenderbuffer)
+			{
+				// Force a renderbuffer update, this no longer exists!
+				currentRenderbuffer = uint.MaxValue;
+			}
+
+			// Finally.
+			glDeleteRenderbuffers(1, ref handle);
+		}
+
+		#endregion
+
+		#region glEnable/glDisable Method
+
+		private void ToggleGLState(GLenum feature, bool enable)
+		{
+			if (enable)
+			{
+				glEnable(feature);
+			}
+			else
+			{
+				glDisable(feature);
+			}
+		}
+
+		#endregion
+
+		#region glClear Method
+
+		public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
+		{
+			// glClear depends on the scissor rectangle!
+			if (scissorTestEnable)
+			{
+				glDisable(GLenum.GL_SCISSOR_TEST);
+			}
+
+			bool clearTarget = (options & ClearOptions.Target) == ClearOptions.Target;
+			bool clearDepth = (options & ClearOptions.DepthBuffer) == ClearOptions.DepthBuffer;
+			bool clearStencil = (options & ClearOptions.Stencil) == ClearOptions.Stencil;
+
+			// Get the clear mask, set the clear properties if needed
+			GLenum clearMask = GLenum.GL_ZERO;
+			if (clearTarget)
+			{
+				clearMask |= GLenum.GL_COLOR_BUFFER_BIT;
+				if (!color.Equals(currentClearColor))
+				{
+					glClearColor(
+						color.X,
+						color.Y,
+						color.Z,
+						color.W
+					);
+					currentClearColor = color;
+				}
+				// glClear depends on the color write mask!
+				if (colorWriteEnable != ColorWriteChannels.All)
+				{
+					// FIXME: ColorWriteChannels1/2/3? -flibit
+					glColorMask(true, true, true, true);
+				}
+			}
+			if (clearDepth)
+			{
+				clearMask |= GLenum.GL_DEPTH_BUFFER_BIT;
+				if (depth != currentClearDepth)
+				{
+					glClearDepth((double) depth);
+					currentClearDepth = depth;
+				}
+				// glClear depends on the depth write mask!
+				if (!zWriteEnable)
+				{
+					glDepthMask(true);
+				}
+			}
+			if (clearStencil)
+			{
+				clearMask |= GLenum.GL_STENCIL_BUFFER_BIT;
+				if (stencil != currentClearStencil)
+				{
+					glClearStencil(stencil);
+					currentClearStencil = stencil;
+				}
+				// glClear depends on the stencil write mask!
+				if (stencilWriteMask != -1)
+				{
+					// AKA 0xFFFFFFFF, ugh -flibit
+					glStencilMask(-1);
+				}
+			}
+
+			// CLEAR!
+			glClear(clearMask);
+
+			// Clean up after ourselves.
+			if (scissorTestEnable)
+			{
+				glEnable(GLenum.GL_SCISSOR_TEST);
+			}
+			if (clearTarget && colorWriteEnable != ColorWriteChannels.All)
+			{
+				// FIXME: ColorWriteChannels1/2/3? -flibit
+				glColorMask(
+					(colorWriteEnable & ColorWriteChannels.Red) != 0,
+					(colorWriteEnable & ColorWriteChannels.Blue) != 0,
+					(colorWriteEnable & ColorWriteChannels.Green) != 0,
+					(colorWriteEnable & ColorWriteChannels.Alpha) != 0
+				);
+			}
+			if (clearDepth && !zWriteEnable)
+			{
+				glDepthMask(false);
+			}
+			if (clearStencil && stencilWriteMask != -1) // AKA 0xFFFFFFFF, ugh -flibit
+			{
+				glStencilMask(stencilWriteMask);
+			}
+		}
+
+		#endregion
+
+		#region SetRenderTargets Method
+
+		public void SetRenderTargets(
+			RenderTargetBinding[] renderTargets,
+			IGLRenderbuffer renderbuffer,
+			DepthFormat depthFormat
+		) {
+			// Bind the right framebuffer, if needed
+			if (renderTargets == null)
+			{
+				BindFramebuffer(
+					(Backbuffer is OpenGLBackbuffer) ?
+						(Backbuffer as OpenGLBackbuffer).Handle :
+						0
+				);
+				flipViewport = 1;
+				return;
+			}
+			else
+			{
+				BindFramebuffer(targetFramebuffer);
+				flipViewport = -1;
+			}
+
+			int i;
+			for (i = 0; i < renderTargets.Length; i += 1)
+			{
+				IGLRenderbuffer colorBuffer = (renderTargets[i].RenderTarget as IRenderTarget).ColorBuffer;
+				if (colorBuffer != null)
+				{
+					attachments[i] = (colorBuffer as OpenGLRenderbuffer).Handle;
+					attachmentTypes[i] = GLenum.GL_RENDERBUFFER;
+				}
+				else
+				{
+					attachments[i] = (renderTargets[i].RenderTarget.texture as OpenGLTexture).Handle;
+					if (renderTargets[i].RenderTarget is RenderTarget2D)
+					{
+						attachmentTypes[i] = GLenum.GL_TEXTURE_2D;
+					}
+					else
+					{
+						attachmentTypes[i] = GLenum.GL_TEXTURE_CUBE_MAP_POSITIVE_X + (int) renderTargets[i].CubeMapFace;
+					}
+				}
+			}
+
+			// Update the color attachments, DrawBuffers state
+			for (i = 0; i < renderTargets.Length; i += 1)
+			{
+				if (attachments[i] != currentAttachments[i])
+				{
+					if (currentAttachments[i] != 0)
+					{
+						if (	attachmentTypes[i] != GLenum.GL_RENDERBUFFER &&
+							currentAttachmentTypes[i] == GLenum.GL_RENDERBUFFER	)
+						{
+							glFramebufferRenderbuffer(
+								GLenum.GL_FRAMEBUFFER,
+								GLenum.GL_COLOR_ATTACHMENT0 + i,
+								GLenum.GL_RENDERBUFFER,
+								0
+							);
+						}
+						else if (	attachmentTypes[i] == GLenum.GL_RENDERBUFFER &&
+								currentAttachmentTypes[i] != GLenum.GL_RENDERBUFFER	)
+						{
+							glFramebufferTexture2D(
+								GLenum.GL_FRAMEBUFFER,
+								GLenum.GL_COLOR_ATTACHMENT0 + i,
+								currentAttachmentTypes[i],
+								0,
+								0
+							);
+						}
+					}
+					if (attachmentTypes[i] == GLenum.GL_RENDERBUFFER)
+					{
+						glFramebufferRenderbuffer(
+							GLenum.GL_FRAMEBUFFER,
+							GLenum.GL_COLOR_ATTACHMENT0 + i,
+							GLenum.GL_RENDERBUFFER,
+							attachments[i]
+						);
+					}
+					else
+					{
+						glFramebufferTexture2D(
+							GLenum.GL_FRAMEBUFFER,
+							GLenum.GL_COLOR_ATTACHMENT0 + i,
+							attachmentTypes[i],
+							attachments[i],
+							0
+						);
+					}
+					currentAttachments[i] = attachments[i];
+					currentAttachmentTypes[i] = attachmentTypes[i];
+				}
+				else if (attachmentTypes[i] != currentAttachmentTypes[i])
+				{
+					// Texture cube face change!
+					glFramebufferTexture2D(
+						GLenum.GL_FRAMEBUFFER,
+						GLenum.GL_COLOR_ATTACHMENT0 + i,
+						attachmentTypes[i],
+						attachments[i],
+						0
+					);
+					currentAttachmentTypes[i] = attachmentTypes[i];
+				}
+			}
+			while (i < currentAttachments.Length)
+			{
+				if (currentAttachments[i] != 0)
+				{
+					if (currentAttachmentTypes[i] == GLenum.GL_RENDERBUFFER)
+					{
+						glFramebufferRenderbuffer(
+							GLenum.GL_FRAMEBUFFER,
+							GLenum.GL_COLOR_ATTACHMENT0 + i,
+							GLenum.GL_RENDERBUFFER,
+							0
+						);
+					}
+					else
+					{
+						glFramebufferTexture2D(
+							GLenum.GL_FRAMEBUFFER,
+							GLenum.GL_COLOR_ATTACHMENT0 + i,
+							currentAttachmentTypes[i],
+							0,
+							0
+						);
+					}
+					currentAttachments[i] = 0;
+					currentAttachmentTypes[i] = GLenum.GL_TEXTURE_2D;
+				}
+				i += 1;
+			}
+			if (renderTargets.Length != currentDrawBuffers)
+			{
+				glDrawBuffers(renderTargets.Length, drawBuffersArray);
+				currentDrawBuffers = renderTargets.Length;
+			}
+
+			// Update the depth/stencil attachment
+			/* FIXME: Notice that we do separate attach calls for the stencil.
+			 * We _should_ be able to do a single attach for depthstencil, but
+			 * some drivers (like Mesa) cannot into GL_DEPTH_STENCIL_ATTACHMENT.
+			 * Use XNAToGL.DepthStencilAttachment when this isn't a problem.
+			 * -flibit
+			 */
+			uint handle;
+			if (renderbuffer == null)
+			{
+				handle = 0;
+			}
+			else
+			{
+				handle = (renderbuffer as OpenGLRenderbuffer).Handle;
+			}
+			if (handle != currentRenderbuffer)
+			{
+				if (currentDepthStencilFormat == DepthFormat.Depth24Stencil8)
+				{
+					glFramebufferRenderbuffer(
+						GLenum.GL_FRAMEBUFFER,
+						GLenum.GL_STENCIL_ATTACHMENT,
+						GLenum.GL_RENDERBUFFER,
+						0
+					);
+				}
+				currentDepthStencilFormat = depthFormat;
+				glFramebufferRenderbuffer(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_DEPTH_ATTACHMENT,
+					GLenum.GL_RENDERBUFFER,
+					handle
+				);
+				if (currentDepthStencilFormat == DepthFormat.Depth24Stencil8)
+				{
+					glFramebufferRenderbuffer(
+						GLenum.GL_FRAMEBUFFER,
+						GLenum.GL_STENCIL_ATTACHMENT,
+						GLenum.GL_RENDERBUFFER,
+						handle
+					);
+				}
+				currentRenderbuffer = handle;
+			}
+		}
+
+		#endregion
+
+		#region Query Object Methods
+
+		public IGLQuery CreateQuery()
+		{
+			uint handle;
+			glGenQueries(1, out handle);
+			return new OpenGLQuery(handle);
+		}
+
+		private void DeleteQuery(IGLQuery query)
+		{
+			uint handle = (query as OpenGLQuery).Handle;
+			glDeleteQueries(
+				1,
+				ref handle
+			);
+		}
+
+		public void QueryBegin(IGLQuery query)
+		{
+			glBeginQuery(
+				GLenum.GL_SAMPLES_PASSED,
+				(query as OpenGLQuery).Handle
+			);
+		}
+
+		public void QueryEnd(IGLQuery query)
+		{
+			// May need to check active queries...?
+			glEndQuery(
+				GLenum.GL_SAMPLES_PASSED
+			);
+		}
+
+		public bool QueryComplete(IGLQuery query)
+		{
+			uint result;
+			glGetQueryObjectuiv(
+				(query as OpenGLQuery).Handle,
+				GLenum.GL_QUERY_RESULT_AVAILABLE,
+				out result
+			);
+			return result != 0;
+		}
+
+		public int QueryPixelCount(IGLQuery query)
+		{
+			uint result;
+			glGetQueryObjectuiv(
+				(query as OpenGLQuery).Handle,
+				GLenum.GL_QUERY_RESULT,
+				out result
+			);
+			return (int) result;
+		}
+
+		#endregion
+
+		#region Shader Object Methods
+
+		private void DeleteShader(Shader shader)
+		{
+			glUseProgram(0);
+			glDeleteShader(shader.VertexShaderHandle);
+			glDeleteShader(shader.FragmentShaderHandle);
+			glDeleteProgram(shader.ProgramHandle);
+		}
+
+		#endregion
+
+		#region XNA->GL Enum Conversion Class
+
+		private static class XNAToGL
+		{
+			public static readonly GLenum[] TextureFormat = new GLenum[]
+			{
+				GLenum.GL_RGBA,				// SurfaceFormat.Color
+				GLenum.GL_RGB,				// SurfaceFormat.Bgr565
+				GLenum.GL_BGRA,				// SurfaceFormat.Bgra5551
+				GLenum.GL_BGRA,				// SurfaceFormat.Bgra4444
+				GLenum.GL_COMPRESSED_TEXTURE_FORMATS,	// SurfaceFormat.Dxt1
+				GLenum.GL_COMPRESSED_TEXTURE_FORMATS,	// SurfaceFormat.Dxt3
+				GLenum.GL_COMPRESSED_TEXTURE_FORMATS,	// SurfaceFormat.Dxt5
+				GLenum.GL_RG,				// SurfaceFormat.NormalizedByte2
+				GLenum.GL_RGBA,				// SurfaceFormat.NormalizedByte4
+				GLenum.GL_RGBA,				// SurfaceFormat.Rgba1010102
+				GLenum.GL_RG,				// SurfaceFormat.Rg32
+				GLenum.GL_RGBA,				// SurfaceFormat.Rgba64
+				GLenum.GL_LUMINANCE,			// SurfaceFormat.Alpha8
+				GLenum.GL_RED,				// SurfaceFormat.Single
+				GLenum.GL_RG,				// SurfaceFormat.Vector2
+				GLenum.GL_RGBA,				// SurfaceFormat.Vector4
+				GLenum.GL_RED,				// SurfaceFormat.HalfSingle
+				GLenum.GL_RG,				// SurfaceFormat.HalfVector2
+				GLenum.GL_RGBA,				// SurfaceFormat.HalfVector4
+				GLenum.GL_RGBA,				// SurfaceFormat.HdrBlendable
+				GLenum.GL_BGRA,				// SurfaceFormat.ColorBgraEXT
+			};
+
+			public static readonly GLenum[] TextureInternalFormat = new GLenum[]
+			{
+				GLenum.GL_RGBA8,				// SurfaceFormat.Color
+				GLenum.GL_RGB8,					// SurfaceFormat.Bgr565
+				GLenum.GL_RGB5_A1,				// SurfaceFormat.Bgra5551
+				GLenum.GL_RGBA4,				// SurfaceFormat.Bgra4444
+				GLenum.GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,	// SurfaceFormat.Dxt1
+				GLenum.GL_COMPRESSED_RGBA_S3TC_DXT3_EXT,	// SurfaceFormat.Dxt3
+				GLenum.GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,	// SurfaceFormat.Dxt5
+				GLenum.GL_RG8,					// SurfaceFormat.NormalizedByte2
+				GLenum.GL_RGBA8,				// SurfaceFormat.NormalizedByte4
+				GLenum.GL_RGB10_A2_EXT,				// SurfaceFormat.Rgba1010102
+				GLenum.GL_RG16,					// SurfaceFormat.Rg32
+				GLenum.GL_RGBA16,				// SurfaceFormat.Rgba64
+				GLenum.GL_LUMINANCE,				// SurfaceFormat.Alpha8
+				GLenum.GL_R32F,					// SurfaceFormat.Single
+				GLenum.GL_RG32F,				// SurfaceFormat.Vector2
+				GLenum.GL_RGBA32F,				// SurfaceFormat.Vector4
+				GLenum.GL_R16F,					// SurfaceFormat.HalfSingle
+				GLenum.GL_RG16F,				// SurfaceFormat.HalfVector2
+				GLenum.GL_RGBA16F,				// SurfaceFormat.HalfVector4
+				GLenum.GL_RGBA16F,				// SurfaceFormat.HdrBlendable
+				GLenum.GL_RGBA8					// SurfaceFormat.ColorBgraEXT
+			};
+
+			public static readonly GLenum[] TextureDataType = new GLenum[]
+			{
+				GLenum.GL_UNSIGNED_BYTE,			// SurfaceFormat.Color
+				GLenum.GL_UNSIGNED_SHORT_5_6_5,			// SurfaceFormat.Bgr565
+				GLenum.GL_UNSIGNED_SHORT_5_5_5_1_REV,		// SurfaceFormat.Bgra5551
+				GLenum.GL_UNSIGNED_SHORT_4_4_4_4_REV,		// SurfaceFormat.Bgra4444
+				GLenum.GL_ZERO,					// NOPE
+				GLenum.GL_ZERO,					// NOPE
+				GLenum.GL_ZERO,					// NOPE
+				GLenum.GL_BYTE,					// SurfaceFormat.NormalizedByte2
+				GLenum.GL_BYTE,					// SurfaceFormat.NormalizedByte4
+				GLenum.GL_UNSIGNED_INT_2_10_10_10_REV,		// SurfaceFormat.Rgba1010102
+				GLenum.GL_UNSIGNED_SHORT,			// SurfaceFormat.Rg32
+				GLenum.GL_UNSIGNED_SHORT,			// SurfaceFormat.Rgba64
+				GLenum.GL_UNSIGNED_BYTE,			// SurfaceFormat.Alpha8
+				GLenum.GL_FLOAT,				// SurfaceFormat.Single
+				GLenum.GL_FLOAT,				// SurfaceFormat.Vector2
+				GLenum.GL_FLOAT,				// SurfaceFormat.Vector4
+				GLenum.GL_HALF_FLOAT,				// SurfaceFormat.HalfSingle
+				GLenum.GL_HALF_FLOAT,				// SurfaceFormat.HalfVector2
+				GLenum.GL_HALF_FLOAT,				// SurfaceFormat.HalfVector4
+				GLenum.GL_HALF_FLOAT,				// SurfaceFormat.HdrBlendable
+				GLenum.GL_UNSIGNED_BYTE
+			};
+
+			public static readonly GLenum[] BlendMode = new GLenum[]
+			{
+				GLenum.GL_ONE,				// Blend.One
+				GLenum.GL_ZERO,				// Blend.Zero
+				GLenum.GL_SRC_COLOR,			// Blend.SourceColor
+				GLenum.GL_ONE_MINUS_SRC_COLOR,		// Blend.InverseSourceColor
+				GLenum.GL_SRC_ALPHA,			// Blend.SourceAlpha
+				GLenum.GL_ONE_MINUS_SRC_ALPHA,		// Blend.InverseSourceAlpha
+				GLenum.GL_DST_COLOR,			// Blend.DestinationColor
+				GLenum.GL_ONE_MINUS_DST_COLOR,		// Blend.InverseDestinationColor
+				GLenum.GL_DST_ALPHA,			// Blend.DestinationAlpha
+				GLenum.GL_ONE_MINUS_DST_ALPHA,		// Blend.InverseDestinationAlpha
+				GLenum.GL_CONSTANT_COLOR,		// Blend.BlendFactor
+				GLenum.GL_ONE_MINUS_CONSTANT_COLOR,	// Blend.InverseBlendFactor
+				GLenum.GL_SRC_ALPHA_SATURATE		// Blend.SourceAlphaSaturation
+			};
+
+			public static readonly GLenum[] BlendEquation = new GLenum[]
+			{
+				GLenum.GL_FUNC_ADD,			// BlendFunction.Add
+				GLenum.GL_FUNC_SUBTRACT,		// BlendFunction.Subtract
+				GLenum.GL_FUNC_REVERSE_SUBTRACT,	// BlendFunction.ReverseSubtract
+				GLenum.GL_MAX,				// BlendFunction.Max
+				GLenum.GL_MIN				// BlendFunction.Min
+			};
+
+			public static readonly GLenum[] CompareFunc = new GLenum[]
+			{
+				GLenum.GL_ALWAYS,	// CompareFunction.Always
+				GLenum.GL_NEVER,	// CompareFunction.Never
+				GLenum.GL_LESS,		// CompareFunction.Less
+				GLenum.GL_LEQUAL,	// CompareFunction.LessEqual
+				GLenum.GL_EQUAL,	// CompareFunction.Equal
+				GLenum.GL_GEQUAL,	// CompareFunction.GreaterEqual
+				GLenum.GL_GREATER,	// CompareFunction.Greater
+				GLenum.GL_NOTEQUAL	// CompareFunction.NotEqual
+			};
+
+			public static readonly GLenum[] GLStencilOp = new GLenum[]
+			{
+				GLenum.GL_KEEP,		// StencilOperation.Keep
+				GLenum.GL_ZERO,		// StencilOperation.Zero
+				GLenum.GL_REPLACE,	// StencilOperation.Replace
+				GLenum.GL_INCR_WRAP,	// StencilOperation.Increment
+				GLenum.GL_DECR_WRAP,	// StencilOperation.Decrement
+				GLenum.GL_INCR,		// StencilOperation.IncrementSaturation
+				GLenum.GL_DECR,		// StencilOperation.DecrementSaturation
+				GLenum.GL_INVERT	// StencilOperation.Invert
+			};
+
+			public static readonly GLenum[] FrontFace = new GLenum[]
+			{
+				GLenum.GL_ZERO,	// NOPE
+				GLenum.GL_CW,	// CullMode.CullClockwiseFace
+				GLenum.GL_CCW	// CullMode.CullCounterClockwiseFace
+			};
+
+			public static readonly GLenum[] GLFillMode = new GLenum[]
+			{
+				GLenum.GL_FILL,	// FillMode.Solid
+				GLenum.GL_LINE	// FillMode.WireFrame
+			};
+
+			public static readonly int[] Wrap = new int[]
+			{
+				(int) GLenum.GL_REPEAT,			// TextureAddressMode.Wrap
+				(int) GLenum.GL_CLAMP_TO_EDGE,		// TextureAddressMode.Clamp
+				(int) GLenum.GL_MIRRORED_REPEAT		// TextureAddressMode.Mirror
+			};
+
+			public static readonly int[] MagFilter = new int[]
+			{
+				(int) GLenum.GL_LINEAR,		// TextureFilter.Linear
+				(int) GLenum.GL_NEAREST,	// TextureFilter.Point
+				(int) GLenum.GL_LINEAR,		// TextureFilter.Anisotropic
+				(int) GLenum.GL_LINEAR,		// TextureFilter.LinearMipPoint
+				(int) GLenum.GL_NEAREST,	// TextureFilter.PointMipLinear
+				(int) GLenum.GL_NEAREST,	// TextureFilter.MinLinearMagPointMipLinear
+				(int) GLenum.GL_NEAREST,	// TextureFilter.MinLinearMagPointMipPoint
+				(int) GLenum.GL_LINEAR,		// TextureFilter.MinPointMagLinearMipLinear
+				(int) GLenum.GL_LINEAR		// TextureFilter.MinPointMagLinearMipPoint
+			};
+
+			public static readonly int[] MinMipFilter = new int[]
+			{
+				(int) GLenum.GL_LINEAR_MIPMAP_LINEAR,	// TextureFilter.Linear
+				(int) GLenum.GL_NEAREST_MIPMAP_NEAREST,	// TextureFilter.Point
+				(int) GLenum.GL_LINEAR_MIPMAP_LINEAR,	// TextureFilter.Anisotropic
+				(int) GLenum.GL_LINEAR_MIPMAP_NEAREST,	// TextureFilter.LinearMipPoint
+				(int) GLenum.GL_NEAREST_MIPMAP_LINEAR,	// TextureFilter.PointMipLinear
+				(int) GLenum.GL_LINEAR_MIPMAP_LINEAR,	// TextureFilter.MinLinearMagPointMipLinear
+				(int) GLenum.GL_LINEAR_MIPMAP_NEAREST,	// TextureFilter.MinLinearMagPointMipPoint
+				(int) GLenum.GL_NEAREST_MIPMAP_LINEAR,	// TextureFilter.MinPointMagLinearMipLinear
+				(int) GLenum.GL_NEAREST_MIPMAP_NEAREST	// TextureFilter.MinPointMagLinearMipPoint
+			};
+
+			public static readonly int[] MinFilter = new int[]
+			{
+				(int) GLenum.GL_LINEAR,		// TextureFilter.Linear
+				(int) GLenum.GL_NEAREST,	// TextureFilter.Point
+				(int) GLenum.GL_LINEAR,		// TextureFilter.Anisotropic
+				(int) GLenum.GL_LINEAR,		// TextureFilter.LinearMipPoint
+				(int) GLenum.GL_NEAREST,	// TextureFilter.PointMipLinear
+				(int) GLenum.GL_LINEAR,		// TextureFilter.MinLinearMagPointMipLinear
+				(int) GLenum.GL_LINEAR,		// TextureFilter.MinLinearMagPointMipPoint
+				(int) GLenum.GL_NEAREST,	// TextureFilter.MinPointMagLinearMipLinear
+				(int) GLenum.GL_NEAREST		// TextureFilter.MinPointMagLinearMipPoint
+			};
+
+			public static readonly GLenum[] DepthStencilAttachment = new GLenum[]
+			{
+				GLenum.GL_ZERO,				// NOPE
+				GLenum.GL_DEPTH_ATTACHMENT,		// DepthFormat.Depth16
+				GLenum.GL_DEPTH_ATTACHMENT,		// DepthFormat.Depth24
+				GLenum.GL_DEPTH_STENCIL_ATTACHMENT	// DepthFormat.Depth24Stencil8
+			};
+
+			public static readonly GLenum[] DepthStorage = new GLenum[]
+			{
+				GLenum.GL_ZERO,			// NOPE
+				GLenum.GL_DEPTH_COMPONENT16,	// DepthFormat.Depth16
+				GLenum.GL_DEPTH_COMPONENT24,	// DepthFormat.Depth24
+				GLenum.GL_DEPTH24_STENCIL8	// DepthFormat.Depth24Stencil8
+			};
+
+			public static readonly float[] DepthBiasScale = new float[]
+			{
+				0.0f,				// DepthFormat.None
+				(float) ((1 << 16) - 1),	// DepthFormat.Depth16
+				(float) ((1 << 24) - 1),	// DepthFormat.Depth24
+				(float) ((1 << 24) - 1)		// DepthFormat.Depth24Stencil8
+			};
+
+			public static readonly MojoShader.MOJOSHADER_usage[] VertexAttribUsage = new MojoShader.MOJOSHADER_usage[]
+			{
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_POSITION,		// VertexElementUsage.Position
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_COLOR,		// VertexElementUsage.Color
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_TEXCOORD,		// VertexElementUsage.TextureCoordinate
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_NORMAL,		// VertexElementUsage.Normal
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_BINORMAL,		// VertexElementUsage.Binormal
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_TANGENT,		// VertexElementUsage.Tangent
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_BLENDINDICES,	// VertexElementUsage.BlendIndices
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_BLENDWEIGHT,	// VertexElementUsage.BlendWeight
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_DEPTH,		// VertexElementUsage.Depth
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_FOG,		// VertexElementUsage.Fog
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_POINTSIZE,		// VertexElementUsage.PointSize
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_SAMPLE,		// VertexElementUsage.Sample
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_TESSFACTOR		// VertexElementUsage.TessellateFactor
+			};
+
+			public static readonly int[] VertexAttribSize = new int[]
+			{
+					1,	// VertexElementFormat.Single
+					2,	// VertexElementFormat.Vector2
+					3,	// VertexElementFormat.Vector3
+					4,	// VertexElementFormat.Vector4
+					4,	// VertexElementFormat.Color
+					4,	// VertexElementFormat.Byte4
+					2,	// VertexElementFormat.Short2
+					4,	// VertexElementFormat.Short4
+					2,	// VertexElementFormat.NormalizedShort2
+					4,	// VertexElementFormat.NormalizedShort4
+					2,	// VertexElementFormat.HalfVector2
+					4	// VertexElementFormat.HalfVector4
+			};
+
+			public static readonly GLenum[] VertexAttribType = new GLenum[]
+			{
+				GLenum.GL_FLOAT,		// VertexElementFormat.Single
+				GLenum.GL_FLOAT,		// VertexElementFormat.Vector2
+				GLenum.GL_FLOAT,		// VertexElementFormat.Vector3
+				GLenum.GL_FLOAT,		// VertexElementFormat.Vector4
+				GLenum.GL_UNSIGNED_BYTE,	// VertexElementFormat.Color
+				GLenum.GL_UNSIGNED_BYTE,	// VertexElementFormat.Byte4
+				GLenum.GL_SHORT,		// VertexElementFormat.Short2
+				GLenum.GL_SHORT,		// VertexElementFormat.Short4
+				GLenum.GL_SHORT,		// VertexElementFormat.NormalizedShort2
+				GLenum.GL_SHORT,		// VertexElementFormat.NormalizedShort4
+				GLenum.GL_HALF_FLOAT,		// VertexElementFormat.HalfVector2
+				GLenum.GL_HALF_FLOAT		// VertexElementFormat.HalfVector4
+			};
+
+			public static bool VertexAttribNormalized(VertexElement element)
+			{
+				return (	element.VertexElementUsage == VertexElementUsage.Color ||
+						element.VertexElementFormat == VertexElementFormat.NormalizedShort2 ||
+						element.VertexElementFormat == VertexElementFormat.NormalizedShort4	);
+			}
+
+			public static readonly GLenum[] IndexType = new GLenum[]
+			{
+				GLenum.GL_UNSIGNED_SHORT,	// IndexElementSize.SixteenBits
+				GLenum.GL_UNSIGNED_INT		// IndexElementSize.ThirtyTwoBits
+			};
+
+			public static readonly int[] IndexSize = new int[]
+			{
+				2,	// IndexElementSize.SixteenBits
+				4	// IndexElementSize.ThirtyTwoBits
+			};
+
+			public static readonly GLenum[] Primitive = new GLenum[]
+			{
+				GLenum.GL_TRIANGLES,		// PrimitiveType.TriangleList
+				GLenum.GL_TRIANGLE_STRIP,	// PrimitiveType.TriangleStrip
+				GLenum.GL_LINES,		// PrimitiveType.LineList
+				GLenum.GL_LINE_STRIP,		// PrimitiveType.LineStrip
+				GLenum.GL_POINTS		// PrimitiveType.PointListEXT
+			};
+
+			public static int PrimitiveVerts(PrimitiveType primitiveType, int primitiveCount)
+			{
+				switch (primitiveType)
+				{
+					case PrimitiveType.TriangleList:
+						return primitiveCount * 3;
+					case PrimitiveType.TriangleStrip:
+						return primitiveCount + 2;
+					case PrimitiveType.LineList:
+						return primitiveCount * 2;
+					case PrimitiveType.LineStrip:
+						return primitiveCount + 1;
+					case PrimitiveType.PointListEXT:
+						return primitiveCount;
+				}
+				throw new NotSupportedException();
+			}
+		}
+
+		#endregion
+
+		#region The Faux-Backbuffer
+
+		private bool UseFauxBackbuffer(PresentationParameters presentationParameters, DisplayMode mode)
+		{
+			int drawX, drawY;
+			SDL.SDL_GL_GetDrawableSize(
+				presentationParameters.DeviceWindowHandle,
+				out drawX,
+				out drawY
+			);
+			bool displayMismatch = (	drawX != presentationParameters.BackBufferWidth ||
+							drawY != presentationParameters.BackBufferHeight	);
+			return displayMismatch || (presentationParameters.MultiSampleCount > 0);
+		}
+
+		private class OpenGLBackbuffer : IGLBackbuffer
+		{
+			public uint Handle
+			{
+				get;
+				private set;
+			}
+
+			public int Width
+			{
+				get;
+				private set;
+			}
+
+			public int Height
+			{
+				get;
+				private set;
+			}
+
+			public DepthFormat DepthFormat
+			{
+				get;
+				private set;
+			}
+
+			public int MultiSampleCount
+			{
+				get;
+				private set;
+			}
+
+			public uint Texture;
+
+			private uint colorAttachment;
+			private uint depthStencilAttachment;
+			private ShaderGLDevice glDevice;
+
+			public OpenGLBackbuffer(
+				ShaderGLDevice device,
+				int width,
+				int height,
+				DepthFormat depthFormat,
+				int multiSampleCount
+			) {
+				Width = width;
+				Height = height;
+
+				glDevice = device;
+				DepthFormat = depthFormat;
+				MultiSampleCount = multiSampleCount;
+				Texture = 0;
+
+				// Generate and bind the FBO.
+				uint handle;
+				glDevice.glGenFramebuffers(1, out handle);
+				Handle = handle;
+				glDevice.BindFramebuffer(Handle);
+
+				// Create and attach the color buffer
+				glDevice.glGenRenderbuffers(1, out colorAttachment);
+				glDevice.glBindRenderbuffer(GLenum.GL_RENDERBUFFER, colorAttachment);
+				if (multiSampleCount > 0)
+				{
+					glDevice.glRenderbufferStorageMultisample(
+						GLenum.GL_RENDERBUFFER,
+						multiSampleCount,
+						GLenum.GL_RGBA8,
+						width,
+						height
+					);
+				}
+				else
+				{
+					glDevice.glRenderbufferStorage(
+						GLenum.GL_RENDERBUFFER,
+						GLenum.GL_RGBA8,
+						width,
+						height
+					);
+				}
+				glDevice.glFramebufferRenderbuffer(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_COLOR_ATTACHMENT0,
+					GLenum.GL_RENDERBUFFER,
+					colorAttachment
+				);
+
+				if (depthFormat == DepthFormat.None)
+				{
+					// Don't bother creating a depth/stencil buffer.
+					depthStencilAttachment = 0;
+
+					// Keep this state sane.
+					glDevice.glBindRenderbuffer(GLenum.GL_RENDERBUFFER, 0);
+
+					return;
+				}
+
+				// Create and attach the depth/stencil buffer
+				glDevice.glGenRenderbuffers(1, out depthStencilAttachment);
+				glDevice.glBindRenderbuffer(GLenum.GL_RENDERBUFFER, depthStencilAttachment);
+				if (multiSampleCount > 0)
+				{
+					glDevice.glRenderbufferStorageMultisample(
+						GLenum.GL_RENDERBUFFER,
+						multiSampleCount,
+						XNAToGL.DepthStorage[(int) depthFormat],
+						width,
+						height
+					);
+				}
+				else
+				{
+					glDevice.glRenderbufferStorage(
+						GLenum.GL_RENDERBUFFER,
+						XNAToGL.DepthStorage[(int) depthFormat],
+						width,
+						height
+					);
+				}
+				glDevice.glFramebufferRenderbuffer(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_DEPTH_ATTACHMENT,
+					GLenum.GL_RENDERBUFFER,
+					depthStencilAttachment
+				);
+				if (depthFormat == DepthFormat.Depth24Stencil8)
+				{
+					glDevice.glFramebufferRenderbuffer(
+						GLenum.GL_FRAMEBUFFER,
+						GLenum.GL_STENCIL_ATTACHMENT,
+						GLenum.GL_RENDERBUFFER,
+						depthStencilAttachment
+					);
+				}
+
+				// Keep this state sane.
+				glDevice.glBindRenderbuffer(GLenum.GL_RENDERBUFFER, 0);
+			}
+
+			public void Dispose()
+			{
+				uint handle = Handle;
+				glDevice.BindFramebuffer(0);
+				glDevice.glDeleteFramebuffers(1, ref handle);
+				glDevice.glDeleteRenderbuffers(1, ref colorAttachment);
+				if (depthStencilAttachment != 0)
+				{
+					glDevice.glDeleteRenderbuffers(1, ref depthStencilAttachment);
+				}
+				if (Texture != 0)
+				{
+					glDevice.glDeleteTextures(1, ref Texture);
+				}
+				glDevice = null;
+				Handle = 0;
+			}
+
+			public void ResetFramebuffer(
+				PresentationParameters presentationParameters,
+				bool renderTargetBound
+			) {
+				Width = presentationParameters.BackBufferWidth;
+				Height = presentationParameters.BackBufferHeight;
+
+				DepthFormat depthFormat = presentationParameters.DepthStencilFormat;
+				MultiSampleCount = presentationParameters.MultiSampleCount;
+				if (Texture != 0)
+				{
+					glDevice.glDeleteTextures(1, ref Texture);
+					Texture = 0;
+				}
+
+				if (renderTargetBound)
+				{
+					glDevice.glBindFramebuffer(
+						GLenum.GL_FRAMEBUFFER, Handle
+					);
+				}
+
+				// Detach color attachment
+				glDevice.glFramebufferRenderbuffer(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_COLOR_ATTACHMENT0,
+					GLenum.GL_RENDERBUFFER,
+					0
+				);
+
+				// Detach depth/stencil attachment, if applicable
+				if (depthStencilAttachment != 0)
+				{
+					glDevice.glFramebufferRenderbuffer(
+						GLenum.GL_FRAMEBUFFER,
+						GLenum.GL_DEPTH_ATTACHMENT,
+						GLenum.GL_RENDERBUFFER,
+						0
+					);
+					if (DepthFormat == DepthFormat.Depth24Stencil8)
+					{
+						glDevice.glFramebufferRenderbuffer(
+							GLenum.GL_FRAMEBUFFER,
+							GLenum.GL_STENCIL_ATTACHMENT,
+							GLenum.GL_RENDERBUFFER,
+							0
+						);
+					}
+				}
+
+				// Update our color attachment to the new resolution.
+				glDevice.glBindRenderbuffer(
+					GLenum.GL_RENDERBUFFER,
+					colorAttachment
+				);
+				if (MultiSampleCount > 0)
+				{
+					glDevice.glRenderbufferStorageMultisample(
+						GLenum.GL_RENDERBUFFER,
+						MultiSampleCount,
+						GLenum.GL_RGBA8,
+						Width,
+						Height
+					);
+				}
+				else
+				{
+					glDevice.glRenderbufferStorage(
+						GLenum.GL_RENDERBUFFER,
+						GLenum.GL_RGBA8,
+						Width,
+						Height
+					);
+				}
+				glDevice.glFramebufferRenderbuffer(
+					GLenum.GL_FRAMEBUFFER,
+					GLenum.GL_COLOR_ATTACHMENT0,
+					GLenum.GL_RENDERBUFFER,
+					colorAttachment
+				);
+
+				// Generate/Delete depth/stencil attachment, if needed
+				if (depthFormat == DepthFormat.None)
+				{
+					if (depthStencilAttachment != 0)
+					{
+						glDevice.glDeleteRenderbuffers(
+							1,
+							ref depthStencilAttachment
+						);
+						depthStencilAttachment = 0;
+					}
+				}
+				else if (depthStencilAttachment == 0)
+				{
+					glDevice.glGenRenderbuffers(
+						1,
+						out depthStencilAttachment
+					);
+				}
+
+				// Update the depth/stencil buffer, if applicable
+				if (depthStencilAttachment != 0)
+				{
+					glDevice.glBindRenderbuffer(
+						GLenum.GL_RENDERBUFFER,
+						depthStencilAttachment
+					);
+					if (MultiSampleCount > 0)
+					{
+						glDevice.glRenderbufferStorageMultisample(
+							GLenum.GL_RENDERBUFFER,
+							MultiSampleCount,
+							XNAToGL.DepthStorage[(int)depthFormat],
+							Width,
+							Height
+						);
+					}
+					else
+					{
+						glDevice.glRenderbufferStorage(
+							GLenum.GL_RENDERBUFFER,
+							XNAToGL.DepthStorage[(int)depthFormat],
+							Width,
+							Height
+						);
+					}
+					glDevice.glFramebufferRenderbuffer(
+						GLenum.GL_FRAMEBUFFER,
+						GLenum.GL_DEPTH_ATTACHMENT,
+						GLenum.GL_RENDERBUFFER,
+						depthStencilAttachment
+					);
+					if (depthFormat == DepthFormat.Depth24Stencil8)
+					{
+						glDevice.glFramebufferRenderbuffer(
+							GLenum.GL_FRAMEBUFFER,
+							GLenum.GL_STENCIL_ATTACHMENT,
+							GLenum.GL_RENDERBUFFER,
+							depthStencilAttachment
+						);
+					}
+				}
+				DepthFormat = depthFormat;
+
+				if (renderTargetBound)
+				{
+					glDevice.glBindFramebuffer(
+						GLenum.GL_FRAMEBUFFER,
+						glDevice.targetFramebuffer
+					);
+				}
+
+				// Keep this state sane.
+				glDevice.glBindRenderbuffer(GLenum.GL_RENDERBUFFER, 0);
+			}
+		}
+
+		#endregion
+
+		#region The Faux-Faux-Backbuffer
+
+		private class NullBackbuffer : IGLBackbuffer
+		{
+			public int Width
+			{
+				get;
+				private set;
+			}
+
+			public int Height
+			{
+				get;
+				private set;
+			}
+
+			public DepthFormat DepthFormat
+			{
+				get;
+				private set;
+			}
+
+			public int MultiSampleCount
+			{
+				get
+				{
+					// Constant, per SDL2_GameWindow
+					return 0;
+				}
+			}
+
+			public NullBackbuffer(int width, int height, DepthFormat depthFormat)
+			{
+				Width = width;
+				Height = height;
+				DepthFormat = depthFormat;
+			}
+
+			public void ResetFramebuffer(
+				PresentationParameters presentationParameters,
+				bool renderTargetBound
+			) {
+				Width = presentationParameters.BackBufferWidth;
+				Height = presentationParameters.BackBufferHeight;
+			}
+		}
+
+		#endregion
+
+		#region Threaded GL Nonsense
+
+		private int mainThreadId;
+
+		private bool IsOnMainThread()
+		{
+			return mainThreadId == Thread.CurrentThread.ManagedThreadId;
+		}
+
+		private void InitThreadedGL(IntPtr window)
+		{
+			mainThreadId = Thread.CurrentThread.ManagedThreadId;
+#if THREADED_GL
+			// Create a background context
+			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
+			WindowInfo = window;
+			BackgroundContext = new GL_ContextHandle()
+			{
+				context = SDL.SDL_GL_CreateContext(window)
+			};
+
+			// Make the foreground context current.
+			SDL.SDL_GL_MakeCurrent(window, glContext);
+
+			// We're going to need glFlush, so load this entry point.
+			glFlush = (Flush) Marshal.GetDelegateForFunctionPointer(
+				SDL.SDL_GL_GetProcAddress("glFlush"),
+				typeof(Flush)
+			);
+#endif
+		}
+
+#if !DISABLE_THREADING
+
+#if THREADED_GL
+		private class GL_ContextHandle
+		{
+			public IntPtr context;
+		}
+		private GL_ContextHandle BackgroundContext;
+		private IntPtr WindowInfo;
+		private delegate void Flush();
+		private Flush glFlush;
+
+#else
+		private System.Collections.Generic.List<Action> actions = new System.Collections.Generic.List<Action>();
+		private void RunActions()
+		{
+			lock (actions)
+			{
+				foreach (Action action in actions)
+				{
+					action();
+				}
+				actions.Clear();
+			}
+		}
+#endif
+
+		private void ForceToMainThread(Action action)
+		{
+			// If we're already on the main thread, just call the action.
+			if (mainThreadId == Thread.CurrentThread.ManagedThreadId)
+			{
+				action();
+				return;
+			}
+
+#if THREADED_GL
+			lock (BackgroundContext)
+			{
+				// Make the context current on this thread.
+				SDL.SDL_GL_MakeCurrent(WindowInfo, BackgroundContext.context);
+
+				// Execute the action.
+				action();
+
+				// Must flush the GL calls now before we release the context.
+				glFlush();
+
+				// Free the threaded context for the next threaded call...
+				SDL.SDL_GL_MakeCurrent(WindowInfo, IntPtr.Zero);
+			}
+#else
+			ManualResetEventSlim resetEvent = new ManualResetEventSlim(false);
+			lock (actions)
+			{
+				actions.Add(() =>
+				{
+					action();
+					resetEvent.Set();
+				});
+			}
+			resetEvent.Wait();
+#endif
+		}
+
+#endif // !DISABLE_THREADING
+
+		#endregion
+	}
+}

--- a/src/FNAPlatform/ShaderGLDevice_GL.cs
+++ b/src/FNAPlatform/ShaderGLDevice_GL.cs
@@ -1,0 +1,2085 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2018 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+using SDL2;
+#endregion
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	internal partial class ShaderGLDevice
+	{
+		#region Fields
+
+		protected bool useES3;
+		protected bool useCoreProfile;
+		protected bool supportsMultisampling;
+		protected bool supportsFauxBackbuffer;
+		protected bool supportsBaseVertex;
+
+		#endregion
+
+		#region Properties
+
+		public bool SupportsHardwareInstancing
+		{
+			get;
+			protected set;
+		}
+
+		#endregion
+
+		#region Private OpenGL Entry Points
+
+		internal enum GLenum : int
+		{
+			// Hint Enum Value
+			GL_DONT_CARE =				0x1100,
+			// 0/1
+			GL_ZERO =				0x0000,
+			GL_ONE =				0x0001,
+			// Types
+			GL_BYTE =				0x1400,
+			GL_UNSIGNED_BYTE =			0x1401,
+			GL_SHORT =				0x1402,
+			GL_UNSIGNED_SHORT =			0x1403,
+			GL_UNSIGNED_INT =			0x1405,
+			GL_FLOAT =				0x1406,
+			GL_HALF_FLOAT =				0x140B,
+			GL_UNSIGNED_SHORT_4_4_4_4_REV =		0x8365,
+			GL_UNSIGNED_SHORT_5_5_5_1_REV =		0x8366,
+			GL_UNSIGNED_INT_2_10_10_10_REV =	0x8368,
+			GL_UNSIGNED_SHORT_5_6_5 =		0x8363,
+			GL_UNSIGNED_INT_24_8 =			0x84FA,
+			// Strings
+			GL_VENDOR =				0x1F00,
+			GL_RENDERER =				0x1F01,
+			GL_VERSION =				0x1F02,
+			GL_EXTENSIONS =				0x1F03,
+			// Clear Mask
+			GL_COLOR_BUFFER_BIT =			0x4000,
+			GL_DEPTH_BUFFER_BIT =			0x0100,
+			GL_STENCIL_BUFFER_BIT =			0x0400,
+			// Enable Caps
+			GL_SCISSOR_TEST =			0x0C11,
+			GL_DEPTH_TEST =				0x0B71,
+			GL_STENCIL_TEST =			0x0B90,
+			// Polygons
+			GL_LINE =				0x1B01,
+			GL_FILL =				0x1B02,
+			GL_CW =					0x0900,
+			GL_CCW =				0x0901,
+			GL_FRONT =				0x0404,
+			GL_BACK =				0x0405,
+			GL_FRONT_AND_BACK =			0x0408,
+			GL_CULL_FACE =				0x0B44,
+			GL_POLYGON_OFFSET_FILL =		0x8037,
+			// Texture Type
+			GL_TEXTURE_2D =				0x0DE1,
+			GL_TEXTURE_3D =				0x806F,
+			GL_TEXTURE_CUBE_MAP =			0x8513,
+			GL_TEXTURE_CUBE_MAP_POSITIVE_X =	0x8515,
+			// Blend Mode
+			GL_BLEND =				0x0BE2,
+			GL_SRC_COLOR =				0x0300,
+			GL_ONE_MINUS_SRC_COLOR =		0x0301,
+			GL_SRC_ALPHA =				0x0302,
+			GL_ONE_MINUS_SRC_ALPHA =		0x0303,
+			GL_DST_ALPHA =				0x0304,
+			GL_ONE_MINUS_DST_ALPHA =		0x0305,
+			GL_DST_COLOR =				0x0306,
+			GL_ONE_MINUS_DST_COLOR =		0x0307,
+			GL_SRC_ALPHA_SATURATE =			0x0308,
+			GL_CONSTANT_COLOR =			0x8001,
+			GL_ONE_MINUS_CONSTANT_COLOR =		0x8002,
+			// Equations
+			GL_MIN =				0x8007,
+			GL_MAX =				0x8008,
+			GL_FUNC_ADD =				0x8006,
+			GL_FUNC_SUBTRACT =			0x800A,
+			GL_FUNC_REVERSE_SUBTRACT =		0x800B,
+			// Comparisons
+			GL_NEVER =				0x0200,
+			GL_LESS =				0x0201,
+			GL_EQUAL =				0x0202,
+			GL_LEQUAL =				0x0203,
+			GL_GREATER =				0x0204,
+			GL_NOTEQUAL =				0x0205,
+			GL_GEQUAL =				0x0206,
+			GL_ALWAYS =				0x0207,
+			// Stencil Operations
+			GL_INVERT =				0x150A,
+			GL_KEEP =				0x1E00,
+			GL_REPLACE =				0x1E01,
+			GL_INCR =				0x1E02,
+			GL_DECR =				0x1E03,
+			GL_INCR_WRAP =				0x8507,
+			GL_DECR_WRAP =				0x8508,
+			// Wrap Modes
+			GL_REPEAT =				0x2901,
+			GL_CLAMP_TO_EDGE =			0x812F,
+			GL_MIRRORED_REPEAT =			0x8370,
+			// Filters
+			GL_NEAREST =				0x2600,
+			GL_LINEAR =				0x2601,
+			GL_NEAREST_MIPMAP_NEAREST =		0x2700,
+			GL_NEAREST_MIPMAP_LINEAR =		0x2702,
+			GL_LINEAR_MIPMAP_NEAREST =		0x2701,
+			GL_LINEAR_MIPMAP_LINEAR =		0x2703,
+			// Attachments
+			GL_COLOR_ATTACHMENT0 =			0x8CE0,
+			GL_DEPTH_ATTACHMENT =			0x8D00,
+			GL_STENCIL_ATTACHMENT =			0x8D20,
+			GL_DEPTH_STENCIL_ATTACHMENT =		0x821A,
+			// Texture Formats
+			GL_RED =				0x1903,
+			GL_RGB =				0x1907,
+			GL_RGBA =				0x1908,
+			GL_LUMINANCE =				0x1909,
+			GL_RGB8 =				0x8051,
+			GL_RGBA8 =				0x8058,
+			GL_RGBA4 =				0x8056,
+			GL_RGB5_A1 =				0x8057,
+			GL_RGB10_A2_EXT =			0x8059,
+			GL_RGBA16 =				0x805B,
+			GL_BGRA =				0x80E1,
+			GL_DEPTH_COMPONENT16 =			0x81A5,
+			GL_DEPTH_COMPONENT24 =			0x81A6,
+			GL_RG =					0x8227,
+			GL_RG8 =				0x822B,
+			GL_RG16 =				0x822C,
+			GL_R16F =				0x822D,
+			GL_R32F =				0x822E,
+			GL_RG16F =				0x822F,
+			GL_RG32F =				0x8230,
+			GL_RGBA32F =				0x8814,
+			GL_RGBA16F =				0x881A,
+			GL_DEPTH24_STENCIL8 =			0x88F0,
+			GL_COMPRESSED_TEXTURE_FORMATS =		0x86A3,
+			GL_COMPRESSED_RGBA_S3TC_DXT1_EXT =	0x83F1,
+			GL_COMPRESSED_RGBA_S3TC_DXT3_EXT =	0x83F2,
+			GL_COMPRESSED_RGBA_S3TC_DXT5_EXT =	0x83F3,
+			// Texture Internal Formats
+			GL_DEPTH_COMPONENT =			0x1902,
+			GL_DEPTH_STENCIL =			0x84F9,
+			// Textures
+			GL_TEXTURE_WRAP_S =			0x2802,
+			GL_TEXTURE_WRAP_T =			0x2803,
+			GL_TEXTURE_WRAP_R =			0x8072,
+			GL_TEXTURE_MAG_FILTER =			0x2800,
+			GL_TEXTURE_MIN_FILTER =			0x2801,
+			GL_TEXTURE_MAX_ANISOTROPY_EXT =		0x84FE,
+			GL_TEXTURE_BASE_LEVEL =			0x813C,
+			GL_TEXTURE_MAX_LEVEL =			0x813D,
+			GL_TEXTURE_LOD_BIAS =			0x8501,
+			GL_UNPACK_ALIGNMENT =			0x0CF5,
+			// Multitexture
+			GL_TEXTURE0 =				0x84C0,
+			GL_MAX_TEXTURE_IMAGE_UNITS =		0x8872,
+			GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS =	0x8B4C,
+			// Buffer objects
+			GL_ARRAY_BUFFER =			0x8892,
+			GL_ELEMENT_ARRAY_BUFFER =		0x8893,
+			GL_STREAM_DRAW =			0x88E0,
+			GL_STATIC_DRAW =			0x88E4,
+			GL_MAX_VERTEX_ATTRIBS =			0x8869,
+			// Render targets
+			GL_FRAMEBUFFER =			0x8D40,
+			GL_READ_FRAMEBUFFER =			0x8CA8,
+			GL_DRAW_FRAMEBUFFER =			0x8CA9,
+			GL_RENDERBUFFER =			0x8D41,
+			GL_MAX_DRAW_BUFFERS =			0x8824,
+			// Draw Primitives
+			GL_POINTS =				0x0000,
+			GL_LINES =				0x0001,
+			GL_LINE_STRIP =				0x0003,
+			GL_TRIANGLES =				0x0004,
+			GL_TRIANGLE_STRIP =			0x0005,
+			// Query Objects
+			GL_QUERY_RESULT =			0x8866,
+			GL_QUERY_RESULT_AVAILABLE =		0x8867,
+			GL_SAMPLES_PASSED =			0x8914,
+			// Multisampling
+			GL_MULTISAMPLE =			0x809D,
+			GL_MAX_SAMPLES =			0x8D57,
+			GL_SAMPLE_MASK =			0x8E51,
+			// 3.2 Core Profile
+			GL_NUM_EXTENSIONS =			0x821D,
+			// Source Enum Values
+			GL_DEBUG_SOURCE_API =			0x8246,
+			GL_DEBUG_SOURCE_WINDOW_SYSTEM =		0x8247,
+			GL_DEBUG_SOURCE_SHADER_COMPILER =	0x8248,
+			GL_DEBUG_SOURCE_THIRD_PARTY =		0x8249,
+			GL_DEBUG_SOURCE_APPLICATION =		0x824A,
+			GL_DEBUG_SOURCE_OTHER =			0x824B,
+			// Type Enum Values
+			GL_DEBUG_TYPE_ERROR =			0x824C,
+			GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR =	0x824D,
+			GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR =	0x824E,
+			GL_DEBUG_TYPE_PORTABILITY =		0x824F,
+			GL_DEBUG_TYPE_PERFORMANCE =		0x8250,
+			GL_DEBUG_TYPE_OTHER =			0x8251,
+			// Severity Enum Values
+			GL_DEBUG_SEVERITY_HIGH =		0x9146,
+			GL_DEBUG_SEVERITY_MEDIUM =		0x9147,
+			GL_DEBUG_SEVERITY_LOW =			0x9148,
+			GL_DEBUG_SEVERITY_NOTIFICATION =	0x826B,
+			
+			// For Shader
+			GL_FRAGMENT_SHADER = 0x8B30,
+			GL_VERTEX_SHADER = 0x8B31,
+			GL_COMPILE_STATUS = 0x8B81,
+			GL_LINK_STATUS = 0x8B82,
+			GL_ACTIVE_UNIFORMS = 0x8B86,
+			GL_ACTIVE_ATTRIBUTES = 0x8B89
+		}
+
+		// Entry Points
+
+		/* BEGIN GET FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate IntPtr GetString(GLenum pname);
+		public GetString INTERNAL_glGetString;
+		public string glGetString(GLenum pname)
+		{
+			unsafe
+			{
+				return new string((sbyte*) INTERNAL_glGetString(pname));
+			}
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GetIntegerv(GLenum pname, out int param);
+		public GetIntegerv glGetIntegerv;
+
+		/* END GET FUNCTIONS */
+
+		/* BEGIN ENABLE/DISABLE FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Enable(GLenum cap);
+		public Enable glEnable;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Disable(GLenum cap);
+		public Disable glDisable;
+
+		/* END ENABLE/DISABLE FUNCTIONS */
+
+		/* BEGIN VIEWPORT/SCISSOR FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void G_Viewport(
+			int x,
+			int y,
+			int width,
+			int height
+		);
+		public G_Viewport glViewport;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DepthRange(
+			double near_val,
+			double far_val
+		);
+		public DepthRange glDepthRange;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DepthRangef(
+			float near_val,
+			float far_val
+		);
+		public DepthRangef glDepthRangef;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Scissor(
+			int x,
+			int y,
+			int width,
+			int height
+		);
+		public Scissor glScissor;
+
+		/* END VIEWPORT/SCISSOR FUNCTIONS */
+
+		/* BEGIN BLEND STATE FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BlendColor(
+			float red,
+			float green,
+			float blue,
+			float alpha
+		);
+		public BlendColor glBlendColor;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BlendFuncSeparate(
+			GLenum srcRGB,
+			GLenum dstRGB,
+			GLenum srcAlpha,
+			GLenum dstAlpha
+		);
+		public BlendFuncSeparate glBlendFuncSeparate;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BlendEquationSeparate(
+			GLenum modeRGB,
+			GLenum modeAlpha
+		);
+		public BlendEquationSeparate glBlendEquationSeparate;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ColorMask(
+			bool red,
+			bool green,
+			bool blue,
+			bool alpha
+		);
+		public ColorMask glColorMask;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ColorMaski(
+			uint buf,
+			bool red,
+			bool green,
+			bool blue,
+			bool alpha
+		);
+		public ColorMaski glColorMaski;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void SampleMaski(uint maskNumber, uint mask);
+		public SampleMaski glSampleMaski;
+
+		/* END BLEND STATE FUNCTIONS */
+
+		/* BEGIN DEPTH/STENCIL STATE FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DepthMask(bool flag);
+		public DepthMask glDepthMask;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DepthFunc(GLenum func);
+		public DepthFunc glDepthFunc;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void StencilMask(int mask);
+		public StencilMask glStencilMask;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void StencilFuncSeparate(
+			GLenum face,
+			GLenum func,
+			int reference,
+			int mask
+		);
+		public StencilFuncSeparate glStencilFuncSeparate;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void StencilOpSeparate(
+			GLenum face,
+			GLenum sfail,
+			GLenum dpfail,
+			GLenum dppass
+		);
+		public StencilOpSeparate glStencilOpSeparate;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void StencilFunc(
+			GLenum fail,
+			int reference,
+			int mask
+		);
+		public StencilFunc glStencilFunc;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void StencilOp(
+			GLenum fail,
+			GLenum zfail,
+			GLenum zpass
+		);
+		public StencilOp glStencilOp;
+
+		/* END DEPTH/STENCIL STATE FUNCTIONS */
+
+		/* BEGIN RASTERIZER STATE FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void FrontFace(GLenum mode);
+		public FrontFace glFrontFace;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void PolygonMode(GLenum face, GLenum mode);
+		public PolygonMode glPolygonMode;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void PolygonOffset(float factor, float units);
+		public PolygonOffset glPolygonOffset;
+
+		/* END RASTERIZER STATE FUNCTIONS */
+
+		/* BEGIN TEXTURE FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GenTextures(int n, out uint textures);
+		public GenTextures glGenTextures;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteTextures(
+			int n,
+			ref uint textures
+		);
+		public DeleteTextures glDeleteTextures;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void G_BindTexture(GLenum target, uint texture);
+		public G_BindTexture glBindTexture;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void TexImage2D(
+			GLenum target,
+			int level,
+			int internalFormat,
+			int width,
+			int height,
+			int border,
+			GLenum format,
+			GLenum type,
+			IntPtr pixels
+		);
+		public TexImage2D glTexImage2D;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void TexSubImage2D(
+			GLenum target,
+			int level,
+			int xoffset,
+			int yoffset,
+			int width,
+			int height,
+			GLenum format,
+			GLenum type,
+			IntPtr pixels
+		);
+		public TexSubImage2D glTexSubImage2D;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void CompressedTexImage2D(
+			GLenum target,
+			int level,
+			int internalFormat,
+			int width,
+			int height,
+			int border,
+			int imageSize,
+			IntPtr pixels
+		);
+		public CompressedTexImage2D glCompressedTexImage2D;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void CompressedTexSubImage2D(
+			GLenum target,
+			int level,
+			int xoffset,
+			int yoffset,
+			int width,
+			int height,
+			GLenum format,
+			int imageSize,
+			IntPtr pixels
+		);
+		public CompressedTexSubImage2D glCompressedTexSubImage2D;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void TexImage3D(
+			GLenum target,
+			int level,
+			int internalFormat,
+			int width,
+			int height,
+			int depth,
+			int border,
+			GLenum format,
+			GLenum type,
+			IntPtr pixels
+		);
+		public TexImage3D glTexImage3D;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void TexSubImage3D(
+			GLenum target,
+			int level,
+			int xoffset,
+			int yoffset,
+			int zoffset,
+			int width,
+			int height,
+			int depth,
+			GLenum format,
+			GLenum type,
+			IntPtr pixels
+		);
+		public TexSubImage3D glTexSubImage3D;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GetTexImage(
+			GLenum target,
+			int level,
+			GLenum format,
+			GLenum type,
+			IntPtr pixels
+		);
+		public GetTexImage glGetTexImage;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void TexParameteri(
+			GLenum target,
+			GLenum pname,
+			int param
+		);
+		public TexParameteri glTexParameteri;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void TexParameterf(
+			GLenum target,
+			GLenum pname,
+			float param
+		);
+		public TexParameterf glTexParameterf;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ActiveTexture(GLenum texture);
+		public ActiveTexture glActiveTexture;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void PixelStorei(GLenum pname, int param);
+		public PixelStorei glPixelStorei;
+
+		/* END TEXTURE FUNCTIONS */
+
+		/* BEGIN BUFFER FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GenBuffers(int n, out uint buffers);
+		public GenBuffers glGenBuffers;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteBuffers(
+			int n,
+			ref uint buffers
+		);
+		public DeleteBuffers glDeleteBuffers;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BindBuffer(GLenum target, uint buffer);
+		public BindBuffer glBindBuffer;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BufferData(
+			GLenum target,
+			IntPtr size,
+			IntPtr data,
+			GLenum usage
+		);
+		public BufferData glBufferData;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BufferSubData(
+			GLenum target,
+			IntPtr offset,
+			IntPtr size,
+			IntPtr data
+		);
+		public BufferSubData glBufferSubData;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GetBufferSubData(
+			GLenum target,
+			IntPtr offset,
+			IntPtr size,
+			IntPtr data
+		);
+		public GetBufferSubData glGetBufferSubData;
+
+		/* END BUFFER FUNCTIONS */
+
+		/* BEGIN CLEAR FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ClearColor(
+			float red,
+			float green,
+			float blue,
+			float alpha
+		);
+		public ClearColor glClearColor;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ClearDepth(double depth);
+		public ClearDepth glClearDepth;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ClearDepthf(float depth);
+		public ClearDepthf glClearDepthf;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ClearStencil(int s);
+		public ClearStencil glClearStencil;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void G_Clear(GLenum mask);
+		public G_Clear glClear;
+
+		/* END CLEAR FUNCTIONS */
+
+		/* BEGIN FRAMEBUFFER FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DrawBuffers(int n, IntPtr bufs);
+		public DrawBuffers glDrawBuffers;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void ReadPixels(
+			int x,
+			int y,
+			int width,
+			int height,
+			GLenum format,
+			GLenum type,
+			IntPtr pixels
+		);
+		public ReadPixels glReadPixels;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GenerateMipmap(GLenum target);
+		public GenerateMipmap glGenerateMipmap;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GenFramebuffers(
+			int n,
+			out uint framebuffers
+		);
+		public GenFramebuffers glGenFramebuffers;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteFramebuffers(
+			int n,
+			ref uint framebuffers
+		);
+		public DeleteFramebuffers glDeleteFramebuffers;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void G_BindFramebuffer(
+			GLenum target,
+			uint framebuffer
+		);
+		public G_BindFramebuffer glBindFramebuffer;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void FramebufferTexture2D(
+			GLenum target,
+			GLenum attachment,
+			GLenum textarget,
+			uint texture,
+			int level
+		);
+		public FramebufferTexture2D glFramebufferTexture2D;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void FramebufferRenderbuffer(
+			GLenum target,
+			GLenum attachment,
+			GLenum renderbuffertarget,
+			uint renderbuffer
+		);
+		public FramebufferRenderbuffer glFramebufferRenderbuffer;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BlitFramebuffer(
+			int srcX0,
+			int srcY0,
+			int srcX1,
+			int srcY1,
+			int dstX0,
+			int dstY0,
+			int dstX1,
+			int dstY1,
+			GLenum mask,
+			GLenum filter
+		);
+		public BlitFramebuffer glBlitFramebuffer;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GenRenderbuffers(
+			int n,
+			out uint renderbuffers
+		);
+		public GenRenderbuffers glGenRenderbuffers;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteRenderbuffers(
+			int n,
+			ref uint renderbuffers
+		);
+		public DeleteRenderbuffers glDeleteRenderbuffers;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BindRenderbuffer(
+			GLenum target,
+			uint renderbuffer
+		);
+		public BindRenderbuffer glBindRenderbuffer;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void RenderbufferStorage(
+			GLenum target,
+			GLenum internalformat,
+			int width,
+			int height
+		);
+		public RenderbufferStorage glRenderbufferStorage;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void RenderbufferStorageMultisample(
+			GLenum target,
+			int samples,
+			GLenum internalformat,
+			int width,
+			int height
+		);
+		public RenderbufferStorageMultisample glRenderbufferStorageMultisample;
+
+		/* END FRAMEBUFFER FUNCTIONS */
+
+		/* BEGIN VERTEX ATTRIBUTE FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void VertexAttribPointer(
+			int index,
+			int size,
+			GLenum type,
+			bool normalized,
+			int stride,
+			IntPtr pointer
+		);
+		public VertexAttribPointer glVertexAttribPointer;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void VertexAttribDivisor(
+			int index,
+			int divisor
+		);
+		public VertexAttribDivisor glVertexAttribDivisor;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void EnableVertexAttribArray(int index);
+		public EnableVertexAttribArray glEnableVertexAttribArray;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DisableVertexAttribArray(int index);
+		public DisableVertexAttribArray glDisableVertexAttribArray;
+
+		/* END VERTEX ATTRIBUTE FUNCTIONS */
+
+		/* BEGIN DRAWING FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DrawElementsInstanced(
+			GLenum mode,
+			int count,
+			GLenum type,
+			IntPtr indices,
+			int instanceCount
+		);
+		public DrawElementsInstanced glDrawElementsInstanced;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DrawRangeElements(
+			GLenum mode,
+			int start,
+			int end,
+			int count,
+			GLenum type,
+			IntPtr indices
+		);
+		public DrawRangeElements glDrawRangeElements;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DrawElementsInstancedBaseVertex(
+			GLenum mode,
+			int count,
+			GLenum type,
+			IntPtr indices,
+			int instanceCount,
+			int baseVertex
+		);
+		public DrawElementsInstancedBaseVertex glDrawElementsInstancedBaseVertex;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DrawRangeElementsBaseVertex(
+			GLenum mode,
+			int start,
+			int end,
+			int count,
+			GLenum type,
+			IntPtr indices,
+			int baseVertex
+		);
+		public DrawRangeElementsBaseVertex glDrawRangeElementsBaseVertex;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DrawElements(
+			GLenum mode,
+			int count,
+			GLenum type,
+			IntPtr indices
+		);
+		public DrawElements glDrawElements;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DrawArrays(
+			GLenum mode,
+			int first,
+			int count
+		);
+		public DrawArrays glDrawArrays;
+
+		/* END DRAWING FUNCTIONS */
+
+		/* BEGIN QUERY FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GenQueries(int n, out uint ids);
+		public GenQueries glGenQueries;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteQueries(int n, ref uint ids);
+		public DeleteQueries glDeleteQueries;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BeginQuery(GLenum target, uint id);
+		public BeginQuery glBeginQuery;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void EndQuery(GLenum target);
+		public EndQuery glEndQuery;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GetQueryObjectuiv(
+			uint id,
+			GLenum pname,
+			out uint param
+		);
+		public GetQueryObjectuiv glGetQueryObjectuiv;
+
+		/* END QUERY FUNCTIONS */
+
+		/* BEGIN 3.2 CORE PROFILE FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate IntPtr GetStringi(GLenum pname, uint index);
+		public GetStringi INTERNAL_glGetStringi;
+		public string glGetStringi(GLenum pname, uint index)
+		{
+			unsafe
+			{
+				return new string((sbyte*) INTERNAL_glGetStringi(pname, index));
+			}
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void GenVertexArrays(int n, out uint arrays);
+		public GenVertexArrays glGenVertexArrays;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteVertexArrays(int n, ref uint arrays);
+		public DeleteVertexArrays glDeleteVertexArrays;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void BindVertexArray(uint array);
+		public BindVertexArray glBindVertexArray;
+
+		/* END 3.2 CORE PROFILE FUNCTIONS */
+
+		/* BEGIN SHADER FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void GetProgramInfoLog(int program, int bufSize, int* length, sbyte* infoLog);
+		public GetProgramInfoLog glGetProgramInfoLog;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate int CreateProgram();
+		public CreateProgram glCreateProgram;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate int CreateShader(GLenum type);
+		public CreateShader glCreateShader;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void ShaderSource(int shader, int count, sbyte** @string, int* length);
+		public ShaderSource glShaderSource;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void CompileShader(int shader);
+		public CompileShader glCompileShader;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void GetShaderiv(int shader, GLenum pname, int* @params);
+		public GetShaderiv glGetShaderiv;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void GetShaderInfoLog(int shader, int bufSize, int* length, sbyte* infoLog);
+		public GetShaderInfoLog glGetShaderInfoLog;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void UseProgram(int program);
+		public UseProgram glUseProgram;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteShaderDelegate(int shader);
+		public DeleteShaderDelegate glDeleteShader;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DeleteProgram(int program);
+		public DeleteProgram glDeleteProgram;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void AttachShader(int program, int shader);
+		public AttachShader glAttachShader;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void LinkProgram(int program);
+		public LinkProgram glLinkProgram;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void GetProgramiv(int program, GLenum pname, int* @params);
+		public GetProgramiv glGetProgramiv;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate int GetAttribLocation(int program, sbyte* name);
+		public GetAttribLocation glGetAttribLocation;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate int GetUniformLocation(int program, sbyte* name);
+		public GetUniformLocation glGetUniformLocation;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform1i(int location, int v0);
+		public Uniform1i glUniform1i;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform2i(int location, int v0, int v1);
+		public Uniform2i glUniform2i;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform3i(int location, int v0, int v1, int v2);
+		public Uniform3i glUniform3i;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform4i(int location, int v0, int v1, int v2, int v3);
+		public Uniform4i glUniform4i;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform1f(int location, float v0);
+		public Uniform1f glUniform1f;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform2f(int location, float v0, float v1);
+		public Uniform2f glUniform2f;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform3f(int location, float v0, float v1, float v2);
+		public Uniform3f glUniform3f;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void Uniform4f(int location, float v0, float v1, float v2, float v3);
+		public Uniform4f glUniform4f;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void Uniform1fv(int location, int count, float* value);
+		public Uniform1fv glUniform1fv;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void Uniform2fv(int location, int count, float* value);
+		public Uniform2fv glUniform2fv;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void Uniform3fv(int location, int count, float* value);
+		public Uniform3fv glUniform3fv;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void Uniform4fv(int location, int count, float* value);
+		public Uniform4fv glUniform4fv;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void UniformMatrix4fv(int location, int count, byte transpose, float* value);
+		public UniformMatrix4fv glUniformMatrix4fv;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void GetActiveUniform(int program, int index, int bufSize, int* length, int* size, int* type, sbyte* name);
+		public GetActiveUniform glGetActiveUniform;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public unsafe delegate void GetActiveAttrib(int program, int index, int bufSize, int* length, int* size, int* type, sbyte* name);
+		public GetActiveAttrib glGetActiveAttrib;
+
+		/* END SHADER FUNCTIONS */
+#if DEBUG
+		/* BEGIN DEBUG OUTPUT FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DebugMessageCallback(
+			IntPtr debugCallback,
+			IntPtr userParam
+		);
+		public DebugMessageCallback glDebugMessageCallback;
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DebugMessageControl(
+			GLenum source,
+			GLenum type,
+			GLenum severity,
+			int count,
+			IntPtr ids, // const GLuint*
+			bool enabled
+		);
+		public DebugMessageControl glDebugMessageControl;
+
+		// ARB_debug_output/KHR_debug callback
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void DebugProc(
+			GLenum source,
+			GLenum type,
+			uint id,
+			GLenum severity,
+			int length,
+			IntPtr message, // const GLchar*
+			IntPtr userParam // const GLvoid*
+		);
+		public DebugProc DebugCall = DebugCallback;
+		public static void DebugCallback(
+			GLenum source,
+			GLenum type,
+			uint id,
+			GLenum severity,
+			int length,
+			IntPtr message, // const GLchar*
+			IntPtr userParam // const GLvoid*
+		) {
+			string err = (
+				Marshal.PtrToStringAnsi(message) +
+				"\n\tSource: " +
+				source.ToString() +
+				"\n\tType: " +
+				type.ToString() +
+				"\n\tSeverity: " +
+				severity.ToString()
+			);
+			if (type == GLenum.GL_DEBUG_TYPE_ERROR)
+			{
+				FNALoggerEXT.LogError(err);
+				throw new InvalidOperationException(err);
+			}
+			FNALoggerEXT.LogWarn(err);
+		}
+
+		/* END DEBUG OUTPUT FUNCTIONS */
+
+		/* BEGIN STRING MARKER FUNCTIONS */
+
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate void StringMarkerGREMEDY(int length, IntPtr chars);
+		public StringMarkerGREMEDY glStringMarkerGREMEDY;
+
+		/* END STRING MARKER FUNCTIONS */
+#endif
+		protected void LoadGLGetString()
+		{
+			try
+			{
+				INTERNAL_glGetString = (GetString) Marshal.GetDelegateForFunctionPointer(
+					SDL.SDL_GL_GetProcAddress("glGetString"),
+					typeof(GetString)
+				);
+			}
+			catch
+			{
+				throw new NoSuitableGraphicsDeviceException("GRAPHICS DRIVER IS EXTREMELY BROKEN!");
+			}
+		}
+
+		protected void LoadGLEntryPoints(string driver)
+		{
+			string baseErrorString;
+			if (useES3)
+			{
+				baseErrorString = "OpenGL ES 3.0";
+			}
+			else
+			{
+				baseErrorString = "OpenGL 2.1";
+			}
+			baseErrorString += " support is required!";
+
+			/* Basic entry points. If you don't have these, you're screwed. */
+			try
+			{
+				glGetIntegerv = (GetIntegerv) GetProcAddress(
+					"glGetIntegerv",
+					typeof(GetIntegerv)
+				);
+				glEnable = (Enable) GetProcAddress(
+					"glEnable",
+					typeof(Enable)
+				);
+				glDisable = (Disable) GetProcAddress(
+					"glDisable",
+					typeof(Disable)
+				);
+				glViewport = (G_Viewport) GetProcAddress(
+					"glViewport",
+					typeof(G_Viewport)
+				);
+				glScissor = (Scissor) GetProcAddress(
+					"glScissor",
+					typeof(Scissor)
+				);
+				glBlendColor = (BlendColor) GetProcAddress(
+					"glBlendColor",
+					typeof(BlendColor)
+				);
+				glBlendFuncSeparate = (BlendFuncSeparate) GetProcAddress(
+					"glBlendFuncSeparate",
+					typeof(BlendFuncSeparate)
+				);
+				glBlendEquationSeparate = (BlendEquationSeparate) GetProcAddress(
+					"glBlendEquationSeparate",
+					typeof(BlendEquationSeparate)
+				);
+				glColorMask = (ColorMask) GetProcAddress(
+					"glColorMask",
+					typeof(ColorMask)
+				);
+				glDepthMask = (DepthMask) GetProcAddress(
+					"glDepthMask",
+					typeof(DepthMask)
+				);
+				glDepthFunc = (DepthFunc) GetProcAddress(
+					"glDepthFunc",
+					typeof(DepthFunc)
+				);
+				glStencilMask = (StencilMask) GetProcAddress(
+					"glStencilMask",
+					typeof(StencilMask)
+				);
+				glStencilFuncSeparate = (StencilFuncSeparate) GetProcAddress(
+					"glStencilFuncSeparate",
+					typeof(StencilFuncSeparate)
+				);
+				glStencilOpSeparate = (StencilOpSeparate) GetProcAddress(
+					"glStencilOpSeparate",
+					typeof(StencilOpSeparate)
+				);
+				glStencilFunc = (StencilFunc) GetProcAddress(
+					"glStencilFunc",
+					typeof(StencilFunc)
+				);
+				glStencilOp = (StencilOp) GetProcAddress(
+					"glStencilOp",
+					typeof(StencilOp)
+				);
+				glFrontFace = (FrontFace) GetProcAddress(
+					"glFrontFace",
+					typeof(FrontFace)
+				);
+				glPolygonOffset = (PolygonOffset) GetProcAddress(
+					"glPolygonOffset",
+					typeof(PolygonOffset)
+				);
+				glGenTextures = (GenTextures) GetProcAddress(
+					"glGenTextures",
+					typeof(GenTextures)
+				);
+				glDeleteTextures = (DeleteTextures) GetProcAddress(
+					"glDeleteTextures",
+					typeof(DeleteTextures)
+				);
+				glBindTexture = (G_BindTexture) GetProcAddress(
+					"glBindTexture",
+					typeof(G_BindTexture)
+				);
+				glTexImage2D = (TexImage2D) GetProcAddress(
+					"glTexImage2D",
+					typeof(TexImage2D)
+				);
+				glTexSubImage2D = (TexSubImage2D) GetProcAddress(
+					"glTexSubImage2D",
+					typeof(TexSubImage2D)
+				);
+				glCompressedTexImage2D = (CompressedTexImage2D) GetProcAddress(
+					"glCompressedTexImage2D",
+					typeof(CompressedTexImage2D)
+				);
+				glCompressedTexSubImage2D = (CompressedTexSubImage2D) GetProcAddress(
+					"glCompressedTexSubImage2D",
+					typeof(CompressedTexSubImage2D)
+				);
+				glTexParameteri = (TexParameteri) GetProcAddress(
+					"glTexParameteri",
+					typeof(TexParameteri)
+				);
+				glTexParameterf = (TexParameterf) GetProcAddress(
+					"glTexParameterf",
+					typeof(TexParameterf)
+				);
+				glActiveTexture = (ActiveTexture) GetProcAddress(
+					"glActiveTexture",
+					typeof(ActiveTexture)
+				);
+				glPixelStorei = (PixelStorei) GetProcAddress(
+					"glPixelStorei",
+					typeof(PixelStorei)
+				);
+				glGenBuffers = (GenBuffers) GetProcAddress(
+					"glGenBuffers",
+					typeof(GenBuffers)
+				);
+				glDeleteBuffers = (DeleteBuffers) GetProcAddress(
+					"glDeleteBuffers",
+					typeof(DeleteBuffers)
+				);
+				glBindBuffer = (BindBuffer) GetProcAddress(
+					"glBindBuffer",
+					typeof(BindBuffer)
+				);
+				glBufferData = (BufferData) GetProcAddress(
+					"glBufferData",
+					typeof(BufferData)
+				);
+				glBufferSubData = (BufferSubData) GetProcAddress(
+					"glBufferSubData",
+					typeof(BufferSubData)
+				);
+				glClearColor = (ClearColor) GetProcAddress(
+					"glClearColor",
+					typeof(ClearColor)
+				);
+				glClearStencil = (ClearStencil) GetProcAddress(
+					"glClearStencil",
+					typeof(ClearStencil)
+				);
+				glClear = (G_Clear) GetProcAddress(
+					"glClear",
+					typeof(G_Clear)
+				);
+				glDrawBuffers = (DrawBuffers) GetProcAddress(
+					"glDrawBuffers",
+					typeof(DrawBuffers)
+				);
+				glReadPixels = (ReadPixels) GetProcAddress(
+					"glReadPixels",
+					typeof(ReadPixels)
+				);
+				glVertexAttribPointer = (VertexAttribPointer) GetProcAddress(
+					"glVertexAttribPointer",
+					typeof(VertexAttribPointer)
+				);
+				glEnableVertexAttribArray = (EnableVertexAttribArray) GetProcAddress(
+					"glEnableVertexAttribArray",
+					typeof(EnableVertexAttribArray)
+				);
+				glDisableVertexAttribArray = (DisableVertexAttribArray) GetProcAddress(
+					"glDisableVertexAttribArray",
+					typeof(DisableVertexAttribArray)
+				);
+				glDrawArrays = (DrawArrays) GetProcAddress(
+					"glDrawArrays",
+					typeof(DrawArrays)
+				);
+
+				// Shaders functions
+				glGetProgramInfoLog = (GetProgramInfoLog)GetProcAddress(
+					"glGetProgramInfoLog",
+					typeof(GetProgramInfoLog)
+				);
+				glCreateProgram = (CreateProgram)GetProcAddress(
+					"glCreateProgram",
+					typeof(CreateProgram)
+				);
+				glCreateShader = (CreateShader)GetProcAddress(
+					"glCreateShader",
+					typeof(CreateShader)
+				);
+				glShaderSource = (ShaderSource)GetProcAddress(
+					"glShaderSource",
+					typeof(ShaderSource)
+				);
+				glCompileShader = (CompileShader)GetProcAddress(
+					"glCompileShader",
+					typeof(CompileShader)
+				);
+				glGetShaderiv = (GetShaderiv)GetProcAddress(
+					"glGetShaderiv",
+					typeof(GetShaderiv)
+				);
+				glGetShaderInfoLog = (GetShaderInfoLog)GetProcAddress(
+					"glGetShaderInfoLog",
+					typeof(GetShaderInfoLog)
+				);
+				glUseProgram = (UseProgram)GetProcAddress(
+					"glUseProgram",
+					typeof(UseProgram)
+				);
+				glDeleteShader = (DeleteShaderDelegate)GetProcAddress(
+					"glDeleteShader",
+					typeof(DeleteShaderDelegate)
+				);
+				glDeleteProgram = (DeleteProgram)GetProcAddress(
+					"glDeleteProgram",
+					typeof(DeleteProgram)
+				);
+				glAttachShader = (AttachShader)GetProcAddress(
+					"glAttachShader",
+					typeof(AttachShader)
+				);
+				glLinkProgram = (LinkProgram)GetProcAddress(
+					"glLinkProgram",
+					typeof(LinkProgram)
+				);
+				glGetProgramiv = (GetProgramiv)GetProcAddress(
+					"glGetProgramiv",
+					typeof(GetProgramiv)
+				);
+				glGetAttribLocation = (GetAttribLocation)GetProcAddress(
+					"glGetAttribLocation",
+					typeof(GetAttribLocation)
+				);
+				glGetUniformLocation = (GetUniformLocation)GetProcAddress(
+					"glGetUniformLocation",
+					typeof(GetUniformLocation)
+				);
+				glUniform1i = (Uniform1i)GetProcAddress(
+					"glUniform1i",
+					typeof(Uniform1i)
+				);
+				glUniform2i = (Uniform2i)GetProcAddress(
+					"glUniform2i",
+					typeof(Uniform2i)
+				);
+				glUniform3i = (Uniform3i)GetProcAddress(
+					"glUniform3i",
+					typeof(Uniform3i)
+				);
+				glUniform4i = (Uniform4i)GetProcAddress(
+					"glUniform4i",
+					typeof(Uniform4i)
+				);
+				glUniform1f = (Uniform1f)GetProcAddress(
+					"glUniform1f",
+					typeof(Uniform1f)
+				);
+				glUniform2f = (Uniform2f)GetProcAddress(
+					"glUniform2f",
+					typeof(Uniform2f)
+				);
+				glUniform3f = (Uniform3f)GetProcAddress(
+					"glUniform3f",
+					typeof(Uniform3f)
+				);
+				glUniform4f = (Uniform4f)GetProcAddress(
+					"glUniform4f",
+					typeof(Uniform4f)
+				);
+				glUniform1fv = (Uniform1fv)GetProcAddress(
+					"glUniform1fv",
+					typeof(Uniform1fv)
+				);
+				glUniform2fv = (Uniform2fv)GetProcAddress(
+					"glUniform2fv",
+					typeof(Uniform2fv)
+				);
+				glUniform3fv = (Uniform3fv)GetProcAddress(
+					"glUniform3fv",
+					typeof(Uniform3fv)
+				);
+				glUniform4fv = (Uniform4fv)GetProcAddress(
+					"glUniform4fv",
+					typeof(Uniform4fv)
+				);
+				glUniformMatrix4fv = (UniformMatrix4fv)GetProcAddress(
+					"glUniformMatrix4fv",
+					typeof(UniformMatrix4fv)
+				);
+				glGetActiveUniform = (GetActiveUniform)GetProcAddress(
+					"glGetActiveUniform",
+					typeof(GetActiveUniform)
+				);
+				glGetActiveAttrib = (GetActiveAttrib)GetProcAddress(
+					"glGetActiveAttrib",
+					typeof(GetActiveAttrib)
+				);
+			}
+			catch (Exception e)
+			{
+				throw new NoSuitableGraphicsDeviceException(
+					baseErrorString +
+					"\nEntry Point: " + e.Message +
+					"\n" + driver
+				);
+			}
+
+			/* ARB_draw_elements_base_vertex is ideal! */
+			IntPtr ep = SDL.SDL_GL_GetProcAddress("glDrawRangeElementsBaseVertex");
+			if (ep == IntPtr.Zero)
+			{
+				ep = SDL.SDL_GL_GetProcAddress("glDrawRangeElementsBaseVertexOES");
+			}
+			supportsBaseVertex = ep != IntPtr.Zero;
+			if (supportsBaseVertex)
+			{
+				glDrawRangeElementsBaseVertex = (DrawRangeElementsBaseVertex) Marshal.GetDelegateForFunctionPointer(
+					ep,
+					typeof(DrawRangeElementsBaseVertex)
+				);
+				glDrawRangeElements = (DrawRangeElements) GetProcAddress(
+					"glDrawRangeElements",
+					typeof(DrawRangeElements)
+				);
+			}
+			else
+			{
+				/* DrawRangeElements is better, and ES3+ should have this */
+				ep = SDL.SDL_GL_GetProcAddress("glDrawRangeElements");
+				if (ep != IntPtr.Zero)
+				{
+					glDrawRangeElements = (DrawRangeElements) Marshal.GetDelegateForFunctionPointer(
+						ep,
+						typeof(DrawRangeElements)
+					);
+					glDrawRangeElementsBaseVertex = DrawRangeElementsNoBase;
+				}
+				else
+				{
+					try
+					{
+						glDrawElements = (DrawElements) GetProcAddress(
+							"glDrawElements",
+							typeof(DrawElements)
+						);
+					}
+					catch (Exception e)
+					{
+						throw new NoSuitableGraphicsDeviceException(
+							baseErrorString +
+							"\nEntry Point: " + e.Message +
+							"\n" + driver
+						);
+					}
+					glDrawRangeElements = DrawRangeElementsUnchecked;
+					glDrawRangeElementsBaseVertex = DrawRangeElementsNoBaseUnchecked;
+				}
+			}
+
+			/* These functions are NOT supported in ES.
+			 * NVIDIA or desktop ES might, but real scenarios where you need ES
+			 * will certainly not have these.
+			 * -flibit
+			 */
+			if (useES3)
+			{
+				ep = SDL.SDL_GL_GetProcAddress("glPolygonMode");
+				if (ep != IntPtr.Zero)
+				{
+					glPolygonMode = (PolygonMode) Marshal.GetDelegateForFunctionPointer(
+						ep,
+						typeof(PolygonMode)
+					);
+				}
+				else
+				{
+					glPolygonMode = PolygonModeESError;
+				}
+				ep = SDL.SDL_GL_GetProcAddress("glGetTexImage");
+				if (ep != IntPtr.Zero)
+				{
+					glGetTexImage = (GetTexImage) Marshal.GetDelegateForFunctionPointer(
+						ep,
+						typeof(GetTexImage)
+					);
+				}
+				else
+				{
+					glGetTexImage = GetTexImageESError;
+				}
+				ep = SDL.SDL_GL_GetProcAddress("glGetBufferSubData");
+				if (ep != IntPtr.Zero)
+				{
+					glGetBufferSubData = (GetBufferSubData) Marshal.GetDelegateForFunctionPointer(
+						ep,
+						typeof(GetBufferSubData)
+					);
+				}
+				else
+				{
+					glGetBufferSubData = GetBufferSubDataESError;
+				}
+			}
+			else
+			{
+				try
+				{
+					glPolygonMode = (PolygonMode) GetProcAddress(
+						"glPolygonMode",
+						typeof(PolygonMode)
+					);
+					glGetTexImage = (GetTexImage) GetProcAddress(
+						"glGetTexImage",
+						typeof(GetTexImage)
+					);
+					glGetBufferSubData = (GetBufferSubData) GetProcAddress(
+						"glGetBufferSubData",
+						typeof(GetBufferSubData)
+					);
+				}
+				catch(Exception e)
+				{
+					throw new NoSuitableGraphicsDeviceException(
+						baseErrorString +
+						"\nEntry Point: " + e.Message +
+						"\n" + driver
+					);
+				}
+			}
+
+			/* We need _some_ form of depth range, ES... */
+			IntPtr drPtr = SDL.SDL_GL_GetProcAddress("glDepthRange");
+			if (drPtr != IntPtr.Zero)
+			{
+				glDepthRange = (DepthRange) Marshal.GetDelegateForFunctionPointer(
+					drPtr,
+					typeof(DepthRange)
+				);
+			}
+			else
+			{
+				try
+				{
+					glDepthRangef = (DepthRangef) GetProcAddress(
+						"glDepthRangef",
+						typeof(DepthRangef)
+					);
+				}
+				catch(Exception e)
+				{
+					throw new NoSuitableGraphicsDeviceException(
+						baseErrorString +
+						"\nEntry Point: " + e.Message +
+						"\n" + driver
+					);
+				}
+				glDepthRange = DepthRangeFloat;
+			}
+			drPtr = SDL.SDL_GL_GetProcAddress("glClearDepth");
+			if (drPtr != IntPtr.Zero)
+			{
+				glClearDepth = (ClearDepth) Marshal.GetDelegateForFunctionPointer(
+					drPtr,
+					typeof(ClearDepth)
+				);
+			}
+			else
+			{
+				try
+				{
+					glClearDepthf = (ClearDepthf) GetProcAddress(
+						"glClearDepthf",
+						typeof(ClearDepthf)
+					);
+				}
+				catch (Exception e)
+				{
+					throw new NoSuitableGraphicsDeviceException(
+						baseErrorString +
+						"\nEntry Point: " + e.Message +
+						"\n" + driver
+					);
+				}
+				glClearDepth = ClearDepthFloat;
+			}
+
+			/* Silently fail if using GLES. You didn't need these, right...? >_> */
+			try
+			{
+				glTexImage3D = (TexImage3D) GetProcAddressEXT(
+					"glTexImage3D",
+					typeof(TexImage3D),
+					"OES"
+				);
+				glTexSubImage3D = (TexSubImage3D) GetProcAddressEXT(
+					"glTexSubImage3D",
+					typeof(TexSubImage3D),
+					"OES"
+				);
+				glGenQueries = (GenQueries) GetProcAddress(
+					"glGenQueries",
+					typeof(GenQueries)
+				);
+				glDeleteQueries = (DeleteQueries) GetProcAddress(
+					"glDeleteQueries",
+					typeof(DeleteQueries)
+				);
+				glBeginQuery = (BeginQuery) GetProcAddress(
+					"glBeginQuery",
+					typeof(BeginQuery)
+				);
+				glEndQuery = (EndQuery) GetProcAddress(
+					"glEndQuery",
+					typeof(EndQuery)
+				);
+				glGetQueryObjectuiv = (GetQueryObjectuiv) GetProcAddress(
+					"glGetQueryObjectuiv",
+					typeof(GetQueryObjectuiv)
+				);
+			}
+			catch
+			{
+				if (useES3)
+				{
+					FNALoggerEXT.LogWarn("Some non-ES functions failed to load. Beware...");
+				}
+				else
+				{
+					throw new NoSuitableGraphicsDeviceException(
+						baseErrorString +
+						"\nFailed on Tex3D/Query entries\n" +
+						driver
+					);
+				}
+			}
+
+			/* ARB_framebuffer_object. We're flexible, but not _that_ flexible. */
+			try
+			{
+				glGenFramebuffers = (GenFramebuffers) GetProcAddressEXT(
+					"glGenFramebuffers",
+					typeof(GenFramebuffers)
+				);
+				glDeleteFramebuffers = (DeleteFramebuffers) GetProcAddressEXT(
+					"glDeleteFramebuffers",
+					typeof(DeleteFramebuffers)
+				);
+				glBindFramebuffer = (G_BindFramebuffer) GetProcAddressEXT(
+					"glBindFramebuffer",
+					typeof(G_BindFramebuffer)
+				);
+				glFramebufferTexture2D = (FramebufferTexture2D) GetProcAddressEXT(
+					"glFramebufferTexture2D",
+					typeof(FramebufferTexture2D)
+				);
+				glFramebufferRenderbuffer = (FramebufferRenderbuffer) GetProcAddressEXT(
+					"glFramebufferRenderbuffer",
+					typeof(FramebufferRenderbuffer)
+				);
+				glGenerateMipmap = (GenerateMipmap) GetProcAddressEXT(
+					"glGenerateMipmap",
+					typeof(GenerateMipmap)
+				);
+				glGenRenderbuffers = (GenRenderbuffers) GetProcAddressEXT(
+					"glGenRenderbuffers",
+					typeof(GenRenderbuffers)
+				);
+				glDeleteRenderbuffers = (DeleteRenderbuffers) GetProcAddressEXT(
+					"glDeleteRenderbuffers",
+					typeof(DeleteRenderbuffers)
+				);
+				glBindRenderbuffer = (BindRenderbuffer) GetProcAddressEXT(
+					"glBindRenderbuffer",
+					typeof(BindRenderbuffer)
+				);
+				glRenderbufferStorage = (RenderbufferStorage) GetProcAddressEXT(
+					"glRenderbufferStorage",
+					typeof(RenderbufferStorage)
+				);
+			}
+			catch
+			{
+				throw new NoSuitableGraphicsDeviceException("OpenGL framebuffer support is required!");
+			}
+
+			/* EXT_framebuffer_blit (or ARB_framebuffer_object) is needed by the faux-backbuffer. */
+			supportsFauxBackbuffer = true;
+			try
+			{
+				glBlitFramebuffer = (BlitFramebuffer) GetProcAddressEXT(
+					"glBlitFramebuffer",
+					typeof(BlitFramebuffer)
+				);
+			}
+			catch
+			{
+				supportsFauxBackbuffer = false;
+			}
+
+			/* EXT_framebuffer_multisample (or ARB_framebuffer_object) is glitter */
+			supportsMultisampling = true;
+			try
+			{
+				glRenderbufferStorageMultisample = (RenderbufferStorageMultisample) GetProcAddressEXT(
+					"glRenderbufferStorageMultisample",
+					typeof(RenderbufferStorageMultisample)
+				);
+			}
+			catch
+			{
+				supportsMultisampling = false;
+			}
+
+			/* ARB_instanced_arrays/ARB_draw_instanced are almost optional. */
+			SupportsHardwareInstancing = true;
+			try
+			{
+				glVertexAttribDivisor = (VertexAttribDivisor) GetProcAddress(
+					"glVertexAttribDivisor",
+					typeof(VertexAttribDivisor)
+				);
+				/* The likelihood of someone having BaseVertex but not Instanced is 0...? */
+				if (supportsBaseVertex)
+				{
+					glDrawElementsInstancedBaseVertex = (DrawElementsInstancedBaseVertex) Marshal.GetDelegateForFunctionPointer(
+						SDL.SDL_GL_GetProcAddress("glDrawElementsInstancedBaseVertex"),
+						typeof(DrawElementsInstancedBaseVertex)
+					);
+				}
+				else
+				{
+					glDrawElementsInstanced = (DrawElementsInstanced) Marshal.GetDelegateForFunctionPointer(
+						SDL.SDL_GL_GetProcAddress("glDrawElementsInstanced"),
+						typeof(DrawElementsInstanced)
+					);
+					glDrawElementsInstancedBaseVertex = DrawElementsInstancedNoBase;
+				}
+			}
+			catch
+			{
+				SupportsHardwareInstancing = false;
+			}
+
+			/* Indexed color mask is a weird thing.
+			 * IndexedEXT was introduced in EXT_draw_buffers2, then
+			 * it was introduced in GL 3.0 as "ColorMaski" with no
+			 * extension at all, and OpenGL ES introduced it as
+			 * ColorMaskiEXT via EXT_draw_buffers_indexed and AGAIN
+			 * as ColorMaskiOES via OES_draw_buffers_indexed at the
+			 * exact same time. WTF.
+			 * -flibit
+			 */
+			IntPtr cm = SDL.SDL_GL_GetProcAddress("glColorMaski");
+			if (cm == IntPtr.Zero)
+			{
+				cm = SDL.SDL_GL_GetProcAddress("glColorMaskIndexedEXT");
+			}
+			if (cm == IntPtr.Zero)
+			{
+				cm = SDL.SDL_GL_GetProcAddress("glColorMaskiOES");
+			}
+			if (cm == IntPtr.Zero)
+			{
+				cm = SDL.SDL_GL_GetProcAddress("glColorMaskiEXT");
+			}
+			try
+			{
+				glColorMaski = (ColorMaski) Marshal.GetDelegateForFunctionPointer(
+					cm,
+					typeof(ColorMaski)
+				);
+			}
+			catch
+			{
+				// FIXME: SupportsIndependentWriteMasks? -flibit
+			}
+
+			/* ARB_texture_multisample is probably used by nobody. */
+			try
+			{
+				glSampleMaski = (SampleMaski) GetProcAddress(
+					"glSampleMaski",
+					typeof(SampleMaski)
+				);
+			}
+			catch
+			{
+				// FIXME: SupportsMultisampleMasks? -flibit
+			}
+
+			if (useCoreProfile)
+			{
+				try
+				{
+					INTERNAL_glGetStringi = (GetStringi) GetProcAddress(
+						"glGetStringi",
+						typeof(GetStringi)
+					);
+					glGenVertexArrays = (GenVertexArrays) GetProcAddress(
+						"glGenVertexArrays",
+						typeof(GenVertexArrays)
+					);
+					glDeleteVertexArrays = (DeleteVertexArrays) GetProcAddress(
+						"glDeleteVertexArrays",
+						typeof(DeleteVertexArrays)
+					);
+					glBindVertexArray = (BindVertexArray) GetProcAddress(
+						"glBindVertexArray",
+						typeof(BindVertexArray)
+					);
+				}
+				catch
+				{
+					throw new NoSuitableGraphicsDeviceException("OpenGL 3.2 support is required!");
+				}
+			}
+
+#if DEBUG
+			/* ARB_debug_output/KHR_debug, for debug contexts */
+			bool supportsDebug = true;
+			IntPtr messageCallback;
+			IntPtr messageControl;
+
+			/* Try KHR_debug first...
+			 *
+			 * "NOTE: when implemented in an OpenGL ES context, all entry points defined
+			 * by this extension must have a "KHR" suffix. When implemented in an
+			 * OpenGL context, all entry points must have NO suffix, as shown below."
+			 * https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_debug.txt
+			 */
+			if (useES3)
+			{
+				messageCallback = SDL.SDL_GL_GetProcAddress("glDebugMessageCallbackKHR");
+				messageControl = SDL.SDL_GL_GetProcAddress("glDebugMessageControlKHR");
+			}
+			else
+			{
+				messageCallback = SDL.SDL_GL_GetProcAddress("glDebugMessageCallback");
+				messageControl = SDL.SDL_GL_GetProcAddress("glDebugMessageControl");
+			}
+			if (messageCallback == IntPtr.Zero || messageControl == IntPtr.Zero)
+			{
+				/* ... then try ARB_debug_output. */
+				messageCallback = SDL.SDL_GL_GetProcAddress("glDebugMessageCallbackARB");
+				messageControl = SDL.SDL_GL_GetProcAddress("glDebugMessageControlARB");
+			}
+			if (messageCallback == IntPtr.Zero || messageControl == IntPtr.Zero)
+			{
+				supportsDebug = false;
+			}
+
+			/* Android developers are incredibly stupid and export stub functions */
+			if (useES3)
+			{
+				if (	SDL.SDL_GL_ExtensionSupported("KHR_debug") == SDL.SDL_bool.SDL_FALSE &&
+					SDL.SDL_GL_ExtensionSupported("ARB_debug_output") == SDL.SDL_bool.SDL_FALSE	)
+				{
+					supportsDebug = false;
+				}
+			}
+
+			/* Set the callback, finally. */
+			if (!supportsDebug)
+			{
+				FNALoggerEXT.LogWarn("ARB_debug_output/KHR_debug not supported!");
+			}
+			else
+			{
+				glDebugMessageCallback = (DebugMessageCallback) Marshal.GetDelegateForFunctionPointer(
+					messageCallback,
+					typeof(DebugMessageCallback)
+				);
+				glDebugMessageControl = (DebugMessageControl) Marshal.GetDelegateForFunctionPointer(
+					messageControl,
+					typeof(DebugMessageControl)
+				);
+				glDebugMessageControl(
+					GLenum.GL_DONT_CARE,
+					GLenum.GL_DONT_CARE,
+					GLenum.GL_DONT_CARE,
+					0,
+					IntPtr.Zero,
+					true
+				);
+				glDebugMessageControl(
+					GLenum.GL_DONT_CARE,
+					GLenum.GL_DEBUG_TYPE_OTHER,
+					GLenum.GL_DEBUG_SEVERITY_LOW,
+					0,
+					IntPtr.Zero,
+					false
+				);
+				glDebugMessageControl(
+					GLenum.GL_DONT_CARE,
+					GLenum.GL_DEBUG_TYPE_OTHER,
+					GLenum.GL_DEBUG_SEVERITY_NOTIFICATION,
+					0,
+					IntPtr.Zero,
+					false
+				);
+				glDebugMessageCallback(Marshal.GetFunctionPointerForDelegate(DebugCall), IntPtr.Zero);
+			}
+
+			/* GREMEDY_string_marker, for apitrace */
+			IntPtr stringMarkerCallback = SDL.SDL_GL_GetProcAddress("glStringMarkerGREMEDY");
+			if (stringMarkerCallback == IntPtr.Zero)
+			{
+				FNALoggerEXT.LogWarn("GREMEDY_string_marker not supported!");
+			}
+			else
+			{
+				glStringMarkerGREMEDY = (StringMarkerGREMEDY) Marshal.GetDelegateForFunctionPointer(
+					stringMarkerCallback,
+					typeof(StringMarkerGREMEDY)
+				);
+			}
+#endif
+		}
+
+		protected Delegate GetProcAddress(string name, Type type)
+		{
+			IntPtr addr = SDL.SDL_GL_GetProcAddress(name);
+			if (addr == IntPtr.Zero)
+			{
+				throw new Exception(name);
+			}
+			return Marshal.GetDelegateForFunctionPointer(addr, type);
+		}
+
+		private Delegate GetProcAddressEXT(string name, Type type, string ext = "EXT")
+		{
+			IntPtr addr = SDL.SDL_GL_GetProcAddress(name);
+			if (addr == IntPtr.Zero)
+			{
+				addr = SDL.SDL_GL_GetProcAddress(name + ext);
+			}
+			if (addr == IntPtr.Zero)
+			{
+				throw new Exception(name);
+			}
+			return Marshal.GetDelegateForFunctionPointer(addr, type);
+		}
+
+		public void DrawRangeElementsNoBase(
+			GLenum mode,
+			int start,
+			int end,
+			int count,
+			GLenum type,
+			IntPtr indices,
+			int baseVertex
+		) {
+			glDrawRangeElements(
+				mode,
+				start,
+				end,
+				count,
+				type,
+				indices
+			);
+		}
+
+		public void DrawRangeElementsNoBaseUnchecked(
+			GLenum mode,
+			int start,
+			int end,
+			int count,
+			GLenum type,
+			IntPtr indices,
+			int baseVertex
+		) {
+			glDrawElements(
+				mode,
+				count,
+				type,
+				indices
+			);
+		}
+
+		public void DrawRangeElementsUnchecked(
+			GLenum mode,
+			int start,
+			int end,
+			int count,
+			GLenum type,
+			IntPtr indices
+		) {
+			glDrawElements(
+				mode,
+				count,
+				type,
+				indices
+			);
+		}
+
+		public void DrawElementsInstancedNoBase(
+			GLenum mode,
+			int count,
+			GLenum type,
+			IntPtr indices,
+			int instanceCount,
+			int baseVertex
+		) {
+			glDrawElementsInstanced(
+				mode,
+				count,
+				type,
+				indices,
+				instanceCount
+			);
+		}
+
+		public void DepthRangeFloat(double near, double far)
+		{
+			glDepthRangef((float) near, (float) far);
+		}
+
+		public void ClearDepthFloat(double depth)
+		{
+			glClearDepthf((float) depth);
+		}
+
+		public void PolygonModeESError(GLenum face, GLenum mode)
+		{
+			throw new NotSupportedException("glPolygonMode is not available in ES!");
+		}
+
+		public void GetTexImageESError(
+			GLenum target,
+			int level,
+			GLenum format,
+			GLenum type,
+			IntPtr pixels
+		) {
+			throw new NotSupportedException("glGetTexImage is not available in ES!");
+		}
+
+		public void GetBufferSubDataESError(
+			GLenum target,
+			IntPtr offset,
+			IntPtr size,
+			IntPtr data
+		) {
+			throw new NotSupportedException("glGetBufferSubData is not available in ES!");
+		}
+
+		#endregion
+	}
+}

--- a/src/Graphics/Shader.cs
+++ b/src/Graphics/Shader.cs
@@ -1,0 +1,852 @@
+﻿#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2018 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+/* This code is based on the code borrowed from LibGDX: https://github.com/libgdx/libgdx */
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using static Microsoft.Xna.Framework.Graphics.ShaderGLDevice;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	/// <summary>
+	/// <p>
+	/// A shader program encapsulates a vertex and fragment shader pair linked to form a shader program.
+	/// </summary>
+	/// <remarks>
+	/// <p>
+	/// A shader program encapsulates a vertex and fragment shader pair linked to form a shader program.
+	/// </p>
+	/// <p>
+	/// After construction a Shader can be used to draw
+	/// <see cref="Mesh"/>
+	/// . To make the GPU use a specific Shader the programs
+	/// <see cref="Apply"/>
+	/// method must be used which effectively binds the program.
+	/// </p>
+	/// <p>
+	/// When a Shader is bound one can set uniforms, vertex attributes and attributes as needed via the respective methods.
+	/// </p>
+	/// <p>
+	/// A Shader can be unbound with a call to
+	/// <see cref="End"/>
+	/// </p>
+	/// <p>
+	/// A Shader must be disposed via a call to
+	/// <see cref="dispose()"/>
+	/// when it is no longer needed
+	/// </p>
+	/// <p>
+	/// Shaders are managed. In case the OpenGL context is lost all shaders get invalidated and have to be reloaded. This
+	/// happens on Android when a user switches to another application or receives an incoming call. Managed Shaders are
+	/// automatically reloaded when the OpenGL context is recreated so you don't have to do this manually.
+	/// </p>
+	/// </remarks>
+	/// <author>author of the original Java code: mzechner</author>
+	public class Shader : GraphicsResource, IGLEffect
+	{
+		public class Uniform
+		{
+			public int Location;
+			public int Type;
+			public int Size;
+		}
+
+		/// <summary>the log</summary>
+		private string _log = string.Empty;
+
+		/// <summary>uniform lookup</summary>
+		private readonly Dictionary<string, Uniform> _uniforms = new Dictionary<string, Uniform>();
+
+		/// <summary>attribute lookup</summary>
+		private readonly Dictionary<string, Uniform> _attributes = new Dictionary<string, Uniform>();
+
+		/// <summary>program handle</summary>
+		private int _programHandle;
+
+		/// <summary>vertex shader handle</summary>
+		private int _vertexShaderHandle;
+
+		/// <summary>fragment shader handle</summary>
+		private int _fragmentShaderHandle;
+
+		/// <summary>vertex shader source</summary>
+		private readonly string _vertexShaderSource;
+
+		/// <summary>fragment shader source</summary>
+		private readonly string _fragmentShaderSource;
+
+		/// <summary>whether this shader was invalidated</summary>
+		private bool _invalidated;
+
+		private readonly Dictionary<VertexElementUsage, int> _attributesLocation = new Dictionary<VertexElementUsage, int>();
+
+		/// <summary>code that is always added to the vertex shader code, typically used to inject a #version line.
+		/// 	</summary>
+		/// <remarks>
+		/// code that is always added to the vertex shader code, typically used to inject a #version line. Note that this is added
+		/// as-is, you should include a newline (`\n`) if needed.
+		/// </remarks>
+		public static string PrependVertexCode = string.Empty;
+
+		/// <summary>code that is always added to every fragment shader code, typically used to inject a #version line.
+		/// 	</summary>
+		/// <remarks>
+		/// code that is always added to every fragment shader code, typically used to inject a #version line. Note that this is added
+		/// as-is, you should include a newline (`\n`) if needed.
+		/// </remarks>
+		public static string PrependFragmentCode = string.Empty;
+
+		private readonly ShaderGLDevice _device;
+
+		/// <returns>
+		/// the log info for the shader compilation and program linking stage. The shader needs to be bound for this method to
+		/// have an effect.
+		/// </returns>
+		public string Log
+		{
+			get
+			{
+				if (string.IsNullOrEmpty(_log))
+				{
+					_log = GetProgramInfoLog(_programHandle);
+				}
+
+				return _log;
+			}
+		}
+
+		internal int ProgramHandle
+		{
+			get { return _programHandle; }
+		}
+
+		internal int VertexShaderHandle
+		{
+			get { return _vertexShaderHandle; }
+		}
+
+		internal int FragmentShaderHandle
+		{
+			get { return _fragmentShaderHandle; }
+		}
+
+		public string VertexShaderSource
+		{
+			get { return _vertexShaderSource; }
+		}
+
+		public string FragmentShaderSource
+		{
+			get { return _fragmentShaderSource; }
+		}
+
+		public Dictionary<string, Uniform> Uniforms
+		{
+			get { return _uniforms; }
+		}
+
+		public Dictionary<string, Uniform> Attributes
+		{
+			get { return _attributes; }
+		}
+
+		internal Dictionary<VertexElementUsage, int> AttributesLocations
+		{
+			get { return _attributesLocation; }
+		}
+
+		public IntPtr EffectData
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		/// <summary>Constructs a new Shader and immediately compiles it.</summary>
+		/// <param name="device"></param>
+		/// <param name="vertexShader">the vertex shader</param>
+		/// <param name="fragmentShader">the fragment shader</param>
+		/// <param name="attributesUsage"></param>
+		public Shader(GraphicsDevice device, string vertexShader, string fragmentShader, Dictionary<string, VertexElementUsage> attributesUsage)
+		{
+			if (device == null)
+			{
+				throw new ArgumentNullException("graphicsDevice");
+			}
+			if (vertexShader == null)
+			{
+				throw new ArgumentNullException("vertexShader");
+			}
+			if (fragmentShader == null)
+			{
+				throw new ArgumentNullException("fragmentShader");
+			}
+
+			if (attributesUsage == null)
+			{
+				throw new ArgumentNullException("attributesUsage");
+			}
+
+			GraphicsDevice = device;
+			_device = (ShaderGLDevice)device.GLDevice;
+
+			if (!string.IsNullOrEmpty(PrependVertexCode))
+			{
+				vertexShader = PrependVertexCode + vertexShader;
+			}
+			if (!string.IsNullOrEmpty(PrependFragmentCode))
+			{
+				fragmentShader = PrependFragmentCode + fragmentShader;
+			}
+			_vertexShaderSource = vertexShader;
+			_fragmentShaderSource = fragmentShader;
+			CompileShaders(vertexShader, fragmentShader);
+			FetchAttributes();
+			FetchUniforms();
+
+			// Build attributes map
+			foreach(var pair in attributesUsage)
+			{
+				var attribute = _attributes[pair.Key];
+
+				_attributesLocation[pair.Value] = attribute.Location;
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (!IsDisposed)
+			{
+				GraphicsDevice.GLDevice.AddDisposeEffect(this);
+			}
+			base.Dispose(disposing);
+		}
+
+		/// <summary>Loads and compiles the shaders, creates a new program and links the shaders.
+		/// 	</summary>
+		/// <param name="vertexShader"/>
+		/// <param name="fragmentShader"></param>
+		private void CompileShaders(string vertexShader, string fragmentShader)
+		{
+			_vertexShaderHandle = LoadShader(GLenum.GL_VERTEX_SHADER, vertexShader);
+			_fragmentShaderHandle = LoadShader(GLenum.GL_FRAGMENT_SHADER, fragmentShader);
+			_programHandle = LinkProgram(_device.glCreateProgram());
+		}
+
+		private int LoadShader(GLenum type, string source)
+		{
+			var shader = _device.glCreateShader(type);
+			if (shader == 0)
+			{
+				throw new Exception(string.Format("glCreateShader({0})", type));
+			}
+
+			unsafe
+			{
+				var hGlobal = Marshal.StringToHGlobalAnsi(source);
+				var ptr = (sbyte*)hGlobal;
+				_device.glShaderSource(shader, 1, &ptr, null);
+				Marshal.FreeHGlobal(hGlobal);
+			}
+
+			_device.glCompileShader(shader);
+			int compiled;
+
+			unsafe
+			{
+				_device.glGetShaderiv(shader, GLenum.GL_COMPILE_STATUS, &compiled);
+			}
+
+			if (compiled == 0)
+			{
+				var _byteBuffer = new byte[256];
+				unsafe
+				{
+					fixed (byte* ptr = _byteBuffer)
+					{
+						int length;
+						_device.glGetShaderInfoLog(_programHandle, _byteBuffer.Length, &length, (sbyte*)ptr);
+
+						var infoLog = Marshal.PtrToStringAnsi(new IntPtr(ptr), length);
+						throw new Exception(infoLog);
+					}
+				}
+			}
+			return shader;
+		}
+
+		private string GetProgramInfoLog(int program)
+		{
+			unsafe
+			{
+				var byteBuffer = new byte[256];
+
+				fixed (byte* ptr = byteBuffer)
+				{
+					int length;
+					_device.glGetProgramInfoLog(program, byteBuffer.Length, &length, (sbyte*)ptr);
+
+					var name = Marshal.PtrToStringAnsi(new IntPtr(ptr), length);
+
+					return name;
+				}
+			}
+		}
+
+		private int LinkProgram(int program)
+		{
+			_device.glAttachShader(program, _vertexShaderHandle);
+			_device.glAttachShader(program, _fragmentShaderHandle);
+			_device.glLinkProgram(program);
+
+			int linked;
+			unsafe
+			{
+				_device.glGetProgramiv(program, GLenum.GL_LINK_STATUS, &linked);
+			}
+			if (linked == 0)
+			{
+				throw new Exception(GetProgramInfoLog(program));
+			}
+			return program;
+		}
+
+		private unsafe int GetAttribLocation(int program, string name)
+		{
+			var hGlobal = Marshal.StringToHGlobalAnsi(name);
+			var result = _device.glGetAttribLocation(program, (sbyte*)hGlobal);
+			Marshal.FreeHGlobal(hGlobal);
+
+			return result;
+		}
+
+		public Uniform FetchAttribute(string name)
+		{
+			Uniform attribute;
+			if (_attributes.TryGetValue(name, out attribute))
+				return attribute;
+
+			var location = GetAttribLocation(_programHandle, name);
+			if (location == -1)
+			{
+				return null;
+			}
+
+			attribute = new Uniform
+			{
+				Location = location
+			};
+
+			_attributes[name] = attribute;
+			return attribute;
+		}
+
+		private unsafe int GetUniformLocation(int program, string name)
+		{
+			var hGlobal = Marshal.StringToHGlobalAnsi(name);
+			var result = _device.glGetUniformLocation(program, (sbyte*)hGlobal);
+			Marshal.FreeHGlobal(hGlobal);
+
+			return result;
+		}
+
+		public Uniform FetchUniform(string name)
+		{
+			Uniform uniform;
+			if (_uniforms.TryGetValue(name, out uniform))
+				return uniform;
+
+			var location = GetUniformLocation(_programHandle, name);
+			if (location == -1)
+			{
+				return null;
+			}
+
+			uniform = new Uniform
+			{
+				Location = location
+			};
+
+			_uniforms[name] = uniform;
+			return uniform;
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value">the value</param>
+		public void SetUniformi(string name, int value)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform1i(uniform.Location, value);
+		}
+
+		public void SetUniformi(int location, int value)
+		{
+			CheckManaged();
+			_device.glUniform1i(location, value);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value1">the first value</param>
+		/// <param name="value2">the second value</param>
+		public void SetUniformi(string name, int value1, int value2)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform2i(uniform.Location, value1, value2);
+		}
+
+		public void SetUniformi(int location, int value1, int value2)
+		{
+			CheckManaged();
+			_device.glUniform2i(location, value1, value2);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value1">the first value</param>
+		/// <param name="value2">the second value</param>
+		/// <param name="value3">the third value</param>
+		public void SetUniformi(string name, int value1, int value2, int value3)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform3i(uniform.Location, value1, value2, value3);
+		}
+
+		public void SetUniformi(int location, int value1, int value2, int value3)
+		{
+			CheckManaged();
+			_device.glUniform3i(location, value1, value2, value3);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value1">the first value</param>
+		/// <param name="value2">the second value</param>
+		/// <param name="value3">the third value</param>
+		/// <param name="value4">the fourth value</param>
+		public void SetUniformi(string name, int value1, int value2, int value3, int value4)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform4i(uniform.Location, value1, value2, value3, value4);
+		}
+
+		public void SetUniformi(int location, int value1, int value2, int value3, int value4)
+		{
+			CheckManaged();
+			_device.glUniform4i(location, value1, value2, value3, value4);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value">the value</param>
+		public void SetUniformf(string name, float value)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform1f(uniform.Location, value);
+		}
+
+		public void SetUniformf(int location, float value)
+		{
+			CheckManaged();
+			_device.glUniform1f(location, value);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value1">the first value</param>
+		/// <param name="value2">the second value</param>
+		public void SetUniformf(string name, float value1, float value2)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform2f(uniform.Location, value1, value2);
+		}
+
+		public void SetUniformf(int location, float value1, float value2)
+		{
+			CheckManaged();
+			_device.glUniform2f(location, value1, value2);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value1">the first value</param>
+		/// <param name="value2">the second value</param>
+		/// <param name="value3">the third value</param>
+		public void SetUniformf(string name, float value1, float value2, float value3)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform3f(uniform.Location, value1, value2, value3);
+		}
+
+		public void SetUniformf(int location, float value1, float value2, float value3)
+		{
+			CheckManaged();
+			_device.glUniform3f(location, value1, value2, value3);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="value1">the first value</param>
+		/// <param name="value2">the second value</param>
+		/// <param name="value3">the third value</param>
+		/// <param name="value4">the fourth value</param>
+		public void SetUniformf(string name, float value1, float value2, float value3, float value4)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			_device.glUniform4f(uniform.Location, value1, value2, value3, value4);
+		}
+
+		public void SetUniformf(int location, float value1, float value2, float value3, float value4)
+		{
+			CheckManaged();
+			_device.glUniform4f(location, value1, value2, value3, value4);
+		}
+
+		private unsafe void Uniform1fv(int location, int count, float[] v, int offset)
+		{
+			fixed (float* ptr = &v[offset])
+			{
+				_device.glUniform1fv(location, count, ptr);
+			}
+		}
+
+		private unsafe void Uniform2fv(int location, int count, float[] v, int offset)
+		{
+			fixed (float* ptr = &v[offset])
+			{
+				_device.glUniform2fv(location, count, ptr);
+			}
+		}
+
+		private unsafe void Uniform3fv(int location, int count, float[] v, int offset)
+		{
+			fixed (float* ptr = &v[offset])
+			{
+				_device.glUniform3fv(location, count, ptr);
+			}
+		}
+
+		private unsafe void Uniform4fv(int location, int count, float[] v, int offset)
+		{
+			fixed (float* ptr = &v[offset])
+			{
+				_device.glUniform4fv(location, count, ptr);
+			}
+		}
+
+		public void SetUniform1fv(string name, float[] values, int offset, int length)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			Uniform1fv(uniform.Location, length, values, offset);
+		}
+
+		public void SetUniform1fv(int location, float[] values, int offset, int length)
+		{
+			CheckManaged();
+			Uniform1fv(location, length, values, offset);
+		}
+
+		public void SetUniform2fv(string name, float[] values, int offset, int length)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			Uniform2fv(uniform.Location, length / 2, values, offset);
+		}
+
+		public void SetUniform2fv(int location, float[] values, int offset, int length)
+		{
+			CheckManaged();
+			Uniform2fv(location, length / 2, values, offset);
+		}
+
+		public void SetUniform3fv(string name, float[] values, int offset, int length)
+		{
+			var uniform = FetchUniform(name);
+			Uniform3fv(uniform.Location, length / 3, values, offset);
+		}
+
+		public void SetUniform3fv(int location, float[] values, int offset, int length)
+		{
+			CheckManaged();
+			Uniform3fv(location, length / 3, values, offset);
+		}
+
+		public void SetUniform4fv(string name, float[] values, int offset, int length)
+		{
+			CheckManaged();
+			var uniform = FetchUniform(name);
+			Uniform4fv(uniform.Location, length / 4, values, offset);
+		}
+
+		public void SetUniform4fv(int location, float[] values, int offset, int length)
+		{
+			CheckManaged();
+			Uniform4fv(location, length / 4, values, offset);
+		}
+
+		private unsafe void UniformMatrix4fv(int location, int count, bool transpose, ref Matrix m)
+		{
+			fixed (Matrix* ptr = &m)
+			{
+				_device.glUniformMatrix4fv(location, count, transpose ? (byte)1 : (byte)0, (float*)ptr);
+			}
+		}
+
+		/// <summary>Sets the uniform matrix with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform matrix with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="matrix">the matrix</param>
+		public void SetUniformMatrix(string name, ref Matrix matrix)
+		{
+			SetUniformMatrix(name, ref matrix, false);
+		}
+
+		/// <summary>Sets the uniform matrix with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform matrix with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="matrix">the matrix</param>
+		/// <param name="transpose">whether the matrix should be transposed</param>
+		public void SetUniformMatrix(string name, ref Matrix matrix, bool transpose)
+		{
+			SetUniformMatrix(FetchUniform(name).Location, ref matrix, transpose);
+		}
+
+		public void SetUniformMatrix(int location, ref Matrix matrix)
+		{
+			SetUniformMatrix(location, ref matrix, false);
+		}
+
+		public void SetUniformMatrix(int location, ref Matrix matrix, bool transpose)
+		{
+			CheckManaged();
+			UniformMatrix4fv(location, 1, transpose, ref matrix);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="values">x and y as the first and second values respectively</param>
+		public void SetUniformf(string name, Vector2 values)
+		{
+			SetUniformf(name, values.X, values.Y);
+		}
+
+		public void SetUniformf(int location, Vector2 values)
+		{
+			SetUniformf(location, values.X, values.Y);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="values">x, y and z as the first, second and third values respectively
+		/// 	</param>
+		public void SetUniformf(string name, Vector3 values)
+		{
+			SetUniformf(name, values.X, values.Y, values.Z);
+		}
+
+		public void SetUniformf(int location, Vector3 values)
+		{
+			SetUniformf(location, values.X, values.Y, values.Z);
+		}
+
+		/// <summary>Sets the uniform with the given name.</summary>
+		/// <remarks>
+		/// Sets the uniform with the given name. The
+		/// <see cref="Shader"/>
+		/// must be bound for this to work.
+		/// </remarks>
+		/// <param name="name">the name of the uniform</param>
+		/// <param name="values">r, g, b and a as the first through fourth values respectively
+		/// 	</param>
+		public void SetUniformf(string name, Vector4 values)
+		{
+			SetUniformf(name, values.X, values.Y, values.Z, values.W);
+		}
+
+		public void SetUniformf(int location, Vector4 values)
+		{
+			SetUniformf(location, values.X, values.Y, values.Z, values.W);
+		}
+
+		public void Apply()
+		{
+			CheckManaged();
+			_device.ApplyShader(this);
+		}
+
+		private void CheckManaged()
+		{
+			if (!_invalidated)
+				return;
+
+			CompileShaders(_vertexShaderSource, _fragmentShaderSource);
+			_invalidated = false;
+		}
+
+		private void FetchUniforms()
+		{
+			int numUniforms;
+			unsafe
+			{
+				_device.glGetProgramiv(_programHandle, GLenum.GL_ACTIVE_UNIFORMS, &numUniforms);
+			}
+
+			var byteBuffer = new byte[256];
+			for (var i = 0; i < numUniforms; i++)
+			{
+				string name;
+				int size, type;
+
+				unsafe
+				{
+					fixed (byte* ptr = byteBuffer)
+					{
+						int length, lsize, ltype;
+						_device.glGetActiveUniform(_programHandle, i, byteBuffer.Length, &length, &lsize, &ltype, (sbyte*)ptr);
+
+						size = lsize;
+						type = ltype;
+
+						name = Marshal.PtrToStringAnsi(new IntPtr(ptr), length);
+					}
+				}
+
+				var location = GetUniformLocation(_programHandle, name);
+
+				var uniform = new Uniform
+				{
+					Location = location,
+					Type = type,
+					Size = size
+				};
+
+				_uniforms[name] = uniform;
+			}
+		}
+
+		private void FetchAttributes()
+		{
+			int numAttributes;
+
+			unsafe
+			{
+				_device.glGetProgramiv(_programHandle, GLenum.GL_ACTIVE_ATTRIBUTES, &numAttributes);
+			}
+
+			var byteBuffer = new byte[256];
+			for (var i = 0; i < numAttributes; i++)
+			{
+				string name;
+				int size, type;
+
+				unsafe
+				{
+					fixed (byte* ptr = byteBuffer)
+					{
+						int length, lsize, ltype;
+						_device.glGetActiveAttrib(_programHandle, i, byteBuffer.Length, &length, &lsize, &ltype, (sbyte*)ptr);
+
+						size = lsize;
+						type = ltype;
+
+						name = Marshal.PtrToStringAnsi(new IntPtr(ptr), length);
+					}
+				}
+
+				var location = GetAttribLocation(_programHandle, name);
+
+				var uniform = new Uniform
+				{
+					Location = location,
+					Type = type,
+					Size = size
+				};
+
+				_attributes[name] = uniform;
+			}
+		}
+
+		public void Invalidate()
+		{
+			_invalidated = true;
+		}
+	}
+}


### PR DESCRIPTION
This PR adds Shader object to the FNA that could be compiled at run-time from GLSL code.
I.e. following is full sample that will draw two textures(second below first), using the new feature:
```c#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System.IO;

namespace ImageTest
{
	public class MyGame : Game
	{
		private const string VertexShader = @"
// Attributes
attribute vec4 a_position;
attribute vec4 a_color;
attribute vec2 a_texCoords0;

// Uniforms
uniform mat4 MatrixTransform;

// Varyings
varying vec4 v_color;
varying vec2 v_texCoords;

void main()
{
	v_color = a_color;
	v_texCoords = a_texCoords0;
	gl_Position = MatrixTransform * a_position;
}
";

		private const string FragmentShader = @"
// Uniforms
uniform sampler2D TextureSampler;

// Varyings
varying vec4 v_color;
varying vec2 v_texCoords;

void main()
{
	gl_FragColor = v_color * texture2D(TextureSampler, v_texCoords);
}
";

		private readonly GraphicsDeviceManager graphics;
		private Texture2D _texture1, _texture2;
		private Shader _shader;
		private IndexBuffer _indexBuffer;
		private VertexBuffer _vertexBuffer1, _vertexBuffer2;

		public MyGame()
		{
			graphics = new GraphicsDeviceManager(this);

			IsMouseVisible = true;
			Window.AllowUserResizing = true;
		}

		protected override void LoadContent()
		{
			base.LoadContent();

			// Shader
			_shader = new Shader(GraphicsDevice, VertexShader, FragmentShader,
				new System.Collections.Generic.Dictionary<string, VertexElementUsage>
				{
					["a_position"] = VertexElementUsage.Position,
					["a_color"] = VertexElementUsage.Color,
					["a_texCoords0"] = VertexElementUsage.TextureCoordinate,
				});

			// Textures
			using (var fileStream = File.OpenRead("d:\\temp\\image1.png"))
			{
				_texture1 = Texture2D.FromStream(GraphicsDevice, fileStream);
			}

			using (var fileStream = File.OpenRead("d:\\temp\\image2.png"))
			{
				_texture2 = Texture2D.FromStream(GraphicsDevice, fileStream);
			}

			// Index Buffer
			var indexData = new short[]
			{
				0, 1, 2, 3, 2, 1
			};

			_indexBuffer = new IndexBuffer(GraphicsDevice, IndexElementSize.SixteenBits, indexData.Length, BufferUsage.WriteOnly);
			_indexBuffer.SetData(indexData);

			// Vertex Buffers
			var vertexData1 = new VertexPositionColorTexture[]
			{
				new VertexPositionColorTexture(new Vector3(0, 0, 0), Color.White, new Vector2(0, 0)),
				new VertexPositionColorTexture(new Vector3(_texture1.Width, 0, 0), Color.White, new Vector2(1, 0)),
				new VertexPositionColorTexture(new Vector3(0, _texture1.Height, 0), Color.White, new Vector2(0, 1)),
				new VertexPositionColorTexture(new Vector3(_texture1.Width, _texture1.Height, 0), Color.White, new Vector2(1, 1)),
			};
			_vertexBuffer1 = new VertexBuffer(GraphicsDevice, typeof(VertexPositionColorTexture), vertexData1.Length, BufferUsage.WriteOnly);
			_vertexBuffer1.SetData(vertexData1);

			var vertexData2 = new VertexPositionColorTexture[]
			{
				new VertexPositionColorTexture(new Vector3(0, 0, 0), Color.White, new Vector2(0, 0)),
				new VertexPositionColorTexture(new Vector3(_texture2.Width, 0, 0), Color.White, new Vector2(1, 0)),
				new VertexPositionColorTexture(new Vector3(0, _texture2.Height, 0), Color.White, new Vector2(0, 1)),
				new VertexPositionColorTexture(new Vector3(_texture2.Width, _texture2.Height, 0), Color.White, new Vector2(1, 1)),
			};
			_vertexBuffer2 = new VertexBuffer(GraphicsDevice, typeof(VertexPositionColorTexture), vertexData2.Length, BufferUsage.WriteOnly);
			_vertexBuffer2.SetData(vertexData2);
		}

		protected override void Draw(GameTime gameTime)
		{
			base.Draw(gameTime);

			GraphicsDevice.Clear(Color.Black);

			GraphicsDevice.Indices = _indexBuffer;
			GraphicsDevice.SetVertexBuffer(_vertexBuffer1);

			GraphicsDevice.BlendState = BlendState.NonPremultiplied;

			_shader.Apply();

			Matrix projection;
			Matrix.CreateOrthographicOffCenter(0,
				GraphicsDevice.PresentationParameters.BackBufferWidth,
				GraphicsDevice.PresentationParameters.BackBufferHeight,
				0,
				0,
				-1,
				out projection);

			_shader.SetUniformMatrix("MatrixTransform", ref projection);

			// Draw texture 1
			GraphicsDevice.SetVertexBuffer(_vertexBuffer1);
			GraphicsDevice.Textures[0] = _texture1;
			GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, _vertexBuffer1.VertexCount, 0, _indexBuffer.IndexCount / 3);

			// Draw texture 2 below first
			Matrix m = Matrix.CreateTranslation(0, _texture1.Height + 20, 0) * projection;
			_shader.SetUniformMatrix("MatrixTransform", ref m);
			GraphicsDevice.SetVertexBuffer(_vertexBuffer2);
			GraphicsDevice.Textures[0] = _texture2;
			GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, _vertexBuffer2.VertexCount, 0, _indexBuffer.IndexCount / 3);
		}
	}
}
```

This PR did some refactoring to the OpenGLDevice/ModernGLDevice, described at #210.
Shader.cs code is seriously reworked Shader.java from libgdx(Apache2 license), which is mentioned in the file header.