### PR TITLE
(structs & pointers) Speed up sorting SpriteBatch modes by avoiding excessive copying of vertex information

### DIFF
--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1134,25 +1134,28 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				fixed (SpriteInfo* spriteInfo = &spriteInfos[numSprites])
 				{
-					spriteInfo->textureHash = texture.GetHashCode();
-					spriteInfo->sourceX = sourceX;
-					spriteInfo->sourceY = sourceY;
-					spriteInfo->sourceW = sourceW;
-					spriteInfo->sourceH = sourceH;
-					spriteInfo->destinationX = destinationX;
-					spriteInfo->destinationY = destinationY;
-					spriteInfo->destinationW = destinationW;
-					spriteInfo->destinationH = destinationH;
-					spriteInfo->color = color;
-					spriteInfo->originX = originX;
-					spriteInfo->originY = originY;
-					spriteInfo->rotationSin = rotationSin;
-					spriteInfo->rotationCos = rotationCos;
-					spriteInfo->depth = depth;
-					spriteInfo->effects = effects;
+					fixed (IntPtr* sortedSpritesPtr = &sortedSprites[0])
+					{
+						spriteInfo->textureHash = texture.GetHashCode();
+						spriteInfo->sourceX = sourceX;
+						spriteInfo->sourceY = sourceY;
+						spriteInfo->sourceW = sourceW;
+						spriteInfo->sourceH = sourceH;
+						spriteInfo->destinationX = destinationX;
+						spriteInfo->destinationY = destinationY;
+						spriteInfo->destinationW = destinationW;
+						spriteInfo->destinationH = destinationH;
+						spriteInfo->color = color;
+						spriteInfo->originX = originX;
+						spriteInfo->originY = originY;
+						spriteInfo->rotationSin = rotationSin;
+						spriteInfo->rotationCos = rotationCos;
+						spriteInfo->depth = depth;
+						spriteInfo->effects = effects;
 
-					// Store a pointer that we will sort when flushing the batch.
-					sortedSprites[numSprites] = (IntPtr) spriteInfo;
+						// Store a pointer that we will sort when flushing the batch.
+						sortedSpritesPtr[numSprites] = (IntPtr) spriteInfo;
+					}
 				}
 
 				// Have to keep Texture2D out of SpriteInfo for it to stay an unmanaged type.

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -10,6 +10,7 @@
 #region Using Statements
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 #endregion
@@ -86,6 +87,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		private IndexBuffer indexBuffer;
 
 		// Local data stored before buffering to GPU
+		private SpriteInfo[] spriteInfos;
+		private IntPtr[] sortedSprites; /* SpriteInfo* */
 		private VertexPositionColorTexture4[] vertexInfo;
 		private Texture2D[] textureInfo;
 
@@ -144,6 +147,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			vertexInfo = new VertexPositionColorTexture4[MAX_SPRITES];
 			textureInfo = new Texture2D[MAX_SPRITES];
+			spriteInfos = new SpriteInfo[MAX_SPRITES];
+			sortedSprites = new IntPtr[MAX_SPRITES];
 			vertexBuffer = new DynamicVertexBuffer(
 				graphicsDevice,
 				typeof(VertexPositionColorTexture),
@@ -1064,93 +1069,65 @@ namespace Microsoft.Xna.Framework.Graphics
 				FlushBatch();
 			}
 
