### PR TITLE
PipelineCache Refactor

### DIFF
--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -24,58 +24,58 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	internal class PipelineCache
+	#region Internal PSO Hash Struct
+
+	[StructLayout(LayoutKind.Sequential, Pack = 4, Size = 128)]
+	internal struct StateHash : IEquatable<StateHash>
 	{
-		#region Private PSO Hash Struct
+		readonly int i1;
+		readonly int i2;
+		readonly int i3;
+		readonly int i4;
 
-		[StructLayout(LayoutKind.Sequential, Pack = 4, Size = 128)]
-		private struct StateHash : IEquatable<StateHash>
+		public StateHash(int i1, int i2, int i3, int i4)
 		{
-			readonly int i1;
-			readonly int i2;
-			readonly int i3;
-			readonly int i4;
-
-			public StateHash(int i1, int i2, int i3, int i4)
-			{
-				this.i1 = i1;
-				this.i2 = i2;
-				this.i3 = i3;
-				this.i4 = i4;
-			}
-
-			public override string ToString()
-			{
-				return	Convert.ToString(i1, 2).PadLeft(32, '0') +
-					Convert.ToString(i2, 2).PadLeft(32, '0') +
-					Convert.ToString(i3, 2).PadLeft(32, '0') +
-					Convert.ToString(i4, 2).PadLeft(32, '0');
-			}
-
-			bool IEquatable<StateHash>.Equals(StateHash hash)
-			{
-				return i1 == hash.i1 && i2 == hash.i2 && i3 == hash.i3 && i4 == hash.i4;
-			}
-
-			public override bool Equals(object obj)
-			{
-				if (obj == null || obj.GetType() != GetType())
-				{
-					return false;
-				}
-
-				StateHash hash = (StateHash) obj;
-				return i1 == hash.i1 && i2 == hash.i2 && i3 == hash.i3 && i4 == hash.i4;
-			}
-
-			public override int GetHashCode()
-			{
-				return unchecked(i1 + i2 + i3 + i4);
-			}
+			this.i1 = i1;
+			this.i2 = i2;
+			this.i3 = i3;
+			this.i4 = i4;
 		}
 
-		#endregion
+		public override string ToString()
+		{
+			return	Convert.ToString(i1, 2).PadLeft(32, '0') +
+				Convert.ToString(i2, 2).PadLeft(32, '0') +
+				Convert.ToString(i3, 2).PadLeft(32, '0') +
+				Convert.ToString(i4, 2).PadLeft(32, '0');
+		}
 
+		bool IEquatable<StateHash>.Equals(StateHash hash)
+		{
+			return i1 == hash.i1 && i2 == hash.i2 && i3 == hash.i3 && i4 == hash.i4;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null || obj.GetType() != GetType())
+			{
+				return false;
+			}
+
+			StateHash hash = (StateHash) obj;
+			return i1 == hash.i1 && i2 == hash.i2 && i3 == hash.i3 && i4 == hash.i4;
+		}
+
+		public override int GetHashCode()
+		{
+			return unchecked(i1 + i2 + i3 + i4);
+		}
+	}
+
+	#endregion
+
+	internal class PipelineCache
+	{
 		#region Private Variables
 
 		private GraphicsDevice device;
@@ -119,7 +119,60 @@ namespace Microsoft.Xna.Framework.Graphics
 		private Dictionary<StateHash, BlendState> blendCache =
 			new Dictionary<StateHash, BlendState>();
 
+		/* Private Hashing Functions */
+
+		private static StateHash GetBlendHash(
+			BlendFunction alphaBlendFunc,
+			Blend alphaDestBlend,
+			Blend alphaSrcBlend,
+			BlendFunction colorBlendFunc,
+			Blend colorDestBlend,
+			Blend colorSrcBlend,
+			ColorWriteChannels channels,
+			ColorWriteChannels channels1,
+			ColorWriteChannels channels2,
+			ColorWriteChannels channels3,
+			Color blendFactor,
+			int multisampleMask
+		) {
+			int funcs = ((int) alphaBlendFunc << 4) | ((int) colorBlendFunc);
+			int blendsAndColorWriteChannels =
+				  ((int) alphaDestBlend	<< (32 - 4))
+				| ((int) alphaSrcBlend	<< (32 - 8))
+				| ((int) colorDestBlend	<< (32 - 12))
+				| ((int) colorSrcBlend	<< (32 - 16))
+				| ((int) channels	<< (32 - 20))
+				| ((int) channels1	<< (32 - 24))
+				| ((int) channels2	<< (32 - 28))
+				| ((int) channels3);
+
+			return new StateHash(
+				funcs,
+				blendsAndColorWriteChannels,
+				(int) blendFactor.PackedValue,
+				multisampleMask
+			);
+		}
+
 		/* Public Functions */
+
+		public static StateHash GetBlendHash(BlendState state)
+		{
+			return GetBlendHash(
+				state.AlphaBlendFunction,
+				state.AlphaDestinationBlend,
+				state.AlphaSourceBlend,
+				state.ColorBlendFunction,
+				state.ColorDestinationBlend,
+				state.ColorSourceBlend,
+				state.ColorWriteChannels,
+				state.ColorWriteChannels1,
+				state.ColorWriteChannels2,
+				state.ColorWriteChannels3,
+				state.BlendFactor,
+				state.MultiSampleMask
+			);
+		}
 
 		public void BeginApplyBlend()
 		{
@@ -145,24 +198,20 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void EndApplyBlend()
 		{
-			int funcs = ((int) AlphaBlendFunction << 4) | ((int) ColorBlendFunction);
-			int blendsAndColorWriteChannels =
-				  ((int) AlphaDestinationBlend	<< (32 - 4))
-				| ((int) AlphaSourceBlend	<< (32 - 8))
-				| ((int) ColorDestinationBlend	<< (32 - 12))
-				| ((int) ColorSourceBlend	<< (32 - 16))
-				| ((int) ColorWriteChannels	<< (32 - 20))
-				| ((int) ColorWriteChannels1	<< (32 - 24))
-				| ((int) ColorWriteChannels2	<< (32 - 28))
-				| ((int) ColorWriteChannels3);
-
-			StateHash hash = new StateHash(
-				funcs,
-				blendsAndColorWriteChannels,
-				(int) BlendFactor.PackedValue,
+			StateHash hash = GetBlendHash(
+				AlphaBlendFunction,
+				AlphaDestinationBlend,
+				AlphaSourceBlend,
+				ColorBlendFunction,
+				ColorDestinationBlend,
+				ColorSourceBlend,
+				ColorWriteChannels,
+				ColorWriteChannels1,
+				ColorWriteChannels2,
+				ColorWriteChannels3,
+				BlendFactor,
 				MultiSampleMask
 			);
-
 			BlendState newBlend;
 			if (!blendCache.TryGetValue(hash, out newBlend))
 			{
@@ -226,7 +275,78 @@ namespace Microsoft.Xna.Framework.Graphics
 		private Dictionary<StateHash, DepthStencilState> depthStencilCache =
 			new Dictionary<StateHash, DepthStencilState>();
 
+		/* Private Hashing Functions */
+
+		private static StateHash GetDepthStencilHash(
+			bool depthBufferEnable,
+			bool depthWriteEnable,
+			CompareFunction depthFunc,
+			bool stencilEnable,
+			CompareFunction stencilFunc,
+			StencilOperation stencilPass,
+			StencilOperation stencilFail,
+			StencilOperation stencilDepthFail,
+			bool twoSidedStencil,
+			CompareFunction ccwStencilFunc,
+			StencilOperation ccwStencilPass,
+			StencilOperation ccwStencilFail,
+			StencilOperation ccwStencilDepthFail,
+			int stencilMask,
+			int stencilWriteMask,
+			int referenceStencil
+		) {
+			// Bool -> Int32 conversion
+			int zEnable = depthBufferEnable ? 1 : 0;
+			int zWriteEnable = depthWriteEnable ? 1 : 0;
+			int sEnable = stencilEnable ? 1 : 0;
+			int twoSided = twoSidedStencil ? 1 : 0;
+
+			int packedProperties =
+				  ((int) zEnable	<< 32 - 2)
+				| ((int) zWriteEnable	<< 32 - 3)
+				| ((int) sEnable	<< 32 - 4)
+				| ((int) twoSided	<< 32 - 5)
+				| ((int) depthFunc	<< 32 - 8)
+				| ((int) stencilFunc	<< 32 - 11)
+				| ((int) ccwStencilFunc	<< 32 - 14)
+				| ((int) stencilPass	<< 32 - 17)
+				| ((int) stencilFail	<< 32 - 20)
+				| ((int) stencilDepthFail	<< 32 - 23)
+				| ((int) ccwStencilFail	<< 32 - 26)
+				| ((int) ccwStencilPass	<< 32 - 29)
+				| ((int) ccwStencilDepthFail);
+
+			return new StateHash(
+				packedProperties,
+				stencilMask,
+				stencilWriteMask,
+				referenceStencil
+			);
+		}
+
 		/* Public Functions */
+
+		public static StateHash GetDepthStencilHash(DepthStencilState state)
+		{
+			return GetDepthStencilHash(
+				state.DepthBufferEnable,
+				state.DepthBufferWriteEnable,
+				state.DepthBufferFunction,
+				state.StencilEnable,
+				state.StencilFunction,
+				state.StencilPass,
+				state.StencilFail,
+				state.StencilDepthBufferFail,
+				state.TwoSidedStencilMode,
+				state.CounterClockwiseStencilFunction,
+				state.CounterClockwiseStencilPass,
+				state.CounterClockwiseStencilFail,
+				state.CounterClockwiseStencilDepthBufferFail,
+				state.StencilMask,
+				state.StencilWriteMask,
+				state.ReferenceStencil
+			);
+		}
 
 		public void BeginApplyDepthStencil()
 		{
@@ -252,34 +372,24 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void EndApplyDepthStencil()
 		{
-			// Bool -> Int32 conversion
-			int depthBufferEnable = DepthBufferEnable ? 1 : 0;
-			int depthBufferWriteEnable = DepthBufferWriteEnable ? 1 : 0;
-			int stencilEnable = StencilEnable ? 1 : 0;
-			int twoSidedStencilMode = TwoSidedStencilMode ? 1 : 0;
-
-			int packedProperties =
-				  ((int) depthBufferEnable	<< 32 - 2)
-				| ((int) depthBufferWriteEnable	<< 32 - 3)
-				| ((int) stencilEnable		<< 32 - 4)
-				| ((int) twoSidedStencilMode	<< 32 - 5)
-				| ((int) DepthBufferFunction	<< 32 - 8)
-				| ((int) StencilFunction	<< 32 - 11)
-				| ((int) CCWStencilFunction	<< 32 - 14)
-				| ((int) StencilPass		<< 32 - 17)
-				| ((int) StencilFail		<< 32 - 20)
-				| ((int) StencilDepthBufferFail	<< 32 - 23)
-				| ((int) CCWStencilFail		<< 32 - 26)
-				| ((int) CCWStencilPass		<< 32 - 29)
-				| ((int) CCWStencilDepthBufferFail);
-
-			StateHash hash = new StateHash(
-				packedProperties,
+			StateHash hash = GetDepthStencilHash(
+				DepthBufferEnable,
+				DepthBufferWriteEnable,
+				DepthBufferFunction,
+				StencilEnable,
+				StencilFunction,
+				StencilPass,
+				StencilFail,
+				StencilDepthBufferFail,
+				TwoSidedStencilMode,
+				CCWStencilFunction,
+				CCWStencilPass,
+				CCWStencilFail,
+				CCWStencilDepthBufferFail,
 				StencilMask,
 				StencilWriteMask,
 				ReferenceStencil
 			);
-
 			DepthStencilState newDepthStencil;
 			if (!depthStencilCache.TryGetValue(hash, out newDepthStencil))
 			{
@@ -337,7 +447,47 @@ namespace Microsoft.Xna.Framework.Graphics
 		private Dictionary<StateHash, RasterizerState> rasterizerCache =
 			new Dictionary<StateHash, RasterizerState>();
 
+		/* Private Hashing Functions */
+
+		private static StateHash GetRasterizerHash(
+			CullMode cullMode,
+			FillMode fillMode,
+			float depthBias,
+			bool msaa,
+			bool scissor,
+			float slopeScaleDepthBias
+		) {
+			// Bool -> Int32 conversion
+			int multiSampleAntiAlias = (msaa ? 1 : 0);
+			int scissorTestEnable = (scissor ? 1 : 0);
+
+			int packedProperties =
+				  ((int) multiSampleAntiAlias	<< 4)
+				| ((int) scissorTestEnable	<< 3)
+				| ((int) cullMode		<< 1)
+				| ((int) fillMode);
+
+			return new StateHash(
+				0,
+				packedProperties,
+				FloatToInt32(depthBias),
+				FloatToInt32(slopeScaleDepthBias)
+			);
+		}
+
 		/* Public Functions */
+
+		public static StateHash GetRasterizerHash(RasterizerState state)
+		{
+			return GetRasterizerHash(
+				state.CullMode,
+				state.FillMode,
+				state.DepthBias,
+				state.MultiSampleAntiAlias,
+				state.ScissorTestEnable,
+				state.SlopeScaleDepthBias
+			);
+		}
 
 		public void BeginApplyRasterizer()
 		{
@@ -353,23 +503,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void EndApplyRasterizer()
 		{
-			// Bool -> Int32 conversion
-			int multiSampleAntiAlias = (MultiSampleAntiAlias ? 1 : 0);
-			int scissorTestEnable = (ScissorTestEnable ? 1 : 0);
-
-			int packedProperties =
-				  ((int) multiSampleAntiAlias	<< 4)
-				| ((int) scissorTestEnable	<< 3)
-				| ((int) CullMode		<< 1)
-				| ((int) FillMode);
-
-			StateHash hash = new StateHash(
-				0,
-				packedProperties,
-				FloatToInt32(DepthBias),
-				FloatToInt32(SlopeScaleDepthBias)
+			StateHash hash = GetRasterizerHash(
+				CullMode,
+				FillMode,
+				DepthBias,
+				MultiSampleAntiAlias,
+				ScissorTestEnable,
+				SlopeScaleDepthBias
 			);
-
 			RasterizerState newRasterizer;
 			if (!rasterizerCache.TryGetValue(hash, out newRasterizer))
 			{
@@ -418,7 +559,45 @@ namespace Microsoft.Xna.Framework.Graphics
 		private Dictionary<StateHash, SamplerState> samplerCache =
 			new Dictionary<StateHash, SamplerState>();
 
+		/* Private Hashing Functions */
+
+		private static StateHash GetSamplerHash(
+			TextureAddressMode addressU,
+			TextureAddressMode addressV,
+			TextureAddressMode addressW,
+			int maxAnisotropy,
+			int maxMipLevel,
+			float mipLODBias,
+			TextureFilter filter
+		) {
+			int filterAndAddresses =
+				  ((int) filter		<< 6)
+				| ((int) addressU	<< 4)
+				| ((int) addressV	<< 2)
+				| ((int) addressW);
+
+			return new StateHash(
+				filterAndAddresses,
+				maxAnisotropy,
+				maxMipLevel,
+				FloatToInt32(mipLODBias)
+			);
+		}
+
 		/* Public Functions */
+
+		public static StateHash GetSamplerHash(SamplerState state)
+		{
+			return GetSamplerHash(
+				state.AddressU,
+				state.AddressV,
+				state.AddressW,
+				state.MaxAnisotropy,
+				state.MaxMipLevel,
+				state.MipMapLevelOfDetailBias,
+				state.Filter
+			);
+		}
 
 		public void BeginApplySampler(SamplerStateCollection samplers, int register)
 		{
@@ -435,19 +614,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void EndApplySampler(SamplerStateCollection samplers, int register)
 		{
-			int filterAndAddresses =
-				  ((int) Filter		<< 6)
-				| ((int) AddressU	<< 4)
-				| ((int) AddressV	<< 2)
-				| ((int) AddressW);
-
-			StateHash hash = new StateHash(
-				filterAndAddresses,
+			StateHash hash = GetSamplerHash(
+				AddressU,
+				AddressV,
+				AddressW,
 				MaxAnisotropy,
 				MaxMipLevel,
-				FloatToInt32(MipMapLODBias)
+				MipMapLODBias,
+				Filter
 			);
-
 			SamplerState newSampler;
 			if (!samplerCache.TryGetValue(hash, out newSampler))
 			{
@@ -482,7 +657,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Private Helper Methods
 
-		private unsafe int FloatToInt32(float f)
+		private static unsafe int FloatToInt32(float f)
 		{
 			return *((int *) &f);
 		}


### PR DESCRIPTION
The final part of the pre-MetalDevice updates. This patch internally exposes the `StateHash` struct and adds internal static functions for getting PSO hashes.