### PR TITLE
Use polling for TouchPanel.GetState + FingerIdEXT

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Xna.Framework
 			StartMicrophone =		SDL2_FNAPlatform.StartMicrophone;
 			StopMicrophone =		SDL2_FNAPlatform.StopMicrophone;
 			GetTouchCapabilities =		SDL2_FNAPlatform.GetTouchCapabilities;
+			UpdateTouchPanelState =		SDL2_FNAPlatform.UpdateTouchPanelState;
 			GetNumTouchFingers =		SDL2_FNAPlatform.GetNumTouchFingers;
 			SupportsOrientationChanges =	SDL2_FNAPlatform.SupportsOrientationChanges;
 
@@ -284,6 +285,9 @@ namespace Microsoft.Xna.Framework
 
 		public delegate TouchPanelCapabilities GetTouchCapabilitiesFunc();
 		public static readonly GetTouchCapabilitiesFunc GetTouchCapabilities;
+
+		public delegate void UpdateTouchPanelStateFunc();
+		public static readonly UpdateTouchPanelStateFunc UpdateTouchPanelState;
 
 		public delegate int GetNumTouchFingersFunc();
 		public static readonly GetNumTouchFingersFunc GetNumTouchFingers;

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -2567,33 +2567,27 @@ namespace Microsoft.Xna.Framework
 			};
 		}
 