-			fixed (VertexPositionColorTexture4* sprite = &vertexInfo[numSprites])
-			{
-				float cornerX = -originX * destinationW;
-				float cornerY = -originY * destinationH;
-				sprite->Position0.X = (
-					(-rotationSin * cornerY) +
-					(rotationCos * cornerX) +
-					destinationX
-				);
-				sprite->Position0.Y = (
-					(rotationCos * cornerY) +
-					(rotationSin * cornerX) +
-					destinationY
-				);
-				cornerX = (1.0f - originX) * destinationW;
-				cornerY = -originY * destinationH;
-				sprite->Position1.X = (
-					(-rotationSin * cornerY) +
-					(rotationCos * cornerX) +
-					destinationX
-				);
-				sprite->Position1.Y = (
-					(rotationCos * cornerY) +
-					(rotationSin * cornerX) +
-					destinationY
-				);
-				cornerX = -originX * destinationW;
-				cornerY = (1.0f - originY) * destinationH;
-				sprite->Position2.X = (
-					(-rotationSin * cornerY) +
-					(rotationCos * cornerX) +
-					destinationX
-				);
-				sprite->Position2.Y = (
-					(rotationCos * cornerY) +
-					(rotationSin * cornerX) +
-					destinationY
-				);
-				cornerX = (1.0f - originX) * destinationW;
-				cornerY = (1.0f - originY) * destinationH;
-				sprite->Position3.X = (
-					(-rotationSin * cornerY) +
-					(rotationCos * cornerX) +
-					destinationX
-				);
-				sprite->Position3.Y = (
-					(rotationCos * cornerY) +
-					(rotationSin * cornerX) +
-					destinationY
-				);
-				fixed (float* flipX = &CornerOffsetX[0]) {
-				fixed (float* flipY = &CornerOffsetY[0]) {
-					sprite->TextureCoordinate0.X = (flipX[0 ^ effects] * sourceW) + sourceX;
-					sprite->TextureCoordinate0.Y = (flipY[0 ^ effects] * sourceH) + sourceY;
-					sprite->TextureCoordinate1.X = (flipX[1 ^ effects] * sourceW) + sourceX;
-					sprite->TextureCoordinate1.Y = (flipY[1 ^ effects] * sourceH) + sourceY;
-					sprite->TextureCoordinate2.X = (flipX[2 ^ effects] * sourceW) + sourceX;
-					sprite->TextureCoordinate2.Y = (flipY[2 ^ effects] * sourceH) + sourceY;
-					sprite->TextureCoordinate3.X = (flipX[3 ^ effects] * sourceW) + sourceX;
-					sprite->TextureCoordinate3.Y = (flipY[3 ^ effects] * sourceH) + sourceY;
-				}}
-				sprite->Position0.Z = depth;
-				sprite->Position1.Z = depth;
-				sprite->Position2.Z = depth;
-				sprite->Position3.Z = depth;
-				sprite->Color0 = color;
-				sprite->Color1 = color;
-				sprite->Color2 = color;
-				sprite->Color3 = color;
-			}
-
 			if (sortMode == SpriteSortMode.Immediate)
 			{
+				fixed (VertexPositionColorTexture4* sprite = &vertexInfo[0])
+				{
+					GenerateVertexInfo(sprite, sourceX, sourceY, sourceW, sourceH, destinationX, destinationY, destinationW,
+						destinationH, color, originX, originY, rotationSin, rotationCos, depth, effects);
+				}
+
 				fixed (VertexPositionColorTexture4* p = &vertexInfo[0])
 				{
 					vertexBuffer.SetDataPointerEXT(
 						0,
-						(IntPtr) p,
+						(IntPtr)p,
 						VertexPositionColorTexture4.RealStride,
 						SetDataOptions.None
 					);
 				}
 				DrawPrimitives(texture, 0, 1);
 			}
+			else if (sortMode == SpriteSortMode.Deferred)
+			{
+				fixed (VertexPositionColorTexture4* sprite = &vertexInfo[numSprites])
+				{
+					GenerateVertexInfo(sprite, sourceX, sourceY, sourceW, sourceH, destinationX, destinationY, destinationW,
+						destinationH, color, originX, originY, rotationSin, rotationCos, depth, effects);
+				}
+
+				textureInfo[numSprites] = texture;
+
+				numSprites += 1;
+			}
 			else
 			{
+				fixed (SpriteInfo* spriteInfo = &spriteInfos[numSprites])
+				{
+					spriteInfo->textureHash = texture.GetHashCode();
+					spriteInfo->sourceX = sourceX;
+					spriteInfo->sourceY = sourceY;
+					spriteInfo->sourceW = sourceW;
+					spriteInfo->sourceH = sourceH;
+					spriteInfo->destinationX = destinationX;
+					spriteInfo->destinationY = destinationY;
+					spriteInfo->destinationW = destinationW;
+					spriteInfo->destinationH = destinationH;
+					spriteInfo->color = color;
+					spriteInfo->originX = originX;
+					spriteInfo->originY = originY;
+					spriteInfo->rotationSin = rotationSin;
+					spriteInfo->rotationCos = rotationCos;
+					spriteInfo->depth = depth;
+					spriteInfo->effects = effects;
+
+					/* Store a pointer that we will sort when flushing the batch. */
+					sortedSprites[numSprites] = (IntPtr)spriteInfo;
+				}
+
+				/* Have to keep Texture2D out of SpriteInfo for it to stay an unmanaged type. */
 				textureInfo[numSprites] = texture;
+
 				numSprites += 1;
 			}
 		}
