### PR TITLE
Orientation Support

### DIFF
--- a/src/FNAPlatform/FNAWindow.cs
+++ b/src/FNAPlatform/FNAWindow.cs
@@ -155,6 +155,23 @@ namespace Microsoft.Xna.Framework
 
 		#region Protected GameWindow Methods
 
+		protected internal override void SetSupportedOrientations(DisplayOrientation orientations)
+		{
+			/* XNA on Windows Phone had the ability to change
+			 * the list of supported device orientations at runtime.
+			 * Unfortunately, we can't support that reliably across
+			 * multiple mobile platforms. Therefore this method is
+			 * essentially a no-op.
+			 *
+			 * Instead, you should set your supported orientations
+			 * in Info.plist (iOS) or AndroidManifest.xml (Android).
+			 *
+			 * -caleb
+			 */
+
+			FNALoggerEXT.LogWarn("Setting SupportedOrientations has no effect!");
+		}
+
 		protected override void SetTitle(string title)
 		{
 			FNAPlatform.SetWindowTitle(window, title);

--- a/src/FNAPlatform/FNAWindow.cs
+++ b/src/FNAPlatform/FNAWindow.cs
@@ -52,11 +52,8 @@ namespace Microsoft.Xna.Framework
 
 		public override DisplayOrientation CurrentOrientation
 		{
-			get
-			{
-				// TODO: return FNAPlatform.GetOrientation(window);
-				return DisplayOrientation.LandscapeLeft;
-			}
+			get;
+			internal set;
 		}
 
 		public override IntPtr Handle
@@ -149,14 +146,14 @@ namespace Microsoft.Xna.Framework
 			OnScreenDeviceNameChanged();
 		}
 
+		internal void INTERNAL_OnOrientationChanged()
+		{
+			OnOrientationChanged();
+		}
+
 		#endregion
 
 		#region Protected GameWindow Methods
-
-		protected internal override void SetSupportedOrientations(DisplayOrientation orientations)
-		{
-			// FNA currently doesn't support orientations.
-		}
 
 		protected override void SetTitle(string title)
 		{

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -183,14 +183,10 @@ namespace Microsoft.Xna.Framework
 				);
 			}
 
-			hint = SDL.SDL_GetHint(SDL.SDL_HINT_ORIENTATIONS);
-			if (String.IsNullOrEmpty(hint))
-			{
-				SDL.SDL_SetHint(
-					SDL.SDL_HINT_ORIENTATIONS,
-					"LandscapeLeft LandscapeRight Portrait"
-				);
-			}
+			SDL.SDL_SetHint(
+				SDL.SDL_HINT_ORIENTATIONS,
+				"LandscapeLeft LandscapeRight Portrait"
+			);
 
 			// We want to initialize the controllers ASAP!
 			SDL.SDL_Event[] evt = new SDL.SDL_Event[1];

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -722,7 +722,7 @@ namespace Microsoft.Xna.Framework
 					return DisplayOrientation.Portrait;
 
 				default:
-					throw new InvalidOperationException("FNA does not support this device orientation.");
+					throw new NotSupportedException("FNA does not support this device orientation.");
 			}
 		}
 

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -749,11 +749,10 @@ namespace Microsoft.Xna.Framework
 			}
 
 			// Update the graphics device and window
-			//FIXME: In which order should these be called?
 			graphicsDevice.PresentationParameters.DisplayOrientation = orientation;
-			graphicsDevice.Reset();
-
 			window.CurrentOrientation = orientation;
+
+			graphicsDevice.Reset();
 			window.INTERNAL_OnOrientationChanged();
 		}
 

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1022,12 +1022,12 @@ namespace Microsoft.Xna.Framework
 						// Orientation Change
 						if (evt.display.displayEvent == SDL.SDL_DisplayEventID.SDL_DISPLAYEVENT_ORIENTATION)
 						{
-							DisplayOrientation fnaOrientation = INTERNAL_ConvertOrientation(
+							DisplayOrientation orientation = INTERNAL_ConvertOrientation(
 								(SDL.SDL_DisplayOrientation) evt.display.data1
 							);
 
 							INTERNAL_HandleOrientationChange(
-								fnaOrientation,
+								orientation,
 								game.GraphicsDevice,
 								(FNAWindow) game.Window
 							);

--- a/src/GameWindow.cs
+++ b/src/GameWindow.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Xna.Framework
 		public abstract DisplayOrientation CurrentOrientation
 		{
 			get;
+			internal set;
 		}
 
 		public abstract IntPtr Handle
@@ -163,10 +164,6 @@ namespace Microsoft.Xna.Framework
 				ScreenDeviceNameChanged(this, EventArgs.Empty);
 			}
 		}
-
-		protected internal abstract void SetSupportedOrientations(
-			DisplayOrientation orientations
-		);
 
 		protected abstract void SetTitle(string title);
 

--- a/src/GameWindow.cs
+++ b/src/GameWindow.cs
@@ -165,6 +165,10 @@ namespace Microsoft.Xna.Framework
 			}
 		}
 
+		protected internal abstract void SetSupportedOrientations(
+			DisplayOrientation orientations
+		);
+
 		protected abstract void SetTitle(string title);
 
 		#endregion

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -85,20 +85,23 @@ namespace Microsoft.Xna.Framework
 			set;
 		}
 