-		public static void UpdateTouchPanelState()
+		public static unsafe void UpdateTouchPanelState()
 		{
 			// Poll the touch device for all active fingers
 			long touchDevice = SDL.SDL_GetTouchDevice(0);
 			for (int i = 0; i < TouchPanel.MAX_TOUCHES; i += 1)
 			{
-				IntPtr fingerPtr = SDL.SDL_GetTouchFinger(touchDevice, i);
-				if (fingerPtr == IntPtr.Zero)
+				SDL.SDL_Finger* finger = (SDL.SDL_Finger*) SDL.SDL_GetTouchFinger(touchDevice, i);
+				if (finger == null)
 				{
 					// No finger found at this index
 					TouchPanel.SetFinger(i, TouchPanel.NO_FINGER, Vector2.Zero);
 					continue;
 				}
 
-				// Get finger info
-				SDL.SDL_Finger finger = (SDL.SDL_Finger) Marshal.PtrToStructure(
-					fingerPtr,
-					typeof(SDL.SDL_Finger)
-				);
-
 				// Send the finger data to the TouchPanel
 				TouchPanel.SetFinger(
 					i,
-					(int) finger.id,
+					(int) finger->id,
 					new Vector2(
-						(float) Math.Round(finger.x * TouchPanel.DisplayWidth),
-						(float) Math.Round(finger.y * TouchPanel.DisplayHeight)
+						(float) Math.Round(finger->x * TouchPanel.DisplayWidth),
+						(float) Math.Round(finger->y * TouchPanel.DisplayHeight)
 					)
 				);
 			}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -884,7 +884,7 @@ namespace Microsoft.Xna.Framework
 						TouchPanel.TouchDeviceExists = true;
 
 						TouchPanel.INTERNAL_onTouchEvent(
-							(int)evt.tfinger.fingerId,
+							(int) evt.tfinger.fingerId,
 							TouchLocationState.Pressed,
 							evt.tfinger.x,
 							evt.tfinger.y,
@@ -895,7 +895,7 @@ namespace Microsoft.Xna.Framework
 					else if (evt.type == SDL.SDL_EventType.SDL_FINGERMOTION)
 					{
 						TouchPanel.INTERNAL_onTouchEvent(
-							(int)evt.tfinger.fingerId,
+							(int) evt.tfinger.fingerId,
 							TouchLocationState.Moved,
 							evt.tfinger.x,
 							evt.tfinger.y,
@@ -906,7 +906,7 @@ namespace Microsoft.Xna.Framework
 					else if (evt.type == SDL.SDL_EventType.SDL_FINGERUP)
 					{
 						TouchPanel.INTERNAL_onTouchEvent(
-							(int)evt.tfinger.fingerId,
+							(int) evt.tfinger.fingerId,
 							TouchLocationState.Released,
 							evt.tfinger.x,
 							evt.tfinger.y,
@@ -2565,6 +2565,37 @@ namespace Microsoft.Xna.Framework
 				IsConnected = touchDeviceExists,
 				MaximumTouchCount = touchDeviceExists ? 4 : 0
 			};
+		}
+
+		public static void UpdateTouchPanelState()
+		{
+			// Poll the touch device for all active fingers
+			long touchDevice = SDL.SDL_GetTouchDevice(0);
+			for (int i = 0; i < TouchPanel.MAX_TOUCHES; i += 1)
+			{
+				IntPtr fingerPtr = SDL.SDL_GetTouchFinger(touchDevice, i);
+				if (fingerPtr == IntPtr.Zero)
+				{
+					TouchPanel.SetFinger(i, -1, Vector2.Zero);
+					continue;
+				}
+
+				// Get finger info
+				SDL.SDL_Finger finger = (SDL.SDL_Finger) Marshal.PtrToStructure(
+					fingerPtr,
+					typeof(SDL.SDL_Finger)
+				);
+
+				// Hand over the finger data to the TouchPanel
+				TouchPanel.SetFinger(
+					i,
+					(int) finger.id,
+					new Vector2(
+						(float) Math.Round(finger.x * TouchPanel.DisplayWidth),
+						(float) Math.Round(finger.y * TouchPanel.DisplayHeight)
+					)
+				);
+			}
 		}
 
 		public static int GetNumTouchFingers()

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -2587,7 +2587,7 @@ namespace Microsoft.Xna.Framework
 					typeof(SDL.SDL_Finger)
 				);
 
-				// Hand over the finger data to the TouchPanel
+				// Send the finger data to the TouchPanel
 				TouchPanel.SetFinger(
 					i,
 					(int) finger.id,

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -2576,7 +2576,8 @@ namespace Microsoft.Xna.Framework
 				IntPtr fingerPtr = SDL.SDL_GetTouchFinger(touchDevice, i);
 				if (fingerPtr == IntPtr.Zero)
 				{
-					TouchPanel.SetFinger(i, -1, Vector2.Zero);
+					// No finger found at this index
+					TouchPanel.SetFinger(i, TouchPanel.NO_FINGER, Vector2.Zero);
 					continue;
 				}
 

--- a/src/Input/Touch/GestureDetector.cs
+++ b/src/Input/Touch/GestureDetector.cs
@@ -156,7 +156,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 								GestureType.DoubleTap,
 								touchPosition,
 								Vector2.Zero,
-								GetGestureTimestamp()
+								GetGestureTimestamp(),
+								-1,
+								-1
 							));
 
 							justDoubleTapped = true;
@@ -221,7 +223,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 									GestureType.Tap,
 									touchPosition,
 									Vector2.Zero,
-									GetGestureTimestamp()
+									GetGestureTimestamp(),
+									-1,
+									-1
 								));
 							}
 
@@ -255,7 +259,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 						GestureType.Flick,
 						Vector2.Zero,
 						Vector2.Zero,
-						GetGestureTimestamp()
+						GetGestureTimestamp(),
+						fingerId,
+						-1
 					));
 				}
 
@@ -283,7 +289,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 						GestureType.DragComplete,
 						Vector2.Zero,
 						Vector2.Zero,
-						GetGestureTimestamp()
+						GetGestureTimestamp(),
+						fingerId,
+						-1
 					));
 				}
 			}
@@ -300,7 +308,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					GestureType.PinchComplete,
 					Vector2.Zero,
 					Vector2.Zero,
-					GetGestureTimestamp()
+					GetGestureTimestamp(),
+					-1,
+					-1
 				));
 			}
 			callBelatedPinchComplete = false;
@@ -390,7 +400,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					GestureType.HorizontalDrag,
 					touchPosition,
 					Vector2.Zero,
-					GetGestureTimestamp()
+					GetGestureTimestamp(),
+					fingerId,
+					-1
 				));
 			}
 			else if (state == GestureState.DRAGGING_V && vdrag)