@@ -1168,43 +1145,37 @@ namespace Microsoft.Xna.Framework.Graphics
 				return;
 			}
 
-			// FIXME: OPTIMIZATION POINT: Speed up sprite sorting! -flibit
-			if (sortMode == SpriteSortMode.Texture)
+			if (sortMode != SpriteSortMode.Deferred)
 			{
+				IComparer<IntPtr> comparer;
+				if (sortMode == SpriteSortMode.Texture)
+				{
+					comparer = TextureCompare;
+				}
+				else if (sortMode == SpriteSortMode.BackToFront)
+				{
+					comparer = BackToFrontCompare;
+				}
+				else
+				{
+					Debug.Assert(sortMode == SpriteSortMode.FrontToBack);
+					comparer = FrontToBackCompare;
+				}
 				Array.Sort(
-					textureInfo,
-					vertexInfo,
-					0,
-					numSprites,
-					TextureCompare
-				);
-			}
-			else if (sortMode == SpriteSortMode.BackToFront)
-			{
-				Array.Sort(
-					vertexInfo,
-					textureInfo,
-					0,
-					numSprites,
-					BackToFrontCompare
-				);
-			}
-			else if (sortMode == SpriteSortMode.FrontToBack)
-			{
-				Array.Sort(
-					vertexInfo,
+					sortedSprites,
 					textureInfo,
 					0,
 					numSprites,
-					FrontToBackCompare
+					comparer
 				);
+				GenerateAllVertexInfo();
 			}
 
 			fixed (VertexPositionColorTexture4* p = &vertexInfo[0])
 			{
 				vertexBuffer.SetDataPointerEXT(
 					0,
-					(IntPtr) p,
+					(IntPtr)p,
 					numSprites * VertexPositionColorTexture4.RealStride,
 					SetDataOptions.None
 				);
@@ -1223,6 +1194,90 @@ namespace Microsoft.Xna.Framework.Graphics
 			DrawPrimitives(curTexture, offset, numSprites - offset);
 
 			numSprites = 0;
+		}
+
+		private unsafe void GenerateAllVertexInfo()
+		{
+			fixed (VertexPositionColorTexture4* sprites = &vertexInfo[0])
+			{
+				fixed (IntPtr* infos = &sortedSprites[0])
+				{
+					for (int i = 0; i < numSprites; i += 1)
+					{
+						SpriteInfo* info = (SpriteInfo*)infos[i];
+						GenerateVertexInfo(
+							&sprites[i],
+							info->sourceX,
+							info->sourceY,
+							info->sourceW,
+							info->sourceH,
+							info->destinationX,
+							info->destinationY,
+							info->destinationW,
+							info->destinationH, info->color,
+							info->originX,
+							info->originY,
+							info->rotationSin,
+							info->rotationCos,
+							info->depth, info->effects);
+					}
+				}
+			}
+		}
+
+		private static unsafe void GenerateVertexInfo(
+			VertexPositionColorTexture4* sprite,
+			float sourceX,
+			float sourceY,
+			float sourceW,
+			float sourceH,
+			float destinationX,
+			float destinationY,
+			float destinationW,
+			float destinationH,
+			Color color,
+			float originX,
+			float originY,
+			float rotationSin,
+			float rotationCos,
+			float depth,
+			byte effects)
+		{
+			float cornerX = -originX * destinationW;
+			float cornerY = -originY * destinationH;
+			sprite->Position0.X = -rotationSin * cornerY + rotationCos * cornerX + destinationX;
+			sprite->Position0.Y = rotationCos * cornerY + rotationSin * cornerX + destinationY;
+			cornerX = (1.0f - originX) * destinationW;
+			cornerY = -originY * destinationH;
+			sprite->Position1.X = -rotationSin * cornerY + rotationCos * cornerX + destinationX;
+			sprite->Position1.Y = rotationCos * cornerY + rotationSin * cornerX + destinationY;
+			cornerX = -originX * destinationW;
+			cornerY = (1.0f - originY) * destinationH;
+			sprite->Position2.X = -rotationSin * cornerY + rotationCos * cornerX + destinationX;
+			sprite->Position2.Y = rotationCos * cornerY + rotationSin * cornerX + destinationY;
+			cornerX = (1.0f - originX) * destinationW;
+			cornerY = (1.0f - originY) * destinationH;
+			sprite->Position3.X = -rotationSin * cornerY + rotationCos * cornerX + destinationX;
+			sprite->Position3.Y = rotationCos * cornerY + rotationSin * cornerX + destinationY;
+			fixed (float* flipX = &CornerOffsetX[0])  {
+			fixed (float* flipY = &CornerOffsetY[0]) {
+			sprite->TextureCoordinate0.X = flipX[0 ^ effects] * sourceW + sourceX;
+			sprite->TextureCoordinate0.Y = flipY[0 ^ effects] * sourceH + sourceY;
+			sprite->TextureCoordinate1.X = flipX[1 ^ effects] * sourceW + sourceX;
+			sprite->TextureCoordinate1.Y = flipY[1 ^ effects] * sourceH + sourceY;
+			sprite->TextureCoordinate2.X = flipX[2 ^ effects] * sourceW + sourceX;
+			sprite->TextureCoordinate2.Y = flipY[2 ^ effects] * sourceH + sourceY;
+			sprite->TextureCoordinate3.X = flipX[3 ^ effects] * sourceW + sourceX;
+			sprite->TextureCoordinate3.Y = flipY[3 ^ effects] * sourceH + sourceY;
+			}}
+			sprite->Position0.Z = depth;
+			sprite->Position1.Z = depth;
+			sprite->Position2.Z = depth;
+			sprite->Position3.Z = depth;
+			sprite->Color0 = color;
+			sprite->Color1 = color;
+			sprite->Color2 = color;
+			sprite->Color3 = color;
 		}
 
 		private void PrepRenderState()
