### PR TITLE
High DPI Support for iOS

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -37,6 +37,10 @@ namespace Microsoft.Xna.Framework
 
 		private static bool SupportsGlobalMouse;
 
+		private static int RetinaWidth;
+
+		private static int RetinaHeight;
+
 		#endregion
 
 		#region Game Objects
@@ -347,7 +351,22 @@ namespace Microsoft.Xna.Framework
 			 * -flibit
 			 */
 			int drawX, drawY;
+			IntPtr ctx = IntPtr.Zero;
+
+			if (OSVersion.Equals("iOS"))
+			{
+				ctx = SDL.SDL_GL_CreateContext(window);
+			}
+
 			SDL.SDL_GL_GetDrawableSize(window, out drawX, out drawY);
+
+			if (OSVersion.Equals("iOS"))
+			{
+				SDL.SDL_GL_DeleteContext(ctx);
+				RetinaWidth = drawX;
+				RetinaHeight = drawY;
+			}
+
 			if (	drawX == GraphicsDeviceManager.DefaultBackBufferWidth &&
 				drawY == GraphicsDeviceManager.DefaultBackBufferHeight	)
 			{
@@ -1171,6 +1190,14 @@ namespace Microsoft.Xna.Framework
 		{
 			SDL.SDL_DisplayMode filler = new SDL.SDL_DisplayMode();
 			SDL.SDL_GetCurrentDisplayMode(adapterIndex, out filler);
+
+			if (OSVersion.Equals("iOS") && Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1")
+			{
+				filler.w = RetinaWidth;
+				filler.h = RetinaHeight;
+				FNALoggerEXT.LogInfo("w/h: " + filler.w + "/" + filler.h);
+			}
+
 			return new DisplayMode(
 				filler.w,
 				filler.h,


### PR DESCRIPTION
With this patch, games can take advantage of the full resolution of an iOS Retina display. All the game needs to do is enable the `FNA_GRAPHICS_ENABLE_HIGHDPI` environment variable and set the preferred back buffer size as follows:

```
graphics.PreferredBackBufferWidth = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width;
graphics.PreferredBackBufferHeight = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height;
```

This makes a huge difference for some games, since it essentially doubles the available screen resolution and makes visuals much clearer.