@@ -402,7 +414,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					GestureType.VerticalDrag,
 					touchPosition,
 					Vector2.Zero,
-					GetGestureTimestamp()
+					GetGestureTimestamp(),
+					fingerId,
+					-1
 				));
 			}
 			else if (state == GestureState.DRAGGING_FREE && fdrag)
@@ -414,7 +428,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					GestureType.FreeDrag,
 					touchPosition,
 					Vector2.Zero,
-					GetGestureTimestamp()
+					GetGestureTimestamp(),
+					fingerId,
+					-1
 				));
 			}
 
@@ -511,7 +527,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 						GestureType.Hold,
 						activeFingerPosition,
 						Vector2.Zero,
-						GetGestureTimestamp()
+						GetGestureTimestamp(),
+						activeFingerId,
+						-1
 					));
 
 					state = GestureState.HELD;
@@ -561,7 +579,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					GestureType.PinchComplete,
 					Vector2.Zero,
 					Vector2.Zero,
-					GetGestureTimestamp()
+					GetGestureTimestamp(),
+					activeFingerId,
+					secondFingerId
 				));
 			}
 
@@ -627,7 +647,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					GestureType.Pinch,
 					activeFingerPosition,
 					secondFingerPosition,
-					GetGestureTimestamp()
+					GetGestureTimestamp(),
+					activeFingerId,
+					secondFingerId
 				));
 			}
 			else
@@ -639,7 +661,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					GestureType.Pinch,
 					activeFingerPosition,
 					secondFingerPosition,
-					GetGestureTimestamp()
+					GetGestureTimestamp(),
+					activeFingerId,
+					secondFingerId
 				));
 			}
 		}

--- a/src/Input/Touch/GestureDetector.cs
+++ b/src/Input/Touch/GestureDetector.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			#endregion
 		}
 
-		internal static void OnTick()
+		internal static void OnUpdate()
 		{
 			if (state == GestureState.PINCHING)
 			{

--- a/src/Input/Touch/GestureDetector.cs
+++ b/src/Input/Touch/GestureDetector.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		#region Private Static Variables
 
 		// The ID of the active finger
-		private static int activeFingerId = -1;
+		private static int activeFingerId = TouchPanel.NO_FINGER;
 
 		// The current position of the active finger
 		private static Vector2 activeFingerPosition;
@@ -49,7 +49,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		private static Vector2 pressPosition;
 
 		// The ID of the second finger (used only for Pinching)
-		private static int secondFingerId = -1;
+		private static int secondFingerId = TouchPanel.NO_FINGER;
 
 		// The current position of the second finger (used only for Pinching)
 		private static Vector2 secondFingerPosition;
@@ -111,7 +111,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			}
 
 			// Set the active finger if there isn't one already
-			if (activeFingerId == -1)
+			if (activeFingerId == TouchPanel.NO_FINGER)
 			{
 				activeFingerId = fingerId;
 				activeFingerPosition = touchPosition;
@@ -157,8 +157,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
 								touchPosition,
 								Vector2.Zero,
 								GetGestureTimestamp(),
-								-1,
-								-1
+								TouchPanel.NO_FINGER,
+								TouchPanel.NO_FINGER
 							));
 
 							justDoubleTapped = true;
@@ -188,7 +188,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			// Did the user lift the active finger?
 			if (fingerId == activeFingerId)
 			{
-				activeFingerId = -1;
+				activeFingerId = TouchPanel.NO_FINGER;
 			}
 
 			// We're only interested in the very last finger to leave
@@ -224,8 +224,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
 									touchPosition,
 									Vector2.Zero,
 									GetGestureTimestamp(),
-									-1,
-									-1
+									TouchPanel.NO_FINGER,
+									TouchPanel.NO_FINGER
 								));
 							}
 
@@ -261,7 +261,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 						Vector2.Zero,
 						GetGestureTimestamp(),
 						fingerId,
-						-1
+						TouchPanel.NO_FINGER
 					));
 				}
 
@@ -291,7 +291,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 						Vector2.Zero,
 						GetGestureTimestamp(),
 						fingerId,
