### PR TITLE
Remove Color(Color, alpha) constructors

### DIFF
--- a/src/Color.cs
+++ b/src/Color.cs
@@ -1598,40 +1598,6 @@ namespace Microsoft.Xna.Framework
 		}
 
 		/// <summary>
-		/// Constructs an RGBA color from a <see cref="Color"/> and an alpha value.
-		/// </summary>
-		/// <param name="color">
-		/// A <see cref="Color"/> for RGB values of new <see cref="Color"/> instance.
-		/// </param>
-		/// <param name="alpha">The alpha component value from 0 to 255.</param>
-		public Color(Color color, int alpha)
-		{
-			packedValue = 0;
-
-			R = color.R;
-			G = color.G;
-			B = color.B;
-			A = (byte) MathHelper.Clamp(alpha, Byte.MinValue, Byte.MaxValue);
-		}
-
-		/// <summary>
-		/// Constructs an RGBA color from color and alpha value.
-		/// </summary>
-		/// <param name="color">
-		/// A <see cref="Color"/> for RGB values of new <see cref="Color"/> instance.
-		/// </param>
-		/// <param name="alpha">Alpha component value from 0.0f to 1.0f.</param>
-		public Color(Color color, float alpha)
-		{
-			packedValue = 0;
-
-			R = color.R;
-			G = color.G;
-			B = color.B;
-			A = (byte) MathHelper.Clamp(alpha * 255, Byte.MinValue, Byte.MaxValue);
-		}
-
-		/// <summary>
 		/// Constructs an RGBA color from scalars which representing red, green and blue values. Alpha value will be opaque.
 		/// </summary>
 		/// <param name="r">Red component value from 0.0f to 1.0f.</param>


### PR DESCRIPTION
This PR simply removes the following `Color` constructor signatures which don't exist in XNA 4.0:
- `Color(Color color, int alpha)`
- `Color(Color color, float alpha)`

They're [not listed on ~~MSDN~~ Microsoft Docs](https://docs.microsoft.com/en-us/previous-versions/windows/xna/ff433831%28v%3dxnagamestudio.41%29) and are currently causing issues in the Celeste modding community, where mods are built once with either FNA or XNA and then relinked to XNA / FNA depending on which version of the game is running:

```
System.MissingMethodException: Method not found: 'Void Microsoft.Xna.Framework.Color..ctor(Microsoft.Xna.Framework.Color, Single)'.
```