### PR TITLE
Fix struct uniforms

### DIFF
--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1120,7 +1120,7 @@ namespace Microsoft.Xna.Framework.Graphics
 								XNAType[(int) mem[j].info.parameter_type],
 								null, // FIXME: Nested structs! -flibit
 								null,
-								curOffset
+								param.value.values + curOffset.ToInt32()
 							));
 							uint memSize = mem[j].info.rows + mem[j].info.columns;
 							if (mem[j].info.elements > 0)

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1110,7 +1110,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						IntPtr curOffset = IntPtr.Zero;
 						for (int j = 0; j < param.value.type.member_count; j += 1)
 						{
-							uint memSize = mem[j].info.rows + mem[j].info.columns;
+							uint memSize = mem[j].info.rows * mem[j].info.columns;
 							if (mem[j].info.elements > 0)
 							{
 								memSize *= mem[j].info.elements;

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1110,6 +1110,11 @@ namespace Microsoft.Xna.Framework.Graphics
 						IntPtr curOffset = IntPtr.Zero;
 						for (int j = 0; j < param.value.type.member_count; j += 1)
 						{
+							uint memSize = mem[j].info.rows + mem[j].info.columns;
+							if (mem[j].info.elements > 0)
+							{
+								memSize *= mem[j].info.elements;
+							}
 							memList.Add(new EffectParameter(
 								Marshal.PtrToStringAnsi(mem[j].name),
 								null,
@@ -1120,22 +1125,19 @@ namespace Microsoft.Xna.Framework.Graphics
 								XNAType[(int) mem[j].info.parameter_type],
 								null, // FIXME: Nested structs! -flibit
 								null,
-								param.value.values + curOffset.ToInt32()
+								param.value.values + curOffset.ToInt32(),
+								(uint)memSize * 4
 							));
-							uint memSize = mem[j].info.rows + mem[j].info.columns;
-							if (mem[j].info.elements > 0)
-							{
-								memSize *= mem[j].info.elements;
-							}
 							curOffset += (int) memSize * 4;
 						}
 					}
 					structMembers = new EffectParameterCollection(memList);
 				}
 
+				var name = Marshal.PtrToStringAnsi(param.value.name);
+				var semantic = Marshal.PtrToStringAnsi(param.value.semantic);
 				parameters.Add(new EffectParameter(
-					Marshal.PtrToStringAnsi(param.value.name),
-					Marshal.PtrToStringAnsi(param.value.semantic),
+					name, semantic,
 					(int) param.value.type.rows,
 					(int) param.value.type.columns,
 					(int) param.value.type.elements,
@@ -1146,7 +1148,8 @@ namespace Microsoft.Xna.Framework.Graphics
 						param.annotations,
 						param.annotation_count
 					),
-					param.value.values
+					param.value.values,
+                    param.value.value_count * sizeof(float)
 				));
 			}
 			Parameters = new EffectParameterCollection(parameters);

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1134,10 +1134,9 @@ namespace Microsoft.Xna.Framework.Graphics
 					structMembers = new EffectParameterCollection(memList);
 				}
 
-				var name = Marshal.PtrToStringAnsi(param.value.name);
-				var semantic = Marshal.PtrToStringAnsi(param.value.semantic);
 				parameters.Add(new EffectParameter(
-					name, semantic,
+					Marshal.PtrToStringAnsi(param.value.name),
+					Marshal.PtrToStringAnsi(param.value.semantic),
 					(int) param.value.type.rows,
 					(int) param.value.type.columns,
 					(int) param.value.type.elements,

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1126,7 +1126,7 @@ namespace Microsoft.Xna.Framework.Graphics
 								null, // FIXME: Nested structs! -flibit
 								null,
 								param.value.values + curOffset.ToInt32(),
-								(uint)memSize * 4
+								memSize * 4
 							));
 							curOffset += (int) memSize * 4;
 						}

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1149,7 +1149,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						param.annotation_count
 					),
 					param.value.values,
-                    param.value.value_count * sizeof(float)
+					param.value.value_count * sizeof(float)
 				));
 			}
 			Parameters = new EffectParameterCollection(parameters);

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		internal Texture texture;
 
 		internal IntPtr values;
+		internal uint   valuesSizeBytes;
 
 		#endregion
 
