### PR TITLE
Replace Queue<int> for sampler modification tracking with bool[]

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -291,8 +291,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Internal Sampler Change Queue
 
-		private readonly Queue<int> modifiedSamplers = new Queue<int>();
-		private readonly Queue<int> modifiedVertexSamplers = new Queue<int>();
+
+		private readonly bool[] modifiedSamplers = new bool[MAX_TEXTURE_SAMPLERS];
+		private readonly bool[] modifiedVertexSamplers = new bool[MAX_VERTEXTEXTURE_SAMPLERS];
 
 		#endregion
 
@@ -1467,24 +1468,37 @@ namespace Microsoft.Xna.Framework.Graphics
 				RenderTargetCount > 0
 			);
 
-			while (modifiedSamplers.Count > 0)
+			for (int sampler = 0; sampler < modifiedSamplers.Length; sampler += 1)
 			{
-				int sampler = modifiedSamplers.Dequeue();
+				if (!modifiedSamplers[sampler])
+				{
+					continue;
+				}
+
+				modifiedSamplers[sampler] = false;
+
 				GLDevice.VerifySampler(
 					sampler,
 					Textures[sampler],
 					SamplerStates[sampler]
 				);
 			}
-			while (modifiedVertexSamplers.Count > 0)
+
+			for (int sampler = 0; sampler < modifiedVertexSamplers.Length; sampler += 1) 
 			{
+				if (!modifiedVertexSamplers[sampler])
+				{
+					continue;
+				}
+
+				modifiedVertexSamplers[sampler] = false;
+
 				/* Believe it or not, this is actually how VertexTextures are
 				 * stored in XNA4! Their D3D9 renderer just uses the last 4
 				 * slots available in the device's sampler array. So that's what
 				 * we get to do.
 				 * -flibit
 				 */
-				int sampler = modifiedVertexSamplers.Dequeue();
 				GLDevice.VerifySampler(
 					vertexSamplerStart + sampler,
 					VertexTextures[sampler],

--- a/src/Graphics/SamplerStateCollection.cs
+++ b/src/Graphics/SamplerStateCollection.cs
@@ -26,10 +26,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			set
 			{
 				samplers[index] = value;
-				if (!modifiedSamplers.Contains(index))
-				{
-					modifiedSamplers.Enqueue(index);
-				}
+				modifiedSamplers[index] = true;
 			}
 		}
 
@@ -38,7 +35,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		#region Private Variables
 
 		private readonly SamplerState[] samplers;
-		private readonly Queue<int> modifiedSamplers;
+		private readonly bool[] modifiedSamplers;
 
 		#endregion
 
@@ -46,7 +43,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal SamplerStateCollection(
 			int slots,
-			Queue<int> modSamplers
+			bool[] modSamplers
 		) {
 			samplers = new SamplerState[slots];
 			modifiedSamplers = modSamplers;

--- a/src/Graphics/TextureCollection.cs
+++ b/src/Graphics/TextureCollection.cs
@@ -36,10 +36,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 #endif
 				textures[index] = value;
-				if (!modifiedSamplers.Contains(index))
-				{
-					modifiedSamplers.Enqueue(index);
-				}
+				modifiedSamplers[index] = true;
 			}
 		}
 
@@ -48,7 +45,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		#region Private Variables
 
 		private readonly Texture[] textures;
-		private readonly Queue<int> modifiedSamplers;
+		private readonly bool[] modifiedSamplers;
 
 		#endregion
 
@@ -56,7 +53,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal TextureCollection(
 			int slots,
-			Queue<int> modSamplers
+			bool[] modSamplers
 		) {
 			textures = new Texture[slots];
 			modifiedSamplers = modSamplers;


### PR DESCRIPTION
The Queue.Contains call was showing up in my profiles (about 1% of total CPU) and doesn't seem necessary.

I can pull out the comments once you're sure the behavior is right