### PR TITLE
IGLDevice Updates

### DIFF
--- a/src/FNAPlatform/IGLDevice.cs
+++ b/src/FNAPlatform/IGLDevice.cs
@@ -159,7 +159,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			SurfaceFormat format,
 			int width,
 			int height,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		);
 		IGLTexture CreateTexture3D(
 			SurfaceFormat format,
@@ -171,7 +172,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		IGLTexture CreateTextureCube(
 			SurfaceFormat format,
 			int size,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		);
 		void AddDisposeTexture(IGLTexture texture);
 		void SetTextureData2D(
@@ -261,7 +263,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			int width,
 			int height,
 			SurfaceFormat format,
-			int multiSampleCount
+			int multiSampleCount,
+			IGLTexture texture
 		);
 		IGLRenderbuffer GenRenderbuffer(
 			int width,

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -2485,7 +2485,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			SurfaceFormat format,
 			int width,
 			int height,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		) {
 			OpenGLTexture result = null;
 
@@ -2600,7 +2601,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		public IGLTexture CreateTextureCube(
 			SurfaceFormat format,
 			int size,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		) {
 			OpenGLTexture result = null;
 
@@ -3291,7 +3293,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			int width,
 			int height,
 			SurfaceFormat format,
-			int multiSampleCount
+			int multiSampleCount,
+			IGLTexture texture
 		) {
 			uint handle = 0;
 

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -635,7 +635,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			// Some users might want pixely upscaling...
 			backbufferScaleMode = Environment.GetEnvironmentVariable(
-				"FNA_OPENGL_BACKBUFFER_SCALE_NEAREST"
+				"FNA_GRAPHICS_BACKBUFFER_SCALE_NEAREST"
 			) == "1" ? GLenum.GL_NEAREST : GLenum.GL_LINEAR;
 
 			// Print GL information

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -2656,7 +2656,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			SurfaceFormat format,
 			int width,
 			int height,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		) {
 			OpenGLTexture result = null;
 
@@ -2762,7 +2763,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		public IGLTexture CreateTextureCube(
 			SurfaceFormat format,
 			int size,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		) {
 			OpenGLTexture result = null;
 
@@ -3600,7 +3602,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			int width,
 			int height,
 			SurfaceFormat format,
-			int multiSampleCount
+			int multiSampleCount,
+			IGLTexture texture
 		) {
 			uint handle = 0;
 

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -712,7 +712,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			// Some users might want pixely upscaling...
 			backbufferScaleMode = Environment.GetEnvironmentVariable(
-				"FNA_OPENGL_BACKBUFFER_SCALE_NEAREST"
+				"FNA_GRAPHICS_BACKBUFFER_SCALE_NEAREST"
 			) == "1" ? GLenum.GL_NEAREST : GLenum.GL_LINEAR;
 
 			// Load the extension list, initialize extension-dependent components

--- a/src/FNAPlatform/ThreadedGLDevice.cs
+++ b/src/FNAPlatform/ThreadedGLDevice.cs
@@ -578,7 +578,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			SurfaceFormat format,
 			int width,
 			int height,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		) {
 			IGLTexture result = null;
 			ForceToMainThread(() =>
@@ -587,7 +588,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					format,
 					width,
 					height,
-					levelCount
+					levelCount,
+					isRenderTarget
 				);
 			}); // End ForceToMainThread
 			return result;
@@ -617,7 +619,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		public IGLTexture CreateTextureCube(
 			SurfaceFormat format,
 			int size,
-			int levelCount
+			int levelCount,
+			bool isRenderTarget
 		) {
 			IGLTexture result = null;
 			ForceToMainThread(() =>
@@ -625,7 +628,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				result = GLDevice.CreateTextureCube(
 					format,
 					size,
-					levelCount
+					levelCount,
+					isRenderTarget
 				);
 			}); // End ForceToMainThread
 			return result;
@@ -844,7 +848,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			int width,
 			int height,
 			SurfaceFormat format,
-			int multiSampleCount
+			int multiSampleCount,
+			IGLTexture texture
 		) {
 			IGLRenderbuffer result = null;
 			ForceToMainThread(() =>
@@ -853,7 +858,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					width,
 					height,
 					format,
-					multiSampleCount
+					multiSampleCount,
+					texture
 				);
 			}); // End ForceToMainThread
 			return result;

--- a/src/Graphics/RenderTarget2D.cs
+++ b/src/Graphics/RenderTarget2D.cs
@@ -149,7 +149,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					Width,
 					Height,
 					Format,
-					MultiSampleCount
+					MultiSampleCount,
+					texture
 				);
 			}
 

--- a/src/Graphics/RenderTargetCube.cs
+++ b/src/Graphics/RenderTargetCube.cs
@@ -184,7 +184,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					Size,
 					Size,
 					Format,
-					MultiSampleCount
+					MultiSampleCount,
+					texture
 				);
 			}
 

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -98,7 +98,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				Format,
 				Width,
 				Height,
-				LevelCount
+				LevelCount,
+				(this is IRenderTarget)
 			);
 		}
 

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			texture = GraphicsDevice.GLDevice.CreateTextureCube(
 				Format,
 				Size,
-				LevelCount
+				LevelCount,
+				(this is IRenderTarget)
 			);
 		}
 


### PR DESCRIPTION
This modifies the IGLDevice interface to allow for features used in MetalDevice. It also renames the `FNA_OPENGL_BACKBUFFER_SCALE_MODE` to `FNA_GRAPHICS_BACKBUFFER_SCALE_MODE`. (The wiki will need to be updated to reflect this change!)