@@ -95,10 +96,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			EffectParameterType parameterType,
 			EffectParameterCollection structureMembers,
 			EffectAnnotationCollection annotations,
-			IntPtr data
+			IntPtr data,
+			uint dataSizeBytes
 		) {
-            if (data == IntPtr.Zero)
-                throw new ArgumentNullException("data");
+			if (data == IntPtr.Zero)
+				throw new ArgumentNullException("data");
 
 			Name = name;
 			Semantic = semantic;
@@ -121,6 +123,11 @@ namespace Microsoft.Xna.Framework.Graphics
 							{
 								memElems = structureMembers[j].Elements.Count;
 							}
+							int memSize = structureMembers[j].RowCount * 4;
+							if (memElems > 0)
+							{
+								memSize *= memElems;
+							}
 							memList.Add(new EffectParameter(
 								structureMembers[j].Name,
 								structureMembers[j].Semantic,
@@ -131,13 +138,9 @@ namespace Microsoft.Xna.Framework.Graphics
 								structureMembers[j].ParameterType,
 								null, // FIXME: Nested structs! -flibit
 								structureMembers[j].Annotations,
-								new IntPtr(data.ToInt64() + curOffset)
+								new IntPtr(data.ToInt64() + curOffset),
+								(uint)memSize * 4
 							));
-							int memSize = structureMembers[j].RowCount * 4;
-							if (memElems > 0)
-							{
-								memSize *= memElems;
-							}
 							curOffset += memSize * 4;
 						}
 						elementMembers = new EffectParameterCollection(memList);
@@ -155,7 +158,9 @@ namespace Microsoft.Xna.Framework.Graphics
 						null,
 						new IntPtr(
 							data.ToInt64() + (i * rowCount * 16)
-						)
+						),
+						// FIXME: Not obvious to me how to compute this -kg
+						0
 					));
 				}
 				Elements = new EffectParameterCollection(elements);
@@ -165,6 +170,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			StructureMembers = structureMembers;
 			Annotations = annotations;
 			values = data;
+			valuesSizeBytes = dataSizeBytes;
 		}
 
 		#endregion
@@ -1055,5 +1061,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+        public void GetDataPointerEXT (out IntPtr pointer, out uint sizeBytes) {
+            pointer = values;
+            sizeBytes = valuesSizeBytes;
+        }
 	}
 }

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		internal Texture texture;
 
 		internal IntPtr values;
-		internal uint   valuesSizeBytes;
+		internal uint valuesSizeBytes;
 
 		#endregion
 
@@ -99,8 +99,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			IntPtr data,
 			uint dataSizeBytes
 		) {
-			if (data == IntPtr.Zero)
+			if (data == IntPtr.Zero) {
 				throw new ArgumentNullException("data");
+			}
 
 			Name = name;
 			Semantic = semantic;
@@ -139,7 +140,7 @@ namespace Microsoft.Xna.Framework.Graphics
 								null, // FIXME: Nested structs! -flibit
 								structureMembers[j].Annotations,
 								new IntPtr(data.ToInt64() + curOffset),
-								(uint)memSize * 4
+								(uint) memSize * 4
 							));
 							curOffset += memSize * 4;
 						}
@@ -1061,10 +1062,5 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
-
-		public void GetDataPointerEXT (out IntPtr pointer, out uint sizeBytes) {
-			pointer = values;
-			sizeBytes = valuesSizeBytes;
-		}
 	}
 }

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -1062,9 +1062,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-        public void GetDataPointerEXT (out IntPtr pointer, out uint sizeBytes) {
-            pointer = values;
-            sizeBytes = valuesSizeBytes;
-        }
+		public void GetDataPointerEXT (out IntPtr pointer, out uint sizeBytes) {
+			pointer = values;
+			sizeBytes = valuesSizeBytes;
+		}
 	}
 }

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -97,6 +97,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			EffectAnnotationCollection annotations,
 			IntPtr data
 		) {
+            if (data == IntPtr.Zero)
+                throw new ArgumentNullException("data");
+
 			Name = name;
 			Semantic = semantic;
 			RowCount = rowCount;


### PR DESCRIPTION
This fixes support for struct-typed shader uniforms by correcting EffectParameter's size calculation, and also exposes an address+size pair for each EffectParameter that user code can get out of the parameter (to fiddle with uniforms by hand, like I do).