### PR TITLE
Use spriteinfo

### DIFF
--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 #endregion
@@ -1160,6 +1161,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+		[MethodImpl(256)]
 		private static unsafe void UpdateVertexInfo(
 			VertexPositionColorTexture4* sprite,
 			float sourceX,


### PR DESCRIPTION
This PR buffers the information used to generate sprite vertex and texture information in an array of SpriteInfo reference types (classes) when sorting modes are used, then sorts it, and finally computes the native compatible vertex information array.  Though the SpriteInfo objects are dynamically allocated, they are allocated up front in contiguous memory and are re-used with each batch.