### PR TITLE
Add RefreshRateEXT

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -7,6 +7,19 @@
  */
 #endregion
 
+#region DISPLAYMODE_KEEP_DUPLICATES Option
+// #define DISPLAYMODE_KEEP_DUPLICATES
+/* By default, FNA will remove all duplicates from the list
+ * of available DisplayModes if they only vary by their
+ * refresh rate or format. This mimics XNA 4.0 behavior.
+ *
+ * However, in some cases it may be beneficial to receive
+ * an unaltered list of available DisplayModes so that you
+ * can filter them by their support for certain refresh rates.
+ * -caleb
+ */
+#endregion
+
 #region Using Statements
 using System;
 using System.IO;
@@ -1251,6 +1264,7 @@ namespace Microsoft.Xna.Framework
 				{
 					SDL.SDL_GetDisplayMode(i, j, out filler);
 
+#if !DISPLAYMODE_KEEP_DUPLICATES
 					// Check for dupes caused by varying refresh rates.
 					bool dupe = false;
 					foreach (DisplayMode mode in modes)
@@ -1261,12 +1275,14 @@ namespace Microsoft.Xna.Framework
 						}
 					}
 					if (!dupe)
+#endif
 					{
 						modes.Add(
 							new DisplayMode(
 								filler.w,
 								filler.h,
-								SurfaceFormat.Color // FIXME: Assumption!
+								SurfaceFormat.Color, // FIXME: Assumption!
+								filler.refresh_rate
 							)
 						);
 					}
@@ -1296,7 +1312,8 @@ namespace Microsoft.Xna.Framework
 			return new DisplayMode(
 				filler.w,
 				filler.h,
-				SurfaceFormat.Color // FIXME: Assumption!
+				SurfaceFormat.Color, // FIXME: Assumption!
+				filler.refresh_rate
 			);
 		}
 

--- a/src/Graphics/DisplayMode.cs
+++ b/src/Graphics/DisplayMode.cs
@@ -57,15 +57,26 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+		public int RefreshRateEXT
+		{
+			get;
+			private set;
+		}
+
 		#endregion
 
 		#region Internal Constructor
 
-		internal DisplayMode(int width, int height, SurfaceFormat format)
-		{
+		internal DisplayMode(
+			int width,
+			int height,
+			SurfaceFormat format,
+			int refreshRate
+		) {
 			Width = width;
 			Height = height;
 			Format = format;
+			RefreshRateEXT = refreshRate;
 		}
 
 		#endregion

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					return new DisplayMode(
 						GLDevice.Backbuffer.Width,
 						GLDevice.Backbuffer.Height,
-						SurfaceFormat.Color
+						SurfaceFormat.Color,
+						0
 					);
 				}
 				return Adapter.CurrentDisplayMode;


### PR DESCRIPTION
The refresh rate of DisplayModes may be useful for some games. In particular, Chasm may need this information to prevent an issue with the game screen turning black at some resolutions. To avoid spamming everyone with duplicate display modes, I added the compile define `DISPLAYMODE_KEEP_DUPLICATES`.

Very experimental!