### PR TITLE
Clamp glPixelStorei alignment for texture uploads to 8 as demanded by the spec

### DIFF
--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -2713,8 +2713,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			else
 			{
-				// Set pixel alignment to match texel size in bytes
-				int packSize = Texture.GetFormatSize(format);
+				// Set pixel alignment to match texel size in bytes. Maximum allowed value is 8
+                // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glPixelStorei.xml
+				int packSize = Math.Min(Texture.GetFormatSize(format), 8);
 				if (packSize != 4)
 				{
 					glPixelStorei(


### PR DESCRIPTION
Right now if I try to upload a Vector4 texture, pixelstorei fails because the requested alignment (16 bytes) is too much.

It seems like uploads still work right with the clamping set to 8.