-						-1
+						TouchPanel.NO_FINGER
 					));
 				}
 			}
@@ -309,8 +309,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					Vector2.Zero,
 					Vector2.Zero,
 					GetGestureTimestamp(),
-					-1,
-					-1
+					TouchPanel.NO_FINGER,
+					TouchPanel.NO_FINGER
 				));
 			}
 			callBelatedPinchComplete = false;
@@ -336,7 +336,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			}
 
 			// Replace the active finger if we lost it
-			if (activeFingerId == -1)
+			if (activeFingerId == TouchPanel.NO_FINGER)
 			{
 				activeFingerId = fingerId;
 			}
@@ -402,7 +402,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					Vector2.Zero,
 					GetGestureTimestamp(),
 					fingerId,
-					-1
+					TouchPanel.NO_FINGER
 				));
 			}
 			else if (state == GestureState.DRAGGING_V && vdrag)
@@ -416,7 +416,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					Vector2.Zero,
 					GetGestureTimestamp(),
 					fingerId,
-					-1
+					TouchPanel.NO_FINGER
 				));
 			}
 			else if (state == GestureState.DRAGGING_FREE && fdrag)
@@ -430,7 +430,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					Vector2.Zero,
 					GetGestureTimestamp(),
 					fingerId,
-					-1
+					TouchPanel.NO_FINGER
 				));
 			}
 
@@ -462,7 +462,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 				if (!IsGestureEnabled(GestureType.Pinch))
 				{
 					state = GestureState.HELD;
-					secondFingerId = -1;
+					secondFingerId = TouchPanel.NO_FINGER;
 
 					// Still might need to trigger a PinchComplete
 					callBelatedPinchComplete = true;
@@ -473,7 +473,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			}
 
 			// Must have an active finger to proceed
-			if (activeFingerId == -1)
+			if (activeFingerId == TouchPanel.NO_FINGER)
 			{
 				return;
 			}
@@ -529,7 +529,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 						Vector2.Zero,
 						GetGestureTimestamp(),
 						activeFingerId,
-						-1
+						TouchPanel.NO_FINGER
 					));
 
 					state = GestureState.HELD;
@@ -594,7 +594,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			}
 
 			// Regardless, we no longer have a second finger
-			secondFingerId = -1;
+			secondFingerId = TouchPanel.NO_FINGER;
 
 			// Attempt to replace our fallen comrade
 			bool replacedSecondFinger = false;

--- a/src/Input/Touch/GestureDetector.cs
+++ b/src/Input/Touch/GestureDetector.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 								touchPosition,
 								Vector2.Zero,
 								GetGestureTimestamp(),
-								TouchPanel.NO_FINGER,
+								fingerId,
 								TouchPanel.NO_FINGER
 							));
 
@@ -224,7 +224,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 									touchPosition,
 									Vector2.Zero,
 									GetGestureTimestamp(),
-									TouchPanel.NO_FINGER,
+									fingerId,
 									TouchPanel.NO_FINGER
 								));
 							}

--- a/src/Input/Touch/GestureSample.cs
+++ b/src/Input/Touch/GestureSample.cs
@@ -56,6 +56,22 @@ namespace Microsoft.Xna.Framework.Input.Touch
 
 		#endregion
 
+		#region Public FNA Extension Properties
+
+		public int FingerIdEXT
+		{
+			get;
+			private set;
+		}
+
+		public int FingerId2EXT
+		{
+			get;
+			private set;
+		}
+
+		#endregion
+
 		#region Internal Constructor
 
 		internal GestureSample(
@@ -64,7 +80,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			GestureType gestureType,
 			Vector2 position,
 			Vector2 position2,
-			TimeSpan timestamp
+			TimeSpan timestamp,
+			int fingerId,
+			int fingerId2
 		) : this() {
 			Delta = delta;
 			Delta2 = delta2;
@@ -72,6 +90,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			Position = position;
 			Position2 = position2;
 			Timestamp = timestamp;
+			FingerIdEXT = fingerId;
+			FingerId2EXT = fingerId2;
 		}
 
 		#endregion

