### PR TITLE
Add missing generic type forwards to XNA ABI-compatibility libraries.

### DIFF
--- a/abi/Microsoft.Xna.Framework.cs
+++ b/abi/Microsoft.Xna.Framework.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Content.ContentManager))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Content.ResourceContentManager))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Content.ContentTypeReader))]
+[assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Content.ContentTypeReader<int>))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.FrameworkDispatcher))]
 #if TODO_MEDIASTUB
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Media.MediaLibrary))]
@@ -84,6 +85,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Design.RayConverter))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Design.ColorConverter))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Graphics.PackedVector.IPackedVector))]
+[assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Graphics.PackedVector.IPackedVector<int>))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Graphics.PackedVector.Alpha8))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Graphics.PackedVector.Bgr565))]
 [assembly: TypeForwardedToAttribute(typeof(Microsoft.Xna.Framework.Graphics.PackedVector.Bgra5551))]


### PR DESCRIPTION
This fixes DLC Quest running under wine-mono, and probably several other games as well.