### PR TITLE
Fix ShowRuntimeError crash

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1487,8 +1487,8 @@ namespace Microsoft.Xna.Framework
 		{
 			SDL.SDL_ShowSimpleMessageBox(
 				SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
-				title,
-				message,
+				title ?? "",
+				message ?? "",
 				IntPtr.Zero
 			);
 		}


### PR DESCRIPTION
Fixes a crash on .NET Core when showing a runtime error message due to the title or message being null.