### PR TITLE
SDL2_FNAPlatform updates

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -11,7 +11,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Reflection;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -36,6 +35,8 @@ namespace Microsoft.Xna.Framework
 		) == "1";
 
 		private static bool SupportsGlobalMouse;
+		private static string ForcedGLDevice;
+		private static string ActualGLDevice;
 
 		// For iOS high dpi support
 		private static int RetinaWidth;
@@ -194,11 +195,21 @@ namespace Microsoft.Xna.Framework
 			return false;
 		}
 
+		private static bool PrepareMTLAttributes()
+		{
+			// Coming soon to an FNA near you!
+			return false;
+		}
+
 		private static bool PrepareGLAttributes()
 		{
-			/* TODO: For platforms not using OpenGL (Vulkan/Metal),
-			 * return false to avoid OpenGL WSI calls.
-			 */
+			if (	!String.IsNullOrEmpty(ForcedGLDevice) &&
+				!ForcedGLDevice.Equals("OpenGLDevice") &&
+				!ForcedGLDevice.Equals("ModernGLDevice") &&
+				!ForcedGLDevice.Equals("ThreadedGLDevice")	)
+			{
+				return false;
+			}
 
 			// GLContext environment variables
 			bool forceES3 = Environment.GetEnvironmentVariable(
@@ -329,14 +340,35 @@ namespace Microsoft.Xna.Framework
 				SDL.SDL_WindowFlags.SDL_WINDOW_MOUSE_FOCUS
 			);
 
-			bool vulkan = false, opengl = false;
+			// Did the user force a particular GLDevice?
+			ForcedGLDevice = Environment.GetEnvironmentVariable(
+				"FNA_GRAPHICS_FORCE_GLDEVICE"
+			);
+
+			bool vulkan = false, metal = false, opengl = false;
 			if (vulkan = PrepareVKAttributes())
 			{
 				initFlags |= SDL.SDL_WindowFlags.SDL_WINDOW_VULKAN;
+				ActualGLDevice = "VulkanDevice";
+			}
+			else if (metal = PrepareMTLAttributes())
+			{
+				// FIXME: SDL_WindowFlags.SDL_WINDOW_METAL?
+				ActualGLDevice = "MetalDevice";
 			}
 			else if (opengl = PrepareGLAttributes())
 			{
 				initFlags |= SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL;
+
+				if (	ForcedGLDevice == "ModernGLDevice" ||
+					ForcedGLDevice == "ThreadedGLDevice"	)
+				{
+					ActualGLDevice = ForcedGLDevice;
+				}
+				else
+				{
+					ActualGLDevice = "OpenGLDevice";
+				}
 			}
 
 			if (Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1")
@@ -371,14 +403,14 @@ namespace Microsoft.Xna.Framework
 			// We hide the mouse cursor by default.
 			OnIsMouseVisibleChanged(false);
 
-			/* iOS requires a GL context to get the drawable size
-			 * of the screen, so we create a temporary one here.
+			/* iOS and tvOS require an active GL context
+			 * to get the drawable size of the screen.
 			 * -caleb
 			 */
-			IntPtr tempGLContext = IntPtr.Zero;
-			if (OSVersion.Equals("iOS"))
+			IntPtr tempContext = IntPtr.Zero;
+			if (opengl && (OSVersion.Equals("iOS") || OSVersion.Equals("tvOS")))
 			{
-				tempGLContext = SDL.SDL_GL_CreateContext(window);
+				tempContext = SDL.SDL_GL_CreateContext(window);
 			}
 
 			/* If high DPI is not found, unset the HIGHDPI var.
@@ -390,13 +422,18 @@ namespace Microsoft.Xna.Framework
 			{
 				SDL.SDL_Vulkan_GetDrawableSize(window, out drawX, out drawY);
 			}
+			else if (metal)
+			{
+				// FIXME: This will be fixed when MetalDevice gets here.
+				drawX = drawY = 0;
+			}
 			else if (opengl)
 			{
 				SDL.SDL_GL_GetDrawableSize(window, out drawX, out drawY);
 			}
 			else
 			{
-				throw new InvalidOperationException("Metal? Glide? What?");
+				throw new InvalidOperationException("DirectX? Glide? What?");
 			}
 			if (	drawX == GraphicsDeviceManager.DefaultBackBufferWidth &&
 				drawY == GraphicsDeviceManager.DefaultBackBufferHeight	)
@@ -410,10 +447,10 @@ namespace Microsoft.Xna.Framework
 				RetinaHeight = drawY;
 			}
 
-			// We're done with that temporary GL context.
-			if (tempGLContext != IntPtr.Zero)
+			// We're done with that temporary context.
+			if (tempContext != IntPtr.Zero)
 			{
-				SDL.SDL_GL_DeleteContext(tempGLContext);
+				SDL.SDL_GL_DeleteContext(tempContext);
 			}
 
 			return new FNAWindow(
@@ -1140,19 +1177,29 @@ namespace Microsoft.Xna.Framework
 			PresentationParameters presentationParameters,
 			GraphicsAdapter adapter
 		) {
-			// This loads the OpenGL entry points.
-			string glDevice = Environment.GetEnvironmentVariable("FNA_GRAPHICS_FORCE_GLDEVICE");
-			if (glDevice == "ModernGLDevice")
+			switch (ActualGLDevice)
 			{
-				// FIXME: This is still experimental! -flibit
-				return new ModernGLDevice(presentationParameters, adapter);
+				case "OpenGLDevice":
+					return new OpenGLDevice(presentationParameters, adapter);
+
+				case "ModernGLDevice":
+					// FIXME: This is still experimental! -flibit
+					return new ModernGLDevice(presentationParameters, adapter);
+
+				case "ThreadedGLDevice":
+					// FIXME: This is still experimental! -flibit
+					return new ThreadedGLDevice(presentationParameters, adapter);
+
+				case "MetalDevice":
+					// Coming soon!
+					break;
+
+				case "VulkanDevice":
+					// Maybe someday!
+					break;
 			}
-			if (glDevice == "ThreadedGLDevice")
-			{
-				// FIXME: This is still experimental! -flibit
-				return new ThreadedGLDevice(presentationParameters, adapter);
-			}
-			return new OpenGLDevice(presentationParameters, adapter);
+
+			throw new InvalidOperationException("Gnmx? WebGPU? What?");
 		}
 
 		#endregion

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Xna.Framework
 			}
 			else if (metal = PrepareMTLAttributes())
 			{
-				// FIXME: SDL_WindowFlags.SDL_WINDOW_METAL?
+				// FIXME: SDL_WINDOW_METAL?
 				ActualGLDevice = "MetalDevice";
 			}
 			else if (opengl = PrepareGLAttributes())
@@ -1198,7 +1198,6 @@ namespace Microsoft.Xna.Framework
 					// Maybe someday!
 					break;
 			}
-
 			throw new InvalidOperationException("Gnmx? WebGPU? What?");
 		}
 

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -44,6 +44,16 @@ namespace Microsoft.Xna.Framework
 
 		#endregion
 
+		#region Graphics Backend String Constants
+
+		private const string OPENGL = "OpenGLDevice";
+		private const string MODERNGL = "ModernGLDevice";
+		private const string THREADEDGL = "ThreadedGLDevice";
+		private const string METAL = "MetalDevice";
+		private const string VULKAN = "VulkanDevice";
+
+		#endregion
+
 		#region Game Objects
 
 		/* This is needed for asynchronous window events */
@@ -204,9 +214,9 @@ namespace Microsoft.Xna.Framework
 		private static bool PrepareGLAttributes()
 		{
 			if (	!String.IsNullOrEmpty(ForcedGLDevice) &&
-				!ForcedGLDevice.Equals("OpenGLDevice") &&
-				!ForcedGLDevice.Equals("ModernGLDevice") &&
-				!ForcedGLDevice.Equals("ThreadedGLDevice")	)
+				!ForcedGLDevice.Equals(OPENGL) &&
+				!ForcedGLDevice.Equals(MODERNGL) &&
+				!ForcedGLDevice.Equals(THREADEDGL)	)
 			{
 				return false;
 			}
@@ -349,24 +359,24 @@ namespace Microsoft.Xna.Framework
 			if (vulkan = PrepareVKAttributes())
 			{
 				initFlags |= SDL.SDL_WindowFlags.SDL_WINDOW_VULKAN;
-				ActualGLDevice = "VulkanDevice";
+				ActualGLDevice = VULKAN;
 			}
 			else if (metal = PrepareMTLAttributes())
 			{
 				// FIXME: SDL_WINDOW_METAL?
-				ActualGLDevice = "MetalDevice";
+				ActualGLDevice = METAL;
 			}
 			else if (opengl = PrepareGLAttributes())
 			{
 				initFlags |= SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL;
-				if (	ForcedGLDevice == "ModernGLDevice" ||
-					ForcedGLDevice == "ThreadedGLDevice"	)
+				if (	ForcedGLDevice == MODERNGL ||
+					ForcedGLDevice == THREADEDGL	)
 				{
 					ActualGLDevice = ForcedGLDevice;
 				}
 				else
 				{
-					ActualGLDevice = "OpenGLDevice";
+					ActualGLDevice = OPENGL;
 				}
 			}
 
@@ -1178,22 +1188,22 @@ namespace Microsoft.Xna.Framework
 		) {
 			switch (ActualGLDevice)
 			{
-				case "OpenGLDevice":
+				case OPENGL:
 					return new OpenGLDevice(presentationParameters, adapter);
 
-				case "ModernGLDevice":
+				case MODERNGL:
 					// FIXME: This is still experimental! -flibit
 					return new ModernGLDevice(presentationParameters, adapter);
 
-				case "ThreadedGLDevice":
+				case THREADEDGL:
 					// FIXME: This is still experimental! -flibit
 					return new ThreadedGLDevice(presentationParameters, adapter);
 
-				case "MetalDevice":
+				case METAL:
 					// Coming soon!
 					break;
 
-				case "VulkanDevice":
+				case VULKAN:
 					// Maybe someday!
 					break;
 			}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -359,7 +359,6 @@ namespace Microsoft.Xna.Framework
 			else if (opengl = PrepareGLAttributes())
 			{
 				initFlags |= SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL;
-
 				if (	ForcedGLDevice == "ModernGLDevice" ||
 					ForcedGLDevice == "ThreadedGLDevice"	)
 				{


### PR DESCRIPTION
Part 2 of the MetalDevice preparation PRs. This one alters SDL2_FNAPlatform to allow for multiple graphics backends. Note that string constants are used instead of an enum in order to play nicer with `ForcedGLDevice`.