@@ -1362,29 +1417,60 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Private SpriteInfo Container Type
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct SpriteInfo
+		{
+			public int textureHash;
+			public float sourceX;
+			public float sourceY;
+			public float sourceW;
+			public float sourceH;
+			public float destinationX;
+			public float destinationY;
+			public float destinationW;
+			public float destinationH;
+			public Color color;
+			public float originX;
+			public float originY;
+			public float rotationSin;
+			public float rotationCos;
+			public float depth;
+			public byte effects;
+		}
+
+		#endregion
+
 		#region Private Sprite Comparison Classes
 
-		private class TextureComparer : IComparer<Texture2D>
+		private class TextureComparer : IComparer<IntPtr>
 		{
-			public int Compare(Texture2D x, Texture2D y)
+			public unsafe int Compare(IntPtr i1, IntPtr i2)
 			{
-				return x.GetHashCode().CompareTo(y.GetHashCode());
+				SpriteInfo* p1 = (SpriteInfo*)i1;
+				SpriteInfo* p2 = (SpriteInfo*)i2;
+				return p1->textureHash.CompareTo(p2->textureHash);
 			}
 		}
 
-		private class BackToFrontComparer : IComparer<VertexPositionColorTexture4>
+		private class BackToFrontComparer : IComparer<IntPtr>
 		{
-			public int Compare(VertexPositionColorTexture4 x, VertexPositionColorTexture4 y)
+			public unsafe int Compare(IntPtr i1, IntPtr i2)
 			{
-				return y.Position0.Z.CompareTo(x.Position0.Z);
+				SpriteInfo* p1 = (SpriteInfo*)i1;
+				SpriteInfo* p2 = (SpriteInfo*)i2;
+				return p2->depth.CompareTo(p1->depth);
 			}
 		}
 