--- a/src/Input/Touch/TouchPanel.cs
+++ b/src/Input/Touch/TouchPanel.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		private static Queue<GestureSample> gestures = new Queue<GestureSample>();
 		private static TouchLocation[] touches = new TouchLocation[MAX_TOUCHES];
 		private static TouchLocation[] prevTouches = new TouchLocation[MAX_TOUCHES];
+		private static List<TouchLocation> validTouches = new List<TouchLocation>();
 
 		#endregion
 
@@ -92,9 +93,15 @@ namespace Microsoft.Xna.Framework.Input.Touch
 
 		public static TouchCollection GetState()
 		{
-			return new TouchCollection(
-				Array.FindAll(touches, t => t.State != TouchLocationState.Invalid)
-			);
+			validTouches.Clear();
+			for (int i = 0; i < MAX_TOUCHES; i += 1)
+			{
+				if (touches[i].State != TouchLocationState.Invalid)
+				{
+					validTouches.Add(touches[i]);
+				}
+			}
+			return new TouchCollection(validTouches.ToArray());
 		}
 
 		public static GestureSample ReadGesture()

--- a/src/Input/Touch/TouchPanel.cs
+++ b/src/Input/Touch/TouchPanel.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 
 				case TouchLocationState.Moved:
 
-					// TODO: Calculate actual (non-rounded) delta if possible
+					// FIXME: This isn't always 100% accurate due to rounding errors
 					Vector2 delta = new Vector2(
 						(float) Math.Round(dx * DisplayWidth),
 						(float) Math.Round(dy * DisplayHeight)

--- a/src/Input/Touch/TouchPanel.cs
+++ b/src/Input/Touch/TouchPanel.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		// The maximum number of simultaneous touches allowed by XNA.
 		internal const int MAX_TOUCHES = 8;
 
+		// The value that represents the absence of a finger.
+		internal const int NO_FINGER = -1;
+
 		#endregion
 
 		#region Public Static Properties
@@ -154,7 +157,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 
 		internal static void SetFinger(int index, int fingerId, Vector2 fingerPos)
 		{
-			if (fingerId == -1)
+			if (fingerId == NO_FINGER)
 			{
 				// Was there a finger here before and the user just released it?
 				if (prevTouches[index].State != TouchLocationState.Invalid
@@ -175,7 +178,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					 * is not included in GetState().
 					 */
 					touches[index] = new TouchLocation(
-						-1,
+						NO_FINGER,
 						TouchLocationState.Invalid,
 						Vector2.Zero
 					);

--- a/src/Input/Touch/TouchPanel.cs
+++ b/src/Input/Touch/TouchPanel.cs
@@ -137,7 +137,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
 
 				case TouchLocationState.Moved:
 
-					// FIXME: This isn't always 100% accurate due to rounding errors
 					Vector2 delta = new Vector2(
 						(float) Math.Round(dx * DisplayWidth),
 						(float) Math.Round(dy * DisplayHeight)


### PR DESCRIPTION
This PR contains a few fixes/changes to the Touch namespace. Namely...

1. The kinda wonky event-based touch processing for TouchPanel.GetState has been replaced with a polling system that scans all the fingers currently active on the screen and compares them to their previous state. This is probably closer to what XNA did internally, and this may fix an annoyingly elusive bug where touches weren't registered as released when they should be. (Haven't 100% verified this fixes it, though.) Gesture detection is still event-driven, though!

2. I replaced the multitude of `-1`'s hanging out in GestureDetector and TouchPanel with an actual constant (`TouchPanel.NO_FINGER`). This makes things clearer, I think, and it also makes it easier to change in the future if we find out -1 is a valid finger id on some platform.

3. I added two extension properties to GestureSample: `FingerIdEXT` and `FingerId2EXT`. These give the finger ids involved in a gesture (or `NO_FINGER` if not applicable), which is very useful for storing finger info and connecting registered gestures with TouchLocations. I added this because I had a need to prevent a finger from registering as a press on virtual gamepad buttons after it had sent a certain Gesture event. There is no other reliable way to gather this information, so I thought this might qualify as a good FNA extension.