### PR TITLE
Hash+Cache Rasterizer, DepthStencil, and Sampler States

### DIFF
--- a/src/Graphics/States/DepthStencilState.cs
+++ b/src/Graphics/States/DepthStencilState.cs
@@ -174,5 +174,56 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Internal Hash Function
+
+		internal DepthStencilStateHash GetHash()
+		{
+			DepthStencilStateHash hash = new DepthStencilStateHash();
+
+			// Bool -> Int32 conversion
+			int depthBufferEnable = DepthBufferEnable ? 1 : 0;
+			int depthBufferWriteEnable = DepthBufferWriteEnable ? 1 : 0;
+			int stencilEnable = StencilEnable ? 1 : 0;
+			int twoSidedStencilMode = TwoSidedStencilMode ? 1 : 0;
+
+			hash.packedProperties =
+				  ((int) depthBufferEnable		<< 32 - 2)
+				| ((int) depthBufferWriteEnable		<< 32 - 3)
+				| ((int) stencilEnable			<< 32 - 4)
+				| ((int) twoSidedStencilMode		<< 32 - 5)
+				| ((int) DepthBufferFunction		<< 32 - 8)
+				| ((int) StencilFunction		<< 32 - 11)
+				| ((int) CounterClockwiseStencilFunction << 32 - 14)
+				| ((int) StencilPass			<< 32 - 17)
+				| ((int) StencilFail			<< 32 - 20)
+				| ((int) StencilDepthBufferFail		<< 32 - 23)
+				| ((int) CounterClockwiseStencilFail	<< 32 - 26)
+				| ((int) CounterClockwiseStencilPass	<< 32 - 29)
+				| ((int) CounterClockwiseStencilDepthBufferFail);
+			hash.stencilMask = StencilMask;
+			hash.stencilWriteMask = StencilWriteMask;
+			hash.referenceStencil = ReferenceStencil;
+
+			return hash;
+		}
+
+		#endregion
+	}
+
+	internal struct DepthStencilStateHash
+	{
+		internal int packedProperties;
+		internal int stencilMask;
+		internal int stencilWriteMask;
+		internal int referenceStencil;
+
+		public override string ToString()
+		{
+			return    System.Convert.ToString(packedProperties, 2).PadLeft(32, '0')
+				+ System.Convert.ToString(stencilMask, 2).PadLeft(32, '0')
+				+ System.Convert.ToString(stencilWriteMask, 2).PadLeft(32, '0')
+				+ System.Convert.ToString(referenceStencil, 2).PadLeft(32, '0');
+		}
 	}
 }

--- a/src/Graphics/States/RasterizerState.cs
+++ b/src/Graphics/States/RasterizerState.cs
@@ -95,5 +95,52 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Internal Hash Function
+
+		internal RasterizerStateHash GetHash()
+		{
+			RasterizerStateHash hash = new RasterizerStateHash();
+
+			// Bool -> Int32 conversion
+			int multiSampleAntiAlias = (MultiSampleAntiAlias ? 1 : 0);
+			int scissorTestEnable = (ScissorTestEnable ? 1 : 0);
+
+			hash.packedProperties =
+				  ((int) multiSampleAntiAlias	<< 4)
+				| ((int) scissorTestEnable	<< 3)
+				| ((int) CullMode		<< 1)
+				| ((int) FillMode);
+			hash.depthBias = DepthBias;
+			hash.slopeScaleDepthBias = SlopeScaleDepthBias;
+
+			return hash;
+		}
+
+		#endregion
+	}
+
+	internal struct RasterizerStateHash
+	{
+		internal int packedProperties;
+		internal float depthBias;
+		internal float slopeScaleDepthBias;
+
+		public override string ToString()
+		{
+			string binary = System.Convert.ToString(packedProperties, 2).PadLeft(32, '0');
+
+			foreach (byte b in System.BitConverter.GetBytes(depthBias))
+			{
+				binary += System.Convert.ToString(b, 2).PadLeft(8, '0');
+			}
+
+			foreach (byte b in System.BitConverter.GetBytes(slopeScaleDepthBias))
+			{
+				binary += System.Convert.ToString(b, 2).PadLeft(8, '0');
+			}
+
+			return binary;
+		}
 	}
 }

--- a/src/Graphics/States/SamplerState.cs
+++ b/src/Graphics/States/SamplerState.cs
@@ -141,5 +141,47 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Internal Hash Function
+
+		internal SamplerStateHash GetHash()
+		{
+			SamplerStateHash hash = new SamplerStateHash();
+
+			hash.filterAndAddresses =
+				  ((int) Filter		<< 6)
+				| ((int) AddressU	<< 4)
+				| ((int) AddressV	<< 2)
+				| ((int) AddressW);
+			hash.maxAnisotropy = MaxAnisotropy;
+			hash.maxMipLevel = MaxMipLevel;
+			hash.mipMapLevelOfDetailBias = MipMapLevelOfDetailBias;
+
+			return hash;
+		}
+
+		#endregion
+	}
+
+	internal struct SamplerStateHash
+	{
+		internal int filterAndAddresses;
+		internal int maxAnisotropy;
+		internal int maxMipLevel;
+		internal float mipMapLevelOfDetailBias;
+
+		public override string ToString()
+		{
+			string binary =   System.Convert.ToString(filterAndAddresses, 2).PadLeft(32, '0')
+					+ System.Convert.ToString(maxAnisotropy, 2).PadLeft(32, '0')
+					+ System.Convert.ToString(maxMipLevel, 2).PadLeft(32, '0');
+
+			foreach (byte b in System.BitConverter.GetBytes(mipMapLevelOfDetailBias))
+			{
+				binary += System.Convert.ToString(b, 2).PadLeft(8, '0');
+			}
+
+			return binary;
+		}
 	}
 }


### PR DESCRIPTION
The other PSOs join the party. Those `ToString` methods are really ugly but useful for verifying hash correctness. We may not need them going forward since I've already tested the hashing pretty extensively, but I'll leave that up to you to decide. I also did a little testing with making arbitrary state changes in an EffectPass for each category of PSO to make sure they get cached properly, and it *seems* right so far. We'd need an actual real-world test case to make sure though.