-		private class FrontToBackComparer : IComparer<VertexPositionColorTexture4>
+		private class FrontToBackComparer : IComparer<IntPtr>
 		{
-			public int Compare(VertexPositionColorTexture4 x, VertexPositionColorTexture4 y)
+			public unsafe int Compare(IntPtr i1, IntPtr i2)
 			{
-				return x.Position0.Z.CompareTo(y.Position0.Z);
+				SpriteInfo* p1 = (SpriteInfo*)i1;
+				SpriteInfo* p2 = (SpriteInfo*)i2;
+				return p1->depth.CompareTo(p2->depth);
 			}
 		}
 

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 #endregion
@@ -1225,6 +1226,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+		[MethodImpl(256)]
 		private static unsafe void GenerateVertexInfo(
 			VertexPositionColorTexture4* sprite,
 			float sourceX,

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		// Local data stored before buffering to GPU
 		private SpriteInfo[] spriteInfos;
-		private IntPtr[] sortedSprites; /* SpriteInfo* */
+		private IntPtr[] sortedSprites; // SpriteInfo*
 		private VertexPositionColorTexture4[] vertexInfo;
 		private Texture2D[] textureInfo;
 
@@ -1073,15 +1073,30 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				fixed (VertexPositionColorTexture4* sprite = &vertexInfo[0])
 				{
-					GenerateVertexInfo(sprite, sourceX, sourceY, sourceW, sourceH, destinationX, destinationY, destinationW,
-						destinationH, color, originX, originY, rotationSin, rotationCos, depth, effects);
+					GenerateVertexInfo(
+						sprite,
+						sourceX,
+						sourceY,
+						sourceW,
+						sourceH,
+						destinationX,
+						destinationY,
+						destinationW,
+						destinationH,
+						color,
+						originX,
+						originY,
+						rotationSin,
+						rotationCos,
+						depth,
+						effects);
 				}
 
 				fixed (VertexPositionColorTexture4* p = &vertexInfo[0])
 				{
 					vertexBuffer.SetDataPointerEXT(
 						0,
-						(IntPtr)p,
+						(IntPtr) p,
 						VertexPositionColorTexture4.RealStride,
 						SetDataOptions.None
 					);
@@ -1092,8 +1107,23 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				fixed (VertexPositionColorTexture4* sprite = &vertexInfo[numSprites])
 				{
-					GenerateVertexInfo(sprite, sourceX, sourceY, sourceW, sourceH, destinationX, destinationY, destinationW,
-						destinationH, color, originX, originY, rotationSin, rotationCos, depth, effects);
+					GenerateVertexInfo(
+						sprite,
+						sourceX,
+						sourceY,
+						sourceW,
+						sourceH,
+						destinationX,
+						destinationY,
+						destinationW,
+						destinationH,
+						color,
+						originX,
+						originY,
+						rotationSin,
+						rotationCos,
+						depth,
+						effects);
 				}
 
 				textureInfo[numSprites] = texture;
@@ -1121,11 +1151,11 @@ namespace Microsoft.Xna.Framework.Graphics
 					spriteInfo->depth = depth;
 					spriteInfo->effects = effects;
 
-					/* Store a pointer that we will sort when flushing the batch. */
-					sortedSprites[numSprites] = (IntPtr)spriteInfo;
+					// Store a pointer that we will sort when flushing the batch.
+					sortedSprites[numSprites] = (IntPtr) spriteInfo;
 				}
 
-				/* Have to keep Texture2D out of SpriteInfo for it to stay an unmanaged type. */
+				// Have to keep Texture2D out of SpriteInfo for it to stay an unmanaged type.
 				textureInfo[numSprites] = texture;
 
 				numSprites += 1;
@@ -1175,7 +1205,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				vertexBuffer.SetDataPointerEXT(
 					0,
-					(IntPtr)p,
+					(IntPtr) p,
 					numSprites * VertexPositionColorTexture4.RealStride,
 					SetDataOptions.None
 				);
@@ -1241,7 +1271,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			float rotationSin,
 			float rotationCos,
 			float depth,
-			byte effects)
+			byte effects
+		)
 		{
 			float cornerX = -originX * destinationW;
 			float cornerY = -originY * destinationH;

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1234,7 +1234,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					for (int i = 0; i < numSprites; i += 1)
 					{
-						SpriteInfo* info = (SpriteInfo*)infos[i];
+						SpriteInfo* info = (SpriteInfo*) infos[i];
 						GenerateVertexInfo(
 							&sprites[i],
 							info->sourceX,
@@ -1479,8 +1479,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			public unsafe int Compare(IntPtr i1, IntPtr i2)
 			{
-				SpriteInfo* p1 = (SpriteInfo*)i1;
-				SpriteInfo* p2 = (SpriteInfo*)i2;
+				SpriteInfo* p1 = (SpriteInfo*) i1;
+				SpriteInfo* p2 = (SpriteInfo*) i2;
 				return p1->textureHash.CompareTo(p2->textureHash);
 			}
 		}
@@ -1489,8 +1489,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			public unsafe int Compare(IntPtr i1, IntPtr i2)
 			{
-				SpriteInfo* p1 = (SpriteInfo*)i1;
-				SpriteInfo* p2 = (SpriteInfo*)i2;
+				SpriteInfo* p1 = (SpriteInfo*) i1;
+				SpriteInfo* p2 = (SpriteInfo*) i2;
 				return p2->depth.CompareTo(p1->depth);
 			}
 		}
@@ -1499,8 +1499,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			public unsafe int Compare(IntPtr i1, IntPtr i2)
 			{
-				SpriteInfo* p1 = (SpriteInfo*)i1;
-				SpriteInfo* p2 = (SpriteInfo*)i2;
+				SpriteInfo* p1 = (SpriteInfo*) i1;
+				SpriteInfo* p2 = (SpriteInfo*) i2;
 				return p1->depth.CompareTo(p2->depth);
 			}
 		}

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 #endregion
@@ -1226,7 +1225,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		[MethodImpl(256)]
 		private static unsafe void GenerateVertexInfo(
 			VertexPositionColorTexture4* sprite,
 			float sourceX,


### PR DESCRIPTION
Why implement one when you can implement two at twice the cost.

This PR buffers the information used to generate sprite vertex and texture information in an array of SpriteInfo value types (structs), when sorting modes are used, then sorts it using an accompanying array of pointers to those structs, and finally computes the native compatible vertex information array.

In my latest measurements on a Ryzen 7 1800X CPU with AMD 390X GPU, this is consistently a little bit faster than my version that uses an array SpriteInfo classes.

```
Technique: Fna (Before - Stock FNA)
           Type Average     Min     Max  Median
       Deferred    4039    2300    6643    4472
      Immediate   32314   29476   52610   41043
        Texture   15854   11469   28702   20086
    BackToFront   16420   11487   24060   17774
    FrontToBack   17040   11760   29844   20802
```

```
Technique: Fna (SpriteInfo classes)
           Type Average     Min     Max  Median
       Deferred    4043    2409    6765    4587
      Immediate   31869   30341   54410   42376
        Texture    8581    5229   13705    9467
    BackToFront   10567    7107   18253   12680
    FrontToBack   10873    7161   17237   12199
```

This PR:
```
Technique: Fna (SpriteInfo structs and pointers)
           Type Average     Min     Max  Median
       Deferred    3873    2368    6963    4666
      Immediate   32400   29600   52248   40924
        Texture    7522    4962   11525    8244
    BackToFront    9458    6385   15803   11094
    FrontToBack    9489    6372   16014   11193
```