+		[Obsolete("Set the supported orientations in Info.plist or AndroidManifest.xml instead.")]
 		public DisplayOrientation SupportedOrientations
 		{
-			get
-			{
-				return supportedOrientations;
-			}
-			set
-			{
-				supportedOrientations = value;
-				if (game.Window != null)
-				{
-					game.Window.SetSupportedOrientations(supportedOrientations);
-				}
-			}
+			/* XNA on Windows Phone had the ability to change
+			 * the list of supported device orientations at runtime.
+			 * Unfortunately, we can't support that reliably across
+			 * multiple mobile platforms. Therefore this property is
+			 * essentially a no-op.
+			 * 
+			 * Instead, you should set your supported orientations in
+			 * Info.plist (iOS) or AndroidManifest.xml (Android).
+			 * 
+			 * -caleb
+			 */
+
+			get;
+			set;
 		}
 
 		#endregion
@@ -107,7 +110,6 @@ namespace Microsoft.Xna.Framework
 
 		private Game game;
 		private GraphicsDevice graphicsDevice;
-		private DisplayOrientation supportedOrientations;
 		private bool drawBegun;
 		private bool disposed;
 		private bool useResizedBackBuffer;
@@ -150,7 +152,7 @@ namespace Microsoft.Xna.Framework
 
 			this.game = game;
 
-			supportedOrientations = DisplayOrientation.Default;
+			SupportedOrientations = DisplayOrientation.Default;
 
 			PreferredBackBufferHeight = DefaultBackBufferHeight;
 			PreferredBackBufferWidth = DefaultBackBufferWidth;

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Xna.Framework
 			{
 				return supportedOrientations;
 			}
-
 			set
 			{
 				FNALoggerEXT.LogWarn("Setting SupportedOrientations has no effect!");

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -87,26 +87,17 @@ namespace Microsoft.Xna.Framework
 
 		public DisplayOrientation SupportedOrientations
 		{
-			/* XNA on Windows Phone had the ability to change
-			 * the list of supported device orientations at runtime.
-			 * Unfortunately, we can't support that reliably across
-			 * multiple mobile platforms. Therefore this property is
-			 * essentially a no-op.
-			 * 
-			 * Instead, you should set your supported orientations in
-			 * Info.plist (iOS) or AndroidManifest.xml (Android).
-			 * 
-			 * -caleb
-			 */
-
 			get
 			{
 				return supportedOrientations;
 			}
 			set
 			{
-				FNALoggerEXT.LogWarn("Setting SupportedOrientations has no effect!");
 				supportedOrientations = value;
+				if (game.Window != null)
+				{
+					game.Window.SetSupportedOrientations(supportedOrientations);
+				}
 			}
 		}
 

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Xna.Framework
 			set;
 		}
 
-		[Obsolete("Set the supported orientations in Info.plist or AndroidManifest.xml instead.")]
 		public DisplayOrientation SupportedOrientations
 		{
 			/* XNA on Windows Phone had the ability to change
@@ -100,8 +99,16 @@ namespace Microsoft.Xna.Framework
 			 * -caleb
 			 */
 
-			get;
-			set;
+			get
+			{
+				return supportedOrientations;
+			}
+
+			set
+			{
+				FNALoggerEXT.LogWarn("Setting SupportedOrientations has no effect!");
+				supportedOrientations = value;
+			}
 		}
 
 		#endregion
@@ -110,6 +117,7 @@ namespace Microsoft.Xna.Framework
 
 		private Game game;
 		private GraphicsDevice graphicsDevice;
+		private DisplayOrientation supportedOrientations;
 		private bool drawBegun;
 		private bool disposed;
 		private bool useResizedBackBuffer;
@@ -152,7 +160,7 @@ namespace Microsoft.Xna.Framework
 
 			this.game = game;
 
-			SupportedOrientations = DisplayOrientation.Default;
+			supportedOrientations = DisplayOrientation.Default;
 
 			PreferredBackBufferHeight = DefaultBackBufferHeight;
 			PreferredBackBufferWidth = DefaultBackBufferWidth;


### PR DESCRIPTION
This PR adds orientation support for mobile devices. Most of the interesting changes are in SDL2_FNAPlatform. This patch depends on SDL 2.0.9 for its orientation features.

Note that this implementation does not allow for changing supported orientations at runtime (via `GraphicsDeviceManager.SupportedOrientation`). Instead, the game's supported orientations must be specified at build time in Info.plist or AndroidManifest.xml, depending on the platform. It sucks that this doesn't match XNA's exact behavior, but there doesn't seem to be a good way to accurately emulate that across modern mobile operating systems. (Besides, I haven't come across a single game or example that uses that feature...)

I have tested this on my iPhone 6S+ and everything works as expected. @0x0ade If you have some time soon, could you play around with this on Android? Should be pretty easy to test, I think -- just draw something to the screen and see if it rotates and scales appropriately for different orientations, and make sure touches are being mapped to the correct location.

One question: should we keep or ditch the `Obsolete` attribute for `SupportedOrientations`? XNA didn't mark the property as obsolete, but this is a rare case where we are actually dumping support for a feature and it works well as a warning to those who would want to use it.