### PR TITLE
Fix for orientation distortion

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Xna.Framework
 			StopMicrophone =		SDL2_FNAPlatform.StopMicrophone;
 			GetTouchCapabilities =		SDL2_FNAPlatform.GetTouchCapabilities;
 			GetNumTouchFingers =		SDL2_FNAPlatform.GetNumTouchFingers;
+			SupportsOrientationChanges =	SDL2_FNAPlatform.SupportsOrientationChanges;
 
 			// Don't overwrite application log hooks!
 			if (FNALoggerEXT.LogInfo == null)
@@ -286,6 +287,9 @@ namespace Microsoft.Xna.Framework
 
 		public delegate int GetNumTouchFingersFunc();
 		public static readonly GetNumTouchFingersFunc GetNumTouchFingers;
+
+		public delegate bool SupportsOrientationChangesFunc();
+		public static readonly SupportsOrientationChangesFunc SupportsOrientationChanges;
 
 		#endregion
 	}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -397,7 +397,8 @@ namespace Microsoft.Xna.Framework
 			ref string resultDeviceName
 		) {
 			bool center = false;
-			if (Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1")
+			if (Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1"
+				&& OSVersion.Equals("Mac OS X"))
 			{
 				/* For high-DPI windows, halve the size!
 				 * The drawable size is now the primary width/height, so

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -714,6 +714,11 @@ namespace Microsoft.Xna.Framework
 			window.INTERNAL_OnOrientationChanged();
 		}
 
+		public static bool SupportsOrientationChanges()
+		{
+			return OSVersion.Equals("iOS") || OSVersion.Equals("Android");
+		}
+
 		#endregion
 
 		#region Event Loop

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -259,7 +259,6 @@ namespace Microsoft.Xna.Framework
 					/* Flip the backbuffer dimensions to scale
 					 * appropriately to the current orientation.
 					 */
-
 					int min = Math.Min(PreferredBackBufferWidth, PreferredBackBufferHeight);
 					int max = Math.Max(PreferredBackBufferWidth, PreferredBackBufferHeight);
 

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -247,10 +247,33 @@ namespace Microsoft.Xna.Framework
 			}
 			else
 			{
-				gdi.PresentationParameters.BackBufferWidth =
-					PreferredBackBufferWidth;
-				gdi.PresentationParameters.BackBufferHeight =
-					PreferredBackBufferHeight;
+				if (!FNAPlatform.SupportsOrientationChanges())
+				{
+					gdi.PresentationParameters.BackBufferWidth =
+						PreferredBackBufferWidth;
+					gdi.PresentationParameters.BackBufferHeight =
+						PreferredBackBufferHeight;
+				}
+				else
+				{
+					/* Flip the backbuffer dimensions to scale
+					 * appropriately to the current orientation.
+					 */
+
+					int min = Math.Min(PreferredBackBufferWidth, PreferredBackBufferHeight);
+					int max = Math.Max(PreferredBackBufferWidth, PreferredBackBufferHeight);
+
+					if (gdi.PresentationParameters.DisplayOrientation == DisplayOrientation.Portrait)
+					{
+						gdi.PresentationParameters.BackBufferWidth = min;
+						gdi.PresentationParameters.BackBufferHeight = max;
+					}
+					else
+					{
+						gdi.PresentationParameters.BackBufferWidth = max;
+						gdi.PresentationParameters.BackBufferHeight = min;
+					}
+				}
 			}
 			gdi.PresentationParameters.DepthStencilFormat =
 				PreferredDepthStencilFormat;


### PR DESCRIPTION
In certain scenarios it is possible for the backbuffer to become distorted upon calling `graphics.ApplyChanges()`. This is because inside ApplyChanges, the backbuffer's width and height are forced to be PreferredBackBufferWidth/Height and do not flip to the appropriate orientation. (For example, an app held in portrait orientation might be forced to have a backbuffer size of 800x480 instead of 480x800, so all visuals are stretched and misshapen.)

This PR fixes that issue and adds a new function to FNAPlatform for checking whether the device supports orientation changes. Up for debate is whether to include WinRT in that list of orientation-supporting OS's.