### PR TITLE
Make VERBOSE_PIPELINECACHE more verbose

### DIFF
--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -182,13 +182,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				blendCache.Add(hash, newBlend);
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New BlendState added to pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 				FNALoggerEXT.LogInfo("Updated size of BlendState cache: " + blendCache.Count);
 			}
 			else
 			{
 				FNALoggerEXT.LogInfo("Retrieved BlendState from pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 #endif
 			}
 
@@ -302,13 +302,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				depthStencilCache.Add(hash, newDepthStencil);
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New DepthStencilState added to pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 				FNALoggerEXT.LogInfo("Updated size of DepthStencilState cache: " + depthStencilCache.Count);
 			}
 			else
 			{
 				FNALoggerEXT.LogInfo("Retrieved DepthStencilState from pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 #endif
 			}
 
@@ -381,13 +381,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				rasterizerCache.Add(hash, newRasterizer);
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New RasterizerState added to pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 				FNALoggerEXT.LogInfo("Updated size of RasterizerState cache: " + rasterizerCache.Count);
 			}
 			else
 			{
 				FNALoggerEXT.LogInfo("Retrieved RasterizerState from pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 #endif
 			}
 
@@ -459,13 +459,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				samplerCache.Add(hash, newSampler);
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New SamplerState added to pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 				FNALoggerEXT.LogInfo("Updated size of SamplerState cache: " + samplerCache.Count);
 			}
 			else
 			{
 				FNALoggerEXT.LogInfo("Retrieved SamplerState from pipeline cache with hash:\n"
-										+ hash.ToString());
+							+ hash.ToString());
 #endif
 			}
 

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -181,7 +181,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 				blendCache.Add(hash, newBlend);
 #if VERBOSE_PIPELINECACHE
-				FNALoggerEXT.LogInfo("New BlendState added to pipeline cache");
+				FNALoggerEXT.LogInfo("New BlendState added to pipeline cache with hash:\n"
+										+ hash.ToString());
+				FNALoggerEXT.LogInfo("Updated size of BlendState cache: " + blendCache.Count);
+			}
+			else
+			{
+				FNALoggerEXT.LogInfo("Retrieved BlendState from pipeline cache with hash:\n"
+										+ hash.ToString());
 #endif
 			}
 
@@ -294,7 +301,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 				depthStencilCache.Add(hash, newDepthStencil);
 #if VERBOSE_PIPELINECACHE
-				FNALoggerEXT.LogInfo("New DepthStencilState added to pipeline cache");
+				FNALoggerEXT.LogInfo("New DepthStencilState added to pipeline cache with hash:\n"
+										+ hash.ToString());
+				FNALoggerEXT.LogInfo("Updated size of DepthStencilState cache: " + depthStencilCache.Count);
+			}
+			else
+			{
+				FNALoggerEXT.LogInfo("Retrieved DepthStencilState from pipeline cache with hash:\n"
+										+ hash.ToString());
 #endif
 			}
 
@@ -366,7 +380,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 				rasterizerCache.Add(hash, newRasterizer);
 #if VERBOSE_PIPELINECACHE
-				FNALoggerEXT.LogInfo("New RasterizerState added to pipeline cache");
+				FNALoggerEXT.LogInfo("New RasterizerState added to pipeline cache with hash:\n"
+										+ hash.ToString());
+				FNALoggerEXT.LogInfo("Updated size of RasterizerState cache: " + rasterizerCache.Count);
+			}
+			else
+			{
+				FNALoggerEXT.LogInfo("Retrieved RasterizerState from pipeline cache with hash:\n"
+										+ hash.ToString());
 #endif
 			}
 
@@ -437,7 +458,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 				samplerCache.Add(hash, newSampler);
 #if VERBOSE_PIPELINECACHE
-				FNALoggerEXT.LogInfo("New SamplerState added to pipeline cache");
+				FNALoggerEXT.LogInfo("New SamplerState added to pipeline cache with hash:\n"
+										+ hash.ToString());
+				FNALoggerEXT.LogInfo("Updated size of SamplerState cache: " + samplerCache.Count);
+			}
+			else
+			{
+				FNALoggerEXT.LogInfo("Retrieved SamplerState from pipeline cache with hash:\n"
+										+ hash.ToString());
 #endif
 			}
 

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -183,7 +183,8 @@ namespace Microsoft.Xna.Framework.Graphics
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New BlendState added to pipeline cache with hash:\n"
 							+ hash.ToString());
-				FNALoggerEXT.LogInfo("Updated size of BlendState cache: " + blendCache.Count);
+				FNALoggerEXT.LogInfo("Updated size of BlendState cache: "
+							+ blendCache.Count);
 			}
 			else
 			{
@@ -303,7 +304,8 @@ namespace Microsoft.Xna.Framework.Graphics
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New DepthStencilState added to pipeline cache with hash:\n"
 							+ hash.ToString());
-				FNALoggerEXT.LogInfo("Updated size of DepthStencilState cache: " + depthStencilCache.Count);
+				FNALoggerEXT.LogInfo("Updated size of DepthStencilState cache: "
+							+ depthStencilCache.Count);
 			}
 			else
 			{
@@ -382,7 +384,8 @@ namespace Microsoft.Xna.Framework.Graphics
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New RasterizerState added to pipeline cache with hash:\n"
 							+ hash.ToString());
-				FNALoggerEXT.LogInfo("Updated size of RasterizerState cache: " + rasterizerCache.Count);
+				FNALoggerEXT.LogInfo("Updated size of RasterizerState cache: "
+							+ rasterizerCache.Count);
 			}
 			else
 			{
@@ -460,7 +463,8 @@ namespace Microsoft.Xna.Framework.Graphics
 #if VERBOSE_PIPELINECACHE
 				FNALoggerEXT.LogInfo("New SamplerState added to pipeline cache with hash:\n"
 							+ hash.ToString());
-				FNALoggerEXT.LogInfo("Updated size of SamplerState cache: " + samplerCache.Count);
+				FNALoggerEXT.LogInfo("Updated size of SamplerState cache: "
+							+ samplerCache.Count);
 			}
 			else
 			{


### PR DESCRIPTION
The build option now makes PipelineCache log *a lot* more verbose. Useful for checking if it's caching and retrieving state objects as expected.