### PR TITLE
Use dictionary for SpriteFont index lookups

### DIFF
--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -761,8 +761,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				/* Get the List index from the character map, defaulting to the
 				 * DefaultCharacter if it's set.
 				 */
-				int index = characterMap.IndexOf(c);
-				if (index == -1)
+				int index;
+				if (!spriteFont.CharacterIndexMap.TryGetValue(c, out index))
 				{
 					if (!spriteFont.DefaultCharacter.HasValue)
 					{
@@ -772,9 +772,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							"text"
 						);
 					}
-					index = characterMap.IndexOf(
-						spriteFont.DefaultCharacter.Value
-					);
+					index = spriteFont.CharacterIndexMap[spriteFont.DefaultCharacter.Value];
 				}
 
 				/* For the first character in a line, always push the width
@@ -959,8 +957,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				/* Get the List index from the character map, defaulting to the
 				 * DefaultCharacter if it's set.
 				 */
-				int index = characterMap.IndexOf(c);
-				if (index == -1)
+				int index;
+				if (!spriteFont.CharacterIndexMap.TryGetValue(c, out index))
 				{
 					if (!spriteFont.DefaultCharacter.HasValue)
 					{
@@ -970,9 +968,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							"text"
 						);
 					}
-					index = characterMap.IndexOf(
-						spriteFont.DefaultCharacter.Value
-					);
+					index = spriteFont.CharacterIndexMap[spriteFont.DefaultCharacter.Value];
 				}
 
 				/* For the first character in a line, always push the width

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -82,6 +82,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		internal int lineSpacing;
 		internal float spacing;
 
+		internal Dictionary<char, int> CharacterIndexMap;
+
 		#endregion
 
 		#region Internal Constructor
@@ -106,6 +108,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			croppingData = cropping;
 			kerning = kerningData;
 			characterMap = characters;
+
+			CharacterIndexMap = new Dictionary<char, int>(characters.Count);
+			for (int i = 0; i < characters.Count; i += 1)
+			{
+				CharacterIndexMap[characters[i]] = i;
+			}
 		}
 
 		#endregion
@@ -154,8 +162,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				/* Get the List index from the character map, defaulting to the
 				 * DefaultCharacter if it's set.
 				 */
-				int index = characterMap.IndexOf(c);
-				if (index == -1)
+				int index;
+				if (!CharacterIndexMap.TryGetValue(c, out index))
 				{
 					if (!DefaultCharacter.HasValue)
 					{
@@ -165,7 +173,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							"text"
 						);
 					}
-					index = characterMap.IndexOf(DefaultCharacter.Value);
+					index = CharacterIndexMap[DefaultCharacter.Value];
 				}
 
 				/* For the first character in a line, always push the width
@@ -250,8 +258,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				/* Get the List index from the character map, defaulting to the
 				 * DefaultCharacter if it's set.
 				 */
-				int index = characterMap.IndexOf(c);
-				if (index == -1)
+				int index;
+				if (!CharacterIndexMap.TryGetValue(c, out index))
 				{
 					if (!DefaultCharacter.HasValue)
 					{
@@ -261,7 +269,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							"text"
 						);
 					}
-					index = characterMap.IndexOf(DefaultCharacter.Value);
+					index = CharacterIndexMap[DefaultCharacter.Value];
 				}
 
 				/* For the first character in a line, always push the width


### PR DESCRIPTION
Tested with Rogue Legacy: Wanderer Edition on an iPhone XR. This change reduces the time spent in Draw() overall by ~10%, and the per-DrawString performance impact has been reduced 8x. From my testing there's no significant memory impact... if anything, this actually made the RAM usage slightly smaller. (No idea how/why. May be a fluke.)

This needs testing on desktop platforms, but I feel pretty good about its performance on ARM.