### PR TITLE
Remove allocations when DISABLE_THREADING is not defined

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -129,6 +129,8 @@
 		<Compile Include="src\FNAPlatform\FNAPlatform.cs" />
 		<Compile Include="src\FNAPlatform\FNAWindow.cs" />
 		<Compile Include="src\FNAPlatform\IGLDevice.cs" />
+		<Compile Include="src\FNAPlatform\MetalDevice.cs" />
+		<Compile Include="src\FNAPlatform\MetalDevice_MTL.cs" />
 		<Compile Include="src\FNAPlatform\ModernGLDevice.cs" />
 		<Compile Include="src\FNAPlatform\ModernGLDevice_GL.cs" />
 		<Compile Include="src\FNAPlatform\OpenGLDevice.cs" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -197,6 +197,8 @@
     <Compile Include="src\FNAPlatform\FNAPlatform.cs" />
     <Compile Include="src\FNAPlatform\FNAWindow.cs" />
     <Compile Include="src\FNAPlatform\IGLDevice.cs" />
+    <Compile Include="src\FNAPlatform\MetalDevice.cs" />
+    <Compile Include="src\FNAPlatform\MetalDevice_MTL.cs" />
     <Compile Include="src\FNAPlatform\ModernGLDevice.cs" />
     <Compile Include="src\FNAPlatform\ModernGLDevice_GL.cs" />
     <Compile Include="src\FNAPlatform\OpenGLDevice.cs" />

--- a/FNA.sln
+++ b/FNA.sln
@@ -1,30 +1,38 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29709.97
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FNA", "FNA.csproj", "{35253CE1-C864-4CD3-8249-4D1319748E8F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
 		Debug|AnyCPU = Debug|AnyCPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|AnyCPU = Release|AnyCPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.ActiveCfg = Debug|x86
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.Build.0 = Debug|x86
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.ActiveCfg = Release|x86
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.Build.0 = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x64.ActiveCfg = Debug|x64
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x64.Build.0 = Debug|x64
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.Build.0 = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.Build.0 = Release|Any CPU
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x64.ActiveCfg = Release|x64
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x64.Build.0 = Release|x64
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.Build.0 = Release|AnyCPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D301291F-FC0A-4CA9-BEB4-9BB6C7B92657}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = FNA.csproj

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ SRC = \
 	src/FNAPlatform/FNAPlatform.cs \
 	src/FNAPlatform/FNAWindow.cs \
 	src/FNAPlatform/IGLDevice.cs \
+	src/FNAPlatform/MetalDevice.cs \
+	src/FNAPlatform/MetalDevice_MTL.cs \
 	src/FNAPlatform/ModernGLDevice.cs \
 	src/FNAPlatform/ModernGLDevice_GL.cs \
 	src/FNAPlatform/OpenGLDevice.cs \

--- a/licenses/LICENSE
+++ b/licenses/LICENSE
@@ -1,5 +1,5 @@
 Microsoft Public License (Ms-PL)
-FNA - Copyright 2009-2019 Ethan Lee and the MonoGame Team
+FNA - Copyright 2009-2020 Ethan Lee and the MonoGame Team
 
 All rights reserved.
 

--- a/src/Audio/AudioCategory.cs
+++ b/src/Audio/AudioCategory.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioChannels.cs
+++ b/src/Audio/AudioChannels.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioEmitter.cs
+++ b/src/Audio/AudioEmitter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioEngine.cs
+++ b/src/Audio/AudioEngine.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioListener.cs
+++ b/src/Audio/AudioListener.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/AudioStopOptions.cs
+++ b/src/Audio/AudioStopOptions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/DynamicSoundEffectInstance.cs
+++ b/src/Audio/DynamicSoundEffectInstance.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/DynamicSoundEffectInstance.cs
+++ b/src/Audio/DynamicSoundEffectInstance.cs
@@ -146,26 +146,29 @@ namespace Microsoft.Xna.Framework.Audio
 		{
 			IntPtr next = Marshal.AllocHGlobal(count);
 			Marshal.Copy(buffer, offset, next, count);
-			queuedBuffers.Add(next);
-			if (State != SoundState.Stopped)
+			lock (queuedBuffers)
 			{
-				FAudio.FAudioBuffer buf = new FAudio.FAudioBuffer();
-				buf.AudioBytes = (uint) count;
-				buf.pAudioData = next;
-				buf.PlayLength = (
-					buf.AudioBytes /
-					(uint) channels /
-					(uint) (format.wBitsPerSample / 8)
-				);
-				FAudio.FAudioSourceVoice_SubmitSourceBuffer(
-					handle,
-					ref buf,
-					IntPtr.Zero
-				);
-			}
-			else
-			{
-				queuedSizes.Add((uint) count);
+				queuedBuffers.Add(next);
+				if (State != SoundState.Stopped)
+				{
+					FAudio.FAudioBuffer buf = new FAudio.FAudioBuffer();
+					buf.AudioBytes = (uint) count;
+					buf.pAudioData = next;
+					buf.PlayLength = (
+						buf.AudioBytes /
+						(uint) channels /
+						(uint) (format.wBitsPerSample / 8)
+					);
+					FAudio.FAudioSourceVoice_SubmitSourceBuffer(
+						handle,
+						ref buf,
+						IntPtr.Zero
+					);
+				}
+				else
+				{
+					queuedSizes.Add((uint) count);
+				}
 			}
 		}
 
@@ -193,26 +196,29 @@ namespace Microsoft.Xna.Framework.Audio
 
 			IntPtr next = Marshal.AllocHGlobal(count * sizeof(float));
 			Marshal.Copy(buffer, offset, next, count);
-			queuedBuffers.Add(next);
-			if (State != SoundState.Stopped)
+			lock (queuedBuffers)
 			{
-				FAudio.FAudioBuffer buf = new FAudio.FAudioBuffer();
-				buf.AudioBytes = (uint) count * sizeof(float);
-				buf.pAudioData = next;
-				buf.PlayLength = (
-					buf.AudioBytes /
-					(uint) channels /
-					(uint) (format.wBitsPerSample / 8)
-				);
-				FAudio.FAudioSourceVoice_SubmitSourceBuffer(
-					handle,
-					ref buf,
-					IntPtr.Zero
-				);
-			}
-			else
-			{
-				queuedSizes.Add((uint) count * sizeof(float));
+				queuedBuffers.Add(next);
+				if (State != SoundState.Stopped)
+				{
+					FAudio.FAudioBuffer buf = new FAudio.FAudioBuffer();
+					buf.AudioBytes = (uint) count * sizeof(float);
+					buf.pAudioData = next;
+					buf.PlayLength = (
+						buf.AudioBytes /
+						(uint) channels /
+						(uint) (format.wBitsPerSample / 8)
+					);
+					FAudio.FAudioSourceVoice_SubmitSourceBuffer(
+						handle,
+						ref buf,
+						IntPtr.Zero
+					);
+				}
+				else
+				{
+					queuedSizes.Add((uint) count * sizeof(float));
+				}
 			}
 		}
 
@@ -233,32 +239,38 @@ namespace Microsoft.Xna.Framework.Audio
 		internal void QueueInitialBuffers()
 		{
 			FAudio.FAudioBuffer buffer = new FAudio.FAudioBuffer();
-			for (int i = 0; i < queuedBuffers.Count; i += 1)
+			lock (queuedBuffers)
 			{
-				buffer.AudioBytes = queuedSizes[i];
-				buffer.pAudioData = queuedBuffers[i];
-				buffer.PlayLength = (
-					buffer.AudioBytes /
-					(uint) channels /
-					(uint) (format.wBitsPerSample / 8)
-				);
-				FAudio.FAudioSourceVoice_SubmitSourceBuffer(
-					handle,
-					ref buffer,
-					IntPtr.Zero
-				);
+				for (int i = 0; i < queuedBuffers.Count; i += 1)
+				{
+					buffer.AudioBytes = queuedSizes[i];
+					buffer.pAudioData = queuedBuffers[i];
+					buffer.PlayLength = (
+						buffer.AudioBytes /
+						(uint) channels /
+						(uint) (format.wBitsPerSample / 8)
+					);
+					FAudio.FAudioSourceVoice_SubmitSourceBuffer(
+						handle,
+						ref buffer,
+						IntPtr.Zero
+					);
+				}
+				queuedSizes.Clear();
 			}
-			queuedSizes.Clear();
 		}
 
 		internal void ClearBuffers()
 		{
-			foreach (IntPtr buf in queuedBuffers)
+			lock (queuedBuffers)
 			{
-				Marshal.FreeHGlobal(buf);
+				foreach (IntPtr buf in queuedBuffers)
+				{
+					Marshal.FreeHGlobal(buf);
+				}
+				queuedBuffers.Clear();
+				queuedSizes.Clear();
 			}
-			queuedBuffers.Clear();
-			queuedSizes.Clear();
 		}
 
 		internal void Update()
@@ -278,6 +290,7 @@ namespace Microsoft.Xna.Framework.Audio
 					FAudio.FAUDIO_VOICE_NOSAMPLESPLAYED
 				);
 				while (PendingBufferCount > state.BuffersQueued)
+				lock (queuedBuffers)
 				{
 					Marshal.FreeHGlobal(queuedBuffers[0]);
 					queuedBuffers.RemoveAt(0);

--- a/src/Audio/InstancePlayLimitException.cs
+++ b/src/Audio/InstancePlayLimitException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/Microphone.cs
+++ b/src/Audio/Microphone.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/MicrophoneState.cs
+++ b/src/Audio/MicrophoneState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/NoAudioHardwareException.cs
+++ b/src/Audio/NoAudioHardwareException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/NoMicrophoneConnectedException.cs
+++ b/src/Audio/NoMicrophoneConnectedException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/RendererDetail.cs
+++ b/src/Audio/RendererDetail.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundBank.cs
+++ b/src/Audio/SoundBank.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/SoundState.cs
+++ b/src/Audio/SoundState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Audio/WaveBank.cs
+++ b/src/Audio/WaveBank.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/BoundingBox.cs
+++ b/src/BoundingBox.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/BoundingFrustum.cs
+++ b/src/BoundingFrustum.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/BoundingSphere.cs
+++ b/src/BoundingSphere.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Color.cs
+++ b/src/Color.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/ContainmentType.cs
+++ b/src/ContainmentType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentExtensions.cs
+++ b/src/Content/ContentExtensions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentLoadException.cs
+++ b/src/Content/ContentLoadException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentManager.cs
+++ b/src/Content/ContentManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReader.cs
+++ b/src/Content/ContentReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/AlphaTestEffectReader.cs
+++ b/src/Content/ContentReaders/AlphaTestEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ArrayReader.cs
+++ b/src/Content/ContentReaders/ArrayReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BasicEffectReader.cs
+++ b/src/Content/ContentReaders/BasicEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BooleanReader.cs
+++ b/src/Content/ContentReaders/BooleanReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BoundingBoxReader.cs
+++ b/src/Content/ContentReaders/BoundingBoxReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BoundingFrustumReader.cs
+++ b/src/Content/ContentReaders/BoundingFrustumReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/BoundingSphereReader.cs
+++ b/src/Content/ContentReaders/BoundingSphereReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ByteReader.cs
+++ b/src/Content/ContentReaders/ByteReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/CharReader.cs
+++ b/src/Content/ContentReaders/CharReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ColorReader.cs
+++ b/src/Content/ContentReaders/ColorReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/CurveReader.cs
+++ b/src/Content/ContentReaders/CurveReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DateTimeReader.cs
+++ b/src/Content/ContentReaders/DateTimeReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DecimalReader.cs
+++ b/src/Content/ContentReaders/DecimalReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DictionaryReader.cs
+++ b/src/Content/ContentReaders/DictionaryReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DoubleReader.cs
+++ b/src/Content/ContentReaders/DoubleReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/DualTextureEffectReader.cs
+++ b/src/Content/ContentReaders/DualTextureEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EffectMaterialReader.cs
+++ b/src/Content/ContentReaders/EffectMaterialReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EffectReader.cs
+++ b/src/Content/ContentReaders/EffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EnumReader.cs
+++ b/src/Content/ContentReaders/EnumReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/EnvironmentMapEffectReader.cs
+++ b/src/Content/ContentReaders/EnvironmentMapEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ExternalReferenceReader.cs
+++ b/src/Content/ContentReaders/ExternalReferenceReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/IndexBufferReader.cs
+++ b/src/Content/ContentReaders/IndexBufferReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Int16Reader.cs
+++ b/src/Content/ContentReaders/Int16Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Int32Reader.cs
+++ b/src/Content/ContentReaders/Int32Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Int64Reader.cs
+++ b/src/Content/ContentReaders/Int64Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ListReader.cs
+++ b/src/Content/ContentReaders/ListReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/MatrixReader.cs
+++ b/src/Content/ContentReaders/MatrixReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ModelReader.cs
+++ b/src/Content/ContentReaders/ModelReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/NullableReader.cs
+++ b/src/Content/ContentReaders/NullableReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/PlaneReader.cs
+++ b/src/Content/ContentReaders/PlaneReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/PointReader.cs
+++ b/src/Content/ContentReaders/PointReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/QuaternionReader.cs
+++ b/src/Content/ContentReaders/QuaternionReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/RayReader.cs
+++ b/src/Content/ContentReaders/RayReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/RectangleReader.cs
+++ b/src/Content/ContentReaders/RectangleReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/ReflectiveReader.cs
+++ b/src/Content/ContentReaders/ReflectiveReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SByteReader.cs
+++ b/src/Content/ContentReaders/SByteReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SingleReader.cs
+++ b/src/Content/ContentReaders/SingleReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SkinnedEffectReader.cs
+++ b/src/Content/ContentReaders/SkinnedEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SongReader.cs
+++ b/src/Content/ContentReaders/SongReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SoundEffectReader.cs
+++ b/src/Content/ContentReaders/SoundEffectReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/SpriteFontReader.cs
+++ b/src/Content/ContentReaders/SpriteFontReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/StringReader.cs
+++ b/src/Content/ContentReaders/StringReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Texture2DReader.cs
+++ b/src/Content/ContentReaders/Texture2DReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Texture3DReader.cs
+++ b/src/Content/ContentReaders/Texture3DReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/TextureCubeReader.cs
+++ b/src/Content/ContentReaders/TextureCubeReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/TextureReader.cs
+++ b/src/Content/ContentReaders/TextureReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/TimeSpanReader.cs
+++ b/src/Content/ContentReaders/TimeSpanReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/UInt16Reader.cs
+++ b/src/Content/ContentReaders/UInt16Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/UInt32Reader.cs
+++ b/src/Content/ContentReaders/UInt32Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/UInt64Reader.cs
+++ b/src/Content/ContentReaders/UInt64Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Vector2Reader.cs
+++ b/src/Content/ContentReaders/Vector2Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Vector3Reader.cs
+++ b/src/Content/ContentReaders/Vector3Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/Vector4Reader.cs
+++ b/src/Content/ContentReaders/Vector4Reader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/VertexBufferReader.cs
+++ b/src/Content/ContentReaders/VertexBufferReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/VertexDeclarationReader.cs
+++ b/src/Content/ContentReaders/VertexDeclarationReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentReaders/VideoReader.cs
+++ b/src/Content/ContentReaders/VideoReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerAttribute.cs
+++ b/src/Content/ContentSerializerAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerCollectionItemNameAttribute.cs
+++ b/src/Content/ContentSerializerCollectionItemNameAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerIgnoreAttribute.cs
+++ b/src/Content/ContentSerializerIgnoreAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerRuntimeTypeAttribute.cs
+++ b/src/Content/ContentSerializerRuntimeTypeAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentSerializerTypeVersionAttribute.cs
+++ b/src/Content/ContentSerializerTypeVersionAttribute.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentTypeReader.cs
+++ b/src/Content/ContentTypeReader.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ContentTypeReaderManager.cs
+++ b/src/Content/ContentTypeReaderManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Content/ResourceContentManager.cs
+++ b/src/Content/ResourceContentManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Curve.cs
+++ b/src/Curve.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveContinuity.cs
+++ b/src/CurveContinuity.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveKey.cs
+++ b/src/CurveKey.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveKeyCollection.cs
+++ b/src/CurveKeyCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveLoopType.cs
+++ b/src/CurveLoopType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/CurveTangent.cs
+++ b/src/CurveTangent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/BoundingBoxConverter.cs
+++ b/src/Design/BoundingBoxConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/BoundingSphereConverter.cs
+++ b/src/Design/BoundingSphereConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/ColorConverter.cs
+++ b/src/Design/ColorConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/MathTypeConverter.cs
+++ b/src/Design/MathTypeConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/MatrixConverter.cs
+++ b/src/Design/MatrixConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/PlaneConverter.cs
+++ b/src/Design/PlaneConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/PointConverter.cs
+++ b/src/Design/PointConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/QuaternionConverter.cs
+++ b/src/Design/QuaternionConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/RayConverter.cs
+++ b/src/Design/RayConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/RectangleConverter.cs
+++ b/src/Design/RectangleConverter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/Vector2Converter.cs
+++ b/src/Design/Vector2Converter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/Vector3Converter.cs
+++ b/src/Design/Vector3Converter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Design/Vector4Converter.cs
+++ b/src/Design/Vector4Converter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/DisplayOrientation.cs
+++ b/src/DisplayOrientation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/DrawableGameComponent.cs
+++ b/src/DrawableGameComponent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNALoggerEXT.cs
+++ b/src/FNALoggerEXT.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/FNAWindow.cs
+++ b/src/FNAPlatform/FNAWindow.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/IGLDevice.cs
+++ b/src/FNAPlatform/IGLDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/IGLDevice.cs
+++ b/src/FNAPlatform/IGLDevice.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			PresentationParameters presentationParameters,
 			GraphicsAdapter adapter
 		);
+		void BeginFrame();
 		void SwapBuffers(
 			Rectangle? sourceRectangle,
 			Rectangle? destinationRectangle,

--- a/src/FNAPlatform/MetalDevice.cs
+++ b/src/FNAPlatform/MetalDevice.cs
@@ -11,6 +11,8 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+
+using SDL2;
 #endregion
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -230,7 +232,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				// Copy over data from old buffer
 				if (oldBuffer != IntPtr.Zero)
 				{
-					memcpy(
+					SDL.SDL_memcpy(
 						Contents,
 						oldContents,
 						(IntPtr) prevSize
@@ -265,7 +267,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				// Copy previous contents, if needed
 				if (prevInternalOffset != InternalOffset && dataLength < (int) BufferSize)
 				{
-					memcpy(
+					SDL.SDL_memcpy(
 						Contents + InternalOffset,
 						Contents + prevInternalOffset,
 						BufferSize
@@ -273,7 +275,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 
 				// Copy the data into the buffer
-				memcpy(
+				SDL.SDL_memcpy(
 					Contents + InternalOffset + offsetInBytes,
 					data,
 					(IntPtr) dataLength
@@ -301,7 +303,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 
 				// Copy the data into the buffer
-				memcpy(
+				SDL.SDL_memcpy(
 					Contents + InternalOffset,
 					data + offsetInBytes,
 					(IntPtr) dataLength
@@ -695,27 +697,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region memcpy Export
-
-		/* This is used a lot for GetData/Read calls... -flibit */
-#if NETSTANDARD2_0
-		private static unsafe void memcpy(IntPtr dst, IntPtr src, IntPtr len)
-		{
-			long size = len.ToInt64();
-			Buffer.MemoryCopy(
-				(void*) src,
-				(void*) dst,
-				size,
-				size
-			);
-		}
-#else
-		[DllImport("msvcrt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void memcpy(IntPtr dst, IntPtr src, IntPtr len);
-#endif
-
-		#endregion
-
 		#region SDL Metal Imports
 
 		// FIXME: Remove this section after SDL 2.0.12 releases!
@@ -730,8 +711,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public static bool UsingSDL2_0_11()
 		{
-			SDL2.SDL.SDL_version version;
-			SDL2.SDL.SDL_GetVersion(out version);
+			SDL.SDL_version version;
+			SDL.SDL_GetVersion(out version);
 			return (version.major >= 2 && version.patch >= 11);
 		}
 
@@ -759,13 +740,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			else
 			{
 				// Create a renderer and grab the layer from it.
-				SDL2.SDL.SDL_SetHint(SDL2.SDL.SDL_HINT_RENDER_DRIVER, "metal");
-				renderer = SDL2.SDL.SDL_CreateRenderer(
+				SDL.SDL_SetHint(SDL.SDL_HINT_RENDER_DRIVER, "metal");
+				renderer = SDL.SDL_CreateRenderer(
 					presentationParameters.DeviceWindowHandle,
 					-1,
-					SDL2.SDL.SDL_RendererFlags.SDL_RENDERER_ACCELERATED
+					SDL.SDL_RendererFlags.SDL_RENDERER_ACCELERATED
 				);
-				layer = SDL2.SDL.SDL_RenderGetMetalLayer(renderer);
+				layer = SDL.SDL_RenderGetMetalLayer(renderer);
 			}
 
 			// Set up the CAMetalLayer
@@ -784,7 +765,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			) == "1" ? MTLSamplerMinMagFilter.Nearest : MTLSamplerMinMagFilter.Linear;
 
 			// Set device properties
-			isMac = SDL2.SDL.SDL_GetPlatform().Equals("Mac OS X");
+			isMac = SDL.SDL_GetPlatform().Equals("Mac OS X");
 			SupportsS3tc = SupportsDxt1 = isMac;
 			MaxMultiSampleCount = mtlSupportsSampleCount(device, 8) ? 8 : 4;
 			supportsOcclusionQueries = isMac || HasModernAppleGPU();
@@ -929,7 +910,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			else
 			{
 				// Destroy the renderer
-				SDL2.SDL.SDL_DestroyRenderer(renderer);
+				SDL.SDL_DestroyRenderer(renderer);
 			}
 		}
 
@@ -1110,7 +1091,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					sx, sy + sh,		0, 1
 				};
 				GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
-				memcpy(
+				SDL.SDL_memcpy(
 					mtlGetBufferContentsPtr(fauxBackbufferDrawBuffer),
 					handle.AddrOfPinnedObject(),
 					(IntPtr) (16 * sizeof(float))
@@ -3275,7 +3256,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementCount,
 			int elementSizeInBytes
 		) {
-			memcpy(
+			SDL.SDL_memcpy(
 				data + (startIndex * elementSizeInBytes),
 				(buffer as MetalBuffer).Contents + offsetInBytes,
 				(IntPtr) (elementCount * elementSizeInBytes)
@@ -3302,7 +3283,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				cpy = data + (startIndex * elementSizeInBytes);
 			}
 
-			memcpy(
+			SDL.SDL_memcpy(
 				cpy,
 				(buffer as MetalBuffer).Contents + offsetInBytes,
 				(IntPtr) (elementCount * vertexStride)
@@ -3314,7 +3295,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				IntPtr dst = data + (startIndex * elementSizeInBytes);
 				for (int i = 0; i < elementCount; i += 1)
 				{
-					memcpy(dst, src, (IntPtr) elementSizeInBytes);
+					SDL.SDL_memcpy(dst, src, (IntPtr) elementSizeInBytes);
 					dst += elementSizeInBytes;
 					src += vertexStride;
 				}
@@ -4666,7 +4647,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				1, 2, 3
 			};
 			GCHandle indicesPinned = GCHandle.Alloc(indices, GCHandleType.Pinned);
-			memcpy(
+			SDL.SDL_memcpy(
 				mtlGetBufferContentsPtr(fauxBackbufferDrawBuffer) + (16 * sizeof(float)),
 				indicesPinned.AddrOfPinnedObject(),
 				(IntPtr) (6 * sizeof(ushort))

--- a/src/FNAPlatform/MetalDevice.cs
+++ b/src/FNAPlatform/MetalDevice.cs
@@ -1,0 +1,4766 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+#endregion
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	internal partial class MetalDevice : IGLDevice
+	{
+		#region Metal Texture Container Class
+
+		private class MetalTexture : IGLTexture
+		{
+			public IntPtr Handle
+			{
+				get;
+				private set;
+			}
+
+			public bool HasMipmaps
+			{
+				get;
+				private set;
+			}
+
+			public int Width
+			{
+				get;
+				private set;
+			}
+
+			public int Height
+			{
+				get;
+				private set;
+			}
+
+			public bool IsPrivate
+			{
+				get;
+				private set;
+			}
+
+			public SurfaceFormat Format;
+			public TextureAddressMode WrapS;
+			public TextureAddressMode WrapT;
+			public TextureAddressMode WrapR;
+			public TextureFilter Filter;
+			public float Anisotropy;
+			public int MaxMipmapLevel;
+			public float LODBias;
+
+			public MetalTexture(
+				IntPtr handle,
+				int width,
+				int height,
+				SurfaceFormat format,
+				int levelCount,
+				bool isPrivate
+			) {
+				Handle = handle;
+				Width = width;
+				Height = height;
+				Format = format;
+				HasMipmaps = levelCount > 1;
+				IsPrivate = isPrivate;
+
+				WrapS = TextureAddressMode.Wrap;
+				WrapT = TextureAddressMode.Wrap;
+				WrapR = TextureAddressMode.Wrap;
+				Filter = TextureFilter.Linear;
+				Anisotropy = 4.0f;
+				MaxMipmapLevel = 0;
+				LODBias = 0.0f;
+			}
+
+			private MetalTexture()
+			{
+				Handle = IntPtr.Zero;
+			}
+			public static readonly MetalTexture NullTexture = new MetalTexture();
+
+			public void Dispose()
+			{
+				objc_release(Handle);
+				Handle = IntPtr.Zero;
+			}
+		}
+
+		#endregion
+
+		#region Metal Renderbuffer Container Class
+
+		private class MetalRenderbuffer : IGLRenderbuffer
+		{
+			public IntPtr Handle
+			{
+				get;
+				private set;
+			}
+
+			public IntPtr MultiSampleHandle
+			{
+				get;
+				private set;
+			}
+
+			public MTLPixelFormat PixelFormat
+			{
+				get;
+				private set;
+			}
+
+			public int MultiSampleCount
+			{
+				get;
+				private set;
+			}
+
+			public MetalRenderbuffer(
+				IntPtr handle,
+				MTLPixelFormat pixelFormat,
+				int multiSampleCount,
+				IntPtr multiSampleHandle
+			) {
+				Handle = handle;
+				PixelFormat = pixelFormat;
+				MultiSampleCount = multiSampleCount;
+				MultiSampleHandle = multiSampleHandle;
+			}
+
+			public void Dispose()
+			{
+				if (MultiSampleHandle == IntPtr.Zero)
+				{
+					objc_release(Handle);
+					Handle = IntPtr.Zero;
+				}
+				else
+				{
+					objc_release(MultiSampleHandle);
+					MultiSampleHandle = IntPtr.Zero;
+
+					/* Don't release the regular Handle since
+					 * it's owned by the associated IGLTexture.
+					 */
+					Handle = IntPtr.Zero;
+				}
+			}
+		}
+
+		#endregion
+
+		#region Metal Buffer Container Class
+
+		private class MetalBuffer : IGLBuffer
+		{
+			public IntPtr Handle
+			{
+				get;
+				private set;
+			}
+
+			public IntPtr Contents
+			{
+				get;
+				private set;
+			}
+
+			public IntPtr BufferSize
+			{
+				get;
+				private set;
+			}
+
+			public int InternalOffset
+			{
+				get;
+				private set;
+			}
+
+			private MetalDevice device;
+			private IntPtr mtlDevice = IntPtr.Zero;
+			private int internalBufferSize = 0;
+			private int prevDataLength = 0;
+			private int prevInternalOffset;
+			private BufferUsage usage;
+			private bool boundThisFrame;
+
+			public MetalBuffer(
+				MetalDevice device,
+				bool dynamic,
+				BufferUsage usage,
+				IntPtr bufferSize
+			) {
+				this.device = device;
+				this.mtlDevice = device.device;
+				this.usage = usage;
+
+				BufferSize = bufferSize;
+				internalBufferSize = (int) bufferSize;
+
+				CreateBackingBuffer(-1);
+			}
+
+			private void CreateBackingBuffer(int prevSize)
+			{
+				IntPtr oldBuffer = Handle;
+				IntPtr oldContents = Contents;
+
+				Handle = mtlNewBufferWithLength(
+					mtlDevice,
+					internalBufferSize,
+					usage == BufferUsage.WriteOnly ?
+						MTLResourceOptions.CPUCacheModeWriteCombined :
+						MTLResourceOptions.CPUCacheModeDefaultCache
+				);
+				Contents = mtlGetBufferContentsPtr(Handle);
+
+				// Copy over data from old buffer
+				if (oldBuffer != IntPtr.Zero)
+				{
+					memcpy(
+						Contents,
+						oldContents,
+						(IntPtr) prevSize
+					);
+					objc_release(oldBuffer);
+				}
+			}
+
+			public void SetData(
+				int offsetInBytes,
+				IntPtr data,
+				int dataLength,
+				SetDataOptions options
+			) {
+				if (options == SetDataOptions.None && boundThisFrame)
+				{
+					device.Stall();
+					boundThisFrame = true;
+				}
+				else if (options == SetDataOptions.Discard && boundThisFrame)
+				{
+					InternalOffset += (int) BufferSize;
+					if (InternalOffset + dataLength > internalBufferSize)
+					{
+						// Expand!
+						int prevSize = internalBufferSize;
+						internalBufferSize *= 2;
+						CreateBackingBuffer(prevSize);
+					}
+				}
+
+				// Copy previous contents, if needed
+				if (prevInternalOffset != InternalOffset && dataLength < (int) BufferSize)
+				{
+					memcpy(
+						Contents + InternalOffset,
+						Contents + prevInternalOffset,
+						BufferSize
+					);
+				}
+
+				// Copy the data into the buffer
+				memcpy(
+					Contents + InternalOffset + offsetInBytes,
+					data,
+					(IntPtr) dataLength
+				);
+
+				prevInternalOffset = InternalOffset;
+				prevDataLength = (int) BufferSize;
+			}
+
+			public void SetData(
+				int offsetInBytes,
+				IntPtr data,
+				int dataLength
+			) {
+				InternalOffset += prevDataLength;
+				if (InternalOffset + dataLength > internalBufferSize)
+				{
+					// Expand!
+					int prevSize = internalBufferSize;
+					internalBufferSize = Math.Max(
+						internalBufferSize * 2,
+						internalBufferSize + dataLength
+					);
+					CreateBackingBuffer(prevSize);
+				}
+
+				// Copy the data into the buffer
+				memcpy(
+					Contents + InternalOffset,
+					data + offsetInBytes,
+					(IntPtr) dataLength
+				);
+
+				prevDataLength = dataLength;
+			}
+
+			public void Bound()
+			{
+				boundThisFrame = true;
+			}
+
+			public void Reset()
+			{
+				InternalOffset = 0;
+				boundThisFrame = false;
+				prevDataLength = 0;
+			}
+
+			public void Dispose()
+			{
+				objc_release(Handle);
+				Handle = IntPtr.Zero;
+			}
+		}
+
+		#endregion
+
+		#region Metal Effect Container Class
+
+		private class MetalEffect : IGLEffect
+		{
+			public IntPtr EffectData
+			{
+				get;
+				private set;
+			}
+
+			public IntPtr MTLEffectData
+			{
+				get;
+				private set;
+			}
+
+			public MetalEffect(IntPtr effect, IntPtr mtlEffect)
+			{
+				EffectData = effect;
+				MTLEffectData = mtlEffect;
+			}
+		}
+
+		#endregion
+
+		#region Metal Query Container Class
+
+		private class MetalQuery : IGLQuery
+		{
+			public IntPtr Handle
+			{
+				get;
+				private set;
+			}
+
+			public MetalQuery(IntPtr handle)
+			{
+				Handle = handle;
+			}
+
+			public void Dispose()
+			{
+				objc_release(Handle);
+				Handle = IntPtr.Zero;
+			}
+		}
+
+		#endregion
+
+		#region Blending State Variables
+
+		private Color blendColor = Color.Transparent;
+		public Color BlendFactor
+		{
+			get
+			{
+				return blendColor;
+			}
+			set
+			{
+				if (value != blendColor)
+				{
+					blendColor = value;
+					SetEncoderBlendColor();
+				}
+			}
+		}
+
+		private int multisampleMask = -1; // AKA 0xFFFFFFFF
+		public int MultiSampleMask
+		{
+			get
+			{
+				return multisampleMask;
+			}
+			set
+			{
+				multisampleMask = value;
+				// FIXME: Metal does not support multisample masks. Workarounds...?
+			}
+		}
+
+		#endregion
+
+		#region Stencil State Variables
+
+		private int stencilRef = 0;
+		public int ReferenceStencil
+		{
+			get
+			{
+				return stencilRef;
+			}
+			set
+			{
+				if (value != stencilRef)
+				{
+					stencilRef = value;
+					SetEncoderStencilReferenceValue();
+				}
+			}
+		}
+
+		#endregion
+
+		#region Rasterizer State Variables
+
+		private bool scissorTestEnable = false;
+		private CullMode cullFrontFace = CullMode.None;
+		private FillMode fillMode = FillMode.Solid;
+		private float depthBias = 0.0f;
+		private float slopeScaleDepthBias = 0.0f;
+		private bool multiSampleEnable = true;
+
+		#endregion
+
+		#region Viewport State Variables
+
+		private Rectangle scissorRectangle = new Rectangle();
+		private Rectangle viewport = new Rectangle();
+		private float depthRangeMin = 0.0f;
+		private float depthRangeMax = 1.0f;
+
+		/* Used for resetting scissor rectangle */
+		private int currentAttachmentWidth;
+		private int currentAttachmentHeight;
+
+		#endregion
+
+		#region Sampler State Variables
+
+		private MetalTexture[] Textures;
+		private IntPtr[] Samplers;
+		private bool[] textureNeedsUpdate;
+		private bool[] samplerNeedsUpdate;
+
+		#endregion
+
+		#region Depth Stencil State Variables
+
+		private DepthStencilState depthStencilState;
+
+		private IntPtr defaultDepthStencilState;	// MTLDepthStencilState*
+		private IntPtr ldDepthStencilState;		// MTLDepthStencilState*
+
+		private MTLPixelFormat D16Format;
+		private MTLPixelFormat D24Format;
+		private MTLPixelFormat D24S8Format;
+
+		#endregion
+
+		#region Buffer Binding Cache Variables
+
+		private List<MetalBuffer> Buffers = new List<MetalBuffer>();
+
+		private MetalBuffer userVertexBuffer = null;
+		private MetalBuffer userIndexBuffer = null;
+		private int userVertexStride = 0;
+
+		// Some vertex declarations may have overlapping attributes :/
+		private bool[,] attrUse = new bool[(int) MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_TOTAL, 10];
+
+		#endregion
+
+		#region Render Target Cache Variables
+
+		private readonly IntPtr[] currentAttachments;
+		private readonly MTLPixelFormat[] currentColorFormats;
+		private readonly IntPtr[] currentMSAttachments;
+		private readonly CubeMapFace[] currentAttachmentSlices;
+		private IntPtr currentDepthStencilBuffer;
+		private DepthFormat currentDepthFormat;
+		private int currentSampleCount;
+
+		#endregion
+
+		#region Clear Cache Variables
+
+		private Vector4 clearColor = new Vector4(0, 0, 0, 0);
+		private float clearDepth = 1.0f;
+		private int clearStencil = 0;
+
+		private bool shouldClearColor = false;
+		private bool shouldClearDepth = false;
+		private bool shouldClearStencil = false;
+
+		#endregion
+
+		#region Private Metal State Variables
+
+		// FIXME: Remove this after SDL 2.0.12!
+		private IntPtr renderer;			// SDL_Renderer*
+
+		private IntPtr view;				// SDL_MetalView*
+		private IntPtr layer;				// CAMetalLayer*
+		private IntPtr device;				// MTLDevice*
+		private IntPtr queue;				// MTLCommandQueue*
+		private IntPtr commandBuffer;			// MTLCommandBuffer*
+		private IntPtr renderCommandEncoder;		// MTLRenderCommandEncoder*
+		private IntPtr currentVertexDescriptor;		// MTLVertexDescriptor*
+		private IntPtr currentVisibilityBuffer;		// MTLBuffer*
+
+		private bool needNewRenderPass;
+
+		#endregion
+
+		#region Operating System Variables
+
+		private bool isMac;
+
+		#endregion
+
+		#region Frame Tracking Variables
+
+		/* FIXME:
+		 * In theory, double- or even triple-buffering could
+		 * significantly help performance by reducing CPU idle
+		 * time. The trade-off is that buffer synchronization
+		 * becomes much more complicated and error-prone.
+		 *
+		 * I've attempted a few implementations of multi-
+		 * buffering, but they all had serious issues and
+		 * typically performed worse than single buffering.
+		 *
+		 * I'm leaving these variables here in case any brave
+		 * souls want to attempt a multi-buffer implementation.
+		 * This could be a huge win for performance, but it'll
+		 * take someone smarter than me to figure this out. ;)
+		 *
+		 * -caleb
+		 */
+		private const int MAX_FRAMES_IN_FLIGHT = 1;
+		private Queue<IntPtr> committedCommandBuffers = new Queue<IntPtr>();
+
+		private bool frameInProgress = false;
+
+		#endregion
+
+		#region Objective-C Memory Management Variables
+
+		private IntPtr pool; // NSAutoreleasePool*
+
+		#endregion
+
+		#region Faux-Backbuffer Variables
+
+		public IGLBackbuffer Backbuffer
+		{
+			get;
+			private set;
+		}
+
+		private MTLSamplerMinMagFilter backbufferScaleMode;
+
+		// Cached data for rendering the faux-backbuffer
+		private Rectangle fauxBackbufferDestBounds;
+		private IntPtr fauxBackbufferDrawBuffer;
+		private IntPtr fauxBackbufferRenderPipeline;
+		private IntPtr fauxBackbufferSamplerState;
+		private bool fauxBackbufferSizeChanged;
+
+		#endregion
+
+		#region Metal Device Capabilities
+
+		public bool SupportsDxt1
+		{
+			get;
+			private set;
+		}
+
+		public bool SupportsS3tc
+		{
+			get;
+			private set;
+		}
+
+		public bool SupportsHardwareInstancing
+		{
+			get
+			{
+				return true;
+			}
+		}
+
+		public bool SupportsNoOverwrite
+		{
+			get
+			{
+				return true;
+			}
+		}
+
+		public int MaxTextureSlots
+		{
+			get
+			{
+				return 16;
+			}
+		}
+
+		public int MaxMultiSampleCount
+		{
+			get;
+			private set;
+		}
+
+		private bool supportsOcclusionQueries;
+
+		#endregion
+
+		#region Private State Object Caches
+
+		private Dictionary<ulong, IntPtr> VertexDescriptorCache =
+			new Dictionary<ulong, IntPtr>();
+
+		private Dictionary<PipelineHash, IntPtr> PipelineStateCache =
+			new Dictionary<PipelineHash, IntPtr>();
+
+		private Dictionary<StateHash, IntPtr> DepthStencilStateCache =
+			new Dictionary<StateHash, IntPtr>();
+
+		private Dictionary<StateHash, IntPtr> SamplerStateCache =
+			new Dictionary<StateHash, IntPtr>();
+
+		private List<MetalTexture> transientTextures =
+			new List<MetalTexture>();
+
+		#endregion
+
+		#region Private Render Pipeline State Variables
+
+		private BlendState blendState;
+		private IntPtr ldPipelineState = IntPtr.Zero;
+
+		#endregion
+
+		#region Private Buffer Binding Cache
+
+		private const int MAX_BOUND_VERTEX_BUFFERS = 16;
+
+		private IntPtr ldVertUniformBuffer = IntPtr.Zero;
+		private IntPtr ldFragUniformBuffer = IntPtr.Zero;
+		private int ldVertUniformOffset = 0;
+		private int ldFragUniformOffset = 0;
+
+		private IntPtr[] ldVertexBuffers;
+		private int[] ldVertexBufferOffsets;
+
+		#endregion
+
+		#region Private MojoShader Interop
+
+		private IntPtr currentEffect = IntPtr.Zero;
+		private IntPtr currentTechnique = IntPtr.Zero;
+		private uint currentPass = 0;
+
+		private IntPtr prevEffect = IntPtr.Zero;
+
+		private MojoShader.MOJOSHADER_mtlShaderState shaderState = new MojoShader.MOJOSHADER_mtlShaderState();
+		private MojoShader.MOJOSHADER_mtlShaderState prevShaderState;
+
+		#endregion
+
+		#region memcpy Export
+
+		/* This is used a lot for GetData/Read calls... -flibit */
+#if NETSTANDARD2_0
+		private static unsafe void memcpy(IntPtr dst, IntPtr src, IntPtr len)
+		{
+			long size = len.ToInt64();
+			Buffer.MemoryCopy(
+				(void*) src,
+				(void*) dst,
+				size,
+				size
+			);
+		}
+#else
+		[DllImport("msvcrt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void memcpy(IntPtr dst, IntPtr src, IntPtr len);
+#endif
+
+		#endregion
+
+		#region SDL Metal Imports
+
+		// FIXME: Remove this section after SDL 2.0.12 releases!
+
+		[DllImport("SDL2", CallingConvention = CallingConvention.Cdecl)]
+		public static extern IntPtr SDL_Metal_CreateView(IntPtr window);
+
+		[DllImport("SDL2", CallingConvention = CallingConvention.Cdecl)]
+		public static extern IntPtr SDL_Metal_DestroyView(IntPtr view);
+
+		public const string SDL_HINT_VIDEO_EXTERNAL_CONTEXT = "SDL_VIDEO_EXTERNAL_CONTEXT";
+
+		public static bool UsingSDL2_0_11()
+		{
+			SDL2.SDL.SDL_version version;
+			SDL2.SDL.SDL_GetVersion(out version);
+			return (version.major >= 2 && version.patch >= 11);
+		}
+
+		#endregion
+
+		#region Public Constructor
+
+		public MetalDevice(
+			PresentationParameters presentationParameters,
+			GraphicsAdapter adapter
+		) {
+			device = MTLCreateSystemDefaultDevice();
+			queue = mtlNewCommandQueue(device);
+
+			if (UsingSDL2_0_11())
+			{
+				// Create the Metal view
+				view = SDL_Metal_CreateView(
+					presentationParameters.DeviceWindowHandle
+				);
+
+				// Get the layer from the view
+				layer = mtlGetLayer(view);
+			}
+			else
+			{
+				// Create a renderer and grab the layer from it.
+				SDL2.SDL.SDL_SetHint(SDL2.SDL.SDL_HINT_RENDER_DRIVER, "metal");
+				renderer = SDL2.SDL.SDL_CreateRenderer(
+					presentationParameters.DeviceWindowHandle,
+					-1,
+					SDL2.SDL.SDL_RendererFlags.SDL_RENDERER_ACCELERATED
+				);
+				layer = SDL2.SDL.SDL_RenderGetMetalLayer(renderer);
+			}
+
+			// Set up the CAMetalLayer
+			mtlSetLayerDevice(layer, device);
+			mtlSetLayerFramebufferOnly(layer, true);
+			mtlSetLayerMagnificationFilter(layer, UTF8ToNSString("nearest"));
+
+			// Log GLDevice info
+			FNALoggerEXT.LogInfo("IGLDevice: MetalDevice");
+			FNALoggerEXT.LogInfo("Device Name: " + mtlGetDeviceName(device));
+			FNALoggerEXT.LogInfo("MojoShader Profile: metal");
+
+			// Some users might want pixely upscaling...
+			backbufferScaleMode = Environment.GetEnvironmentVariable(
+				"FNA_GRAPHICS_BACKBUFFER_SCALE_NEAREST"
+			) == "1" ? MTLSamplerMinMagFilter.Nearest : MTLSamplerMinMagFilter.Linear;
+
+			// Set device properties
+			isMac = SDL2.SDL.SDL_GetPlatform().Equals("Mac OS X");
+			SupportsS3tc = SupportsDxt1 = isMac;
+			MaxMultiSampleCount = mtlSupportsSampleCount(device, 8) ? 8 : 4;
+			supportsOcclusionQueries = isMac || HasModernAppleGPU();
+
+			// Determine supported depth formats
+			D16Format = MTLPixelFormat.Depth32Float;
+			D24Format = MTLPixelFormat.Depth32Float;
+			D24S8Format = MTLPixelFormat.Depth32Float_Stencil8;
+
+			if (isMac)
+			{
+				bool supportsD24S8 = mtlSupportsDepth24Stencil8(device);
+				if (supportsD24S8)
+				{
+					D24S8Format = MTLPixelFormat.Depth24Unorm_Stencil8;
+
+					// Gross, but at least it's a unorm format! -caleb
+					D24Format = MTLPixelFormat.Depth24Unorm_Stencil8;
+					D16Format = MTLPixelFormat.Depth24Unorm_Stencil8;
+				}
+
+				// Depth16Unorm requires macOS 10.12+
+				if (OperatingSystemAtLeast(10, 12, 0))
+				{
+					D16Format = MTLPixelFormat.Depth16Unorm;
+					if (!supportsD24S8)
+					{
+						// Less precision, but oh well!
+						D24Format = MTLPixelFormat.Depth16Unorm;
+					}
+				}
+			}
+			else
+			{
+				// Depth16Unorm requires iOS 13+
+				if (OperatingSystemAtLeast(13, 0, 0))
+				{
+					D16Format = MTLPixelFormat.Depth16Unorm;
+					D24Format = MTLPixelFormat.Depth16Unorm;
+				}
+			}
+
+			// Add fallbacks for missing texture formats on macOS
+			if (isMac)
+			{
+				XNAToMTL.TextureFormat[(int) SurfaceFormat.Bgr565]
+					= MTLPixelFormat.BGRA8Unorm;
+				XNAToMTL.TextureFormat[(int) SurfaceFormat.Bgra5551]
+					= MTLPixelFormat.BGRA8Unorm;
+				XNAToMTL.TextureFormat[(int) SurfaceFormat.Bgra4444]
+					= MTLPixelFormat.BGRA8Unorm;
+			}
+
+			// Initialize texture and sampler collections
+			Textures = new MetalTexture[MaxTextureSlots];
+			Samplers = new IntPtr[MaxTextureSlots];
+			for (int i = 0; i < MaxTextureSlots; i += 1)
+			{
+				Textures[i] = MetalTexture.NullTexture;
+				Samplers[i] = IntPtr.Zero;
+			}
+			textureNeedsUpdate = new bool[MaxTextureSlots];
+			samplerNeedsUpdate = new bool[MaxTextureSlots];
+
+			// Initialize attachment arrays
+			int numAttachments = GraphicsDevice.MAX_RENDERTARGET_BINDINGS;
+			currentAttachments = new IntPtr[numAttachments];
+			currentColorFormats = new MTLPixelFormat[numAttachments];
+			currentMSAttachments = new IntPtr[numAttachments];
+			currentAttachmentSlices = new CubeMapFace[numAttachments];
+
+			// Initialize vertex buffer cache
+			ldVertexBuffers = new IntPtr[MAX_BOUND_VERTEX_BUFFERS];
+			ldVertexBufferOffsets = new int[MAX_BOUND_VERTEX_BUFFERS];
+
+			// Create a default depth stencil state
+			IntPtr defDS = mtlNewDepthStencilDescriptor();
+			defaultDepthStencilState = mtlNewDepthStencilStateWithDescriptor(device, defDS);
+			objc_release(defDS);
+
+			// Create and setup the faux-backbuffer
+			InitializeFauxBackbuffer(presentationParameters);
+		}
+
+		#endregion
+
+		#region Dispose Method
+
+		public void Dispose()
+		{
+			// Stop rendering
+			EndPass();
+
+			// Release vertex descriptors
+			foreach (IntPtr vdesc in VertexDescriptorCache.Values)
+			{
+				objc_release(vdesc);
+			}
+			VertexDescriptorCache.Clear();
+			VertexDescriptorCache = null;
+
+			// Release depth stencil states
+			foreach (IntPtr ds in DepthStencilStateCache.Values)
+			{
+				objc_release(ds);
+			}
+			DepthStencilStateCache.Clear();
+			DepthStencilStateCache = null;
+
+			// Release pipeline states
+			foreach (IntPtr pso in PipelineStateCache.Values)
+			{
+				objc_release(pso);
+			}
+			PipelineStateCache.Clear();
+			PipelineStateCache = null;
+
+			// Release sampler states
+			foreach (IntPtr ss in SamplerStateCache.Values)
+			{
+				objc_release(ss);
+			}
+			SamplerStateCache.Clear();
+			SamplerStateCache = null;
+
+			// Release transient textures
+			foreach (MetalTexture tex in transientTextures)
+			{
+				objc_release(tex.Handle);
+			}
+			transientTextures.Clear();
+			transientTextures = null;
+
+			// Dispose the backbuffer
+			(Backbuffer as MetalBackbuffer).Dispose();
+
+			if (UsingSDL2_0_11())
+			{
+				// Destroy the view
+				SDL_Metal_DestroyView(view);
+			}
+			else
+			{
+				// Destroy the renderer
+				SDL2.SDL.SDL_DestroyRenderer(renderer);
+			}
+		}
+
+		#endregion
+
+		#region GetDrawableSize Methods
+
+		public static void GetDrawableSize(
+			IntPtr layer,
+			out int w,
+			out int h
+		) {
+			CGSize size = mtlGetDrawableSize(layer);
+			w = (int) size.width;
+			h = (int) size.height;
+		}
+
+		public static void GetDrawableSizeFromView(
+			IntPtr view,
+			out int w,
+			out int h
+		) {
+			GetDrawableSize(mtlGetLayer(view), out w, out h);
+		}
+
+		#endregion
+
+		#region Window Backbuffer Reset Method
+
+		public void ResetBackbuffer(
+			PresentationParameters presentationParameters,
+			GraphicsAdapter adapter
+		) {
+			Backbuffer.ResetFramebuffer(
+				presentationParameters
+			);
+		}
+
+		#endregion
+
+		#region BeginFrame Method
+
+		public void BeginFrame()
+		{
+			if (frameInProgress) return;
+
+			// Wait for command buffers to complete...
+			while (committedCommandBuffers.Count >= MAX_FRAMES_IN_FLIGHT)
+			{
+				IntPtr cmdbuf = committedCommandBuffers.Dequeue();
+				mtlCommandBufferWaitUntilCompleted(cmdbuf);
+				objc_release(cmdbuf);
+			}
+
+			// The cycle begins anew!
+			frameInProgress = true;
+			pool = objc_autoreleasePoolPush();
+			commandBuffer = mtlMakeCommandBuffer(queue);
+		}
+
+		#endregion
+
+		#region Window SwapBuffers Method
+
+		public void SwapBuffers(
+			Rectangle? sourceRectangle,
+			Rectangle? destinationRectangle,
+			IntPtr overrideWindowHandle
+		) {
+			// Bind the backbuffer and finalize rendering
+			SetRenderTargets(null, null, DepthFormat.None);
+			EndPass();
+
+			// Determine the regions to present
+			int srcX, srcY, srcW, srcH;
+			int dstX, dstY, dstW, dstH;
+			if (sourceRectangle.HasValue)
+			{
+				srcX = sourceRectangle.Value.X;
+				srcY = sourceRectangle.Value.Y;
+				srcW = sourceRectangle.Value.Width;
+				srcH = sourceRectangle.Value.Height;
+			}
+			else
+			{
+				srcX = 0;
+				srcY = 0;
+				srcW = Backbuffer.Width;
+				srcH = Backbuffer.Height;
+			}
+			if (destinationRectangle.HasValue)
+			{
+				dstX = destinationRectangle.Value.X;
+				dstY = destinationRectangle.Value.Y;
+				dstW = destinationRectangle.Value.Width;
+				dstH = destinationRectangle.Value.Height;
+			}
+			else
+			{
+				dstX = 0;
+				dstY = 0;
+				GetDrawableSize(
+					layer,
+					out dstW,
+					out dstH
+				);
+			}
+
+			// Get the next drawable
+			IntPtr drawable = mtlNextDrawable(layer);
+
+			// "Blit" the backbuffer to the drawable
+			BlitFramebuffer(
+				currentAttachments[0],
+				new Rectangle(srcX, srcY, srcW, srcH),
+				mtlGetTextureFromDrawable(drawable),
+				new Rectangle(dstX, dstY, dstW, dstH)
+			);
+
+			// Commit the command buffer for presentation
+			mtlPresentDrawable(commandBuffer, drawable);
+			mtlCommitCommandBuffer(commandBuffer);
+
+			// Enqueue the command buffer for tracking
+			objc_retain(commandBuffer);
+			committedCommandBuffers.Enqueue(commandBuffer);
+			commandBuffer = IntPtr.Zero;
+
+			// Release allocations from the past frame
+			objc_autoreleasePoolPop(pool);
+
+			// Reset buffers
+			for (int i = 0; i < Buffers.Count; i += 1)
+			{
+				Buffers[i].Reset();
+			}
+			MojoShader.MOJOSHADER_mtlEndFrame();
+
+			// We're done here.
+			frameInProgress = false;
+		}
+
+		private void BlitFramebuffer(
+			IntPtr srcTex,
+			Rectangle srcRect,
+			IntPtr dstTex,
+			Rectangle dstRect
+		) {
+			if (	srcRect.Width == 0 ||
+				srcRect.Height == 0 ||
+				dstRect.Width == 0 ||
+				dstRect.Height == 0	)
+			{
+				// Enjoy that bright red window!
+				return;
+			}
+
+			// Update cached vertex buffer if needed
+			if (fauxBackbufferDestBounds != dstRect || fauxBackbufferSizeChanged)
+			{
+				fauxBackbufferDestBounds = dstRect;
+				fauxBackbufferSizeChanged = false;
+
+				// Scale the coordinates to (-1, 1)
+				int dw, dh;
+				GetDrawableSize(layer, out dw, out dh);
+				float sx = -1 + (dstRect.X / (float) dw);
+				float sy = -1 + (dstRect.Y / (float) dh);
+				float sw = (dstRect.Width / (float) dw) * 2;
+				float sh = (dstRect.Height / (float) dh) * 2;
+
+				// Update the vertex buffer contents
+				float[] data = new float[]
+				{
+					sx, sy,			0, 0,
+					sx + sw, sy,		1, 0,
+					sx + sw, sy + sh,	1, 1,
+					sx, sy + sh,		0, 1
+				};
+				GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+				memcpy(
+					mtlGetBufferContentsPtr(fauxBackbufferDrawBuffer),
+					handle.AddrOfPinnedObject(),
+					(IntPtr) (16 * sizeof(float))
+				);
+				handle.Free();
+			}
+
+			// Render the source texture to the destination texture
+			IntPtr backbufferRenderPass = mtlMakeRenderPassDescriptor();
+			mtlSetAttachmentTexture(
+				mtlGetColorAttachment(backbufferRenderPass, 0),
+				dstTex
+			);
+			IntPtr rce = mtlMakeRenderCommandEncoder(
+				commandBuffer,
+				backbufferRenderPass
+			);
+			mtlSetRenderPipelineState(rce, fauxBackbufferRenderPipeline);
+			mtlSetVertexBuffer(rce, fauxBackbufferDrawBuffer, 0, 0);
+			mtlSetFragmentTexture(rce, srcTex, 0);
+			mtlSetFragmentSamplerState(rce, fauxBackbufferSamplerState, 0);
+			mtlDrawIndexedPrimitives(
+				rce,
+				MTLPrimitiveType.Triangle,
+				6,
+				MTLIndexType.UInt16,
+				fauxBackbufferDrawBuffer,
+				16 * sizeof(float),
+				1
+			);
+			mtlEndEncoding(rce);
+		}
+
+		#endregion
+
+		#region Render Command Encoder Methods
+
+		private void EndPass()
+		{
+			if (renderCommandEncoder != IntPtr.Zero)
+			{
+				mtlEndEncoding(renderCommandEncoder);
+				renderCommandEncoder = IntPtr.Zero;
+			}
+		}
+
+		private void UpdateRenderPass()
+		{
+			if (!needNewRenderPass) return;
+
+			/* Normally the frame begins in BeginDraw(),
+			 * but some games perform drawing outside
+			 * of the Draw method (e.g. initializing
+			 * render targets in LoadContent). This call
+			 * ensures that we catch any unexpected draws.
+			 * -caleb
+			 */
+			BeginFrame();
+
+			// Wrap up rendering with the old encoder
+			EndPass();
+
+			// Generate the descriptor
+			IntPtr passDesc = mtlMakeRenderPassDescriptor();
+
+			// Bind color attachments
+			for (int i = 0; i < currentAttachments.Length; i += 1)
+			{
+				if (currentAttachments[i] == IntPtr.Zero)
+				{
+					continue;
+				}
+
+				IntPtr colorAttachment = mtlGetColorAttachment(passDesc, i);
+				mtlSetAttachmentTexture(
+					colorAttachment,
+					currentAttachments[i]
+				);
+				mtlSetAttachmentSlice(
+					colorAttachment,
+					(int) currentAttachmentSlices[i]
+				);
+
+				// Multisample?
+				if (currentSampleCount > 0)
+				{
+					mtlSetAttachmentTexture(
+						colorAttachment,
+						currentMSAttachments[i]
+					);
+					mtlSetAttachmentSlice(
+						colorAttachment,
+						0
+					);
+					mtlSetAttachmentResolveTexture(
+						colorAttachment,
+						currentAttachments[i]
+					);
+					mtlSetAttachmentStoreAction(
+						colorAttachment,
+						MTLStoreAction.MultisampleResolve
+					);
+					mtlSetAttachmentResolveSlice(
+						colorAttachment,
+						(int) currentAttachmentSlices[i]
+					);
+				}
+
+				// Clear color
+				if (shouldClearColor)
+				{
+					mtlSetAttachmentLoadAction(
+						colorAttachment,
+						MTLLoadAction.Clear
+					);
+					mtlSetColorAttachmentClearColor(
+						colorAttachment,
+						clearColor.X,
+						clearColor.Y,
+						clearColor.Z,
+						clearColor.W
+					);
+				}
+				else
+				{
+					mtlSetAttachmentLoadAction(
+						colorAttachment,
+						MTLLoadAction.Load
+					);
+				}
+			}
+
+			// Bind depth attachment
+			if (currentDepthFormat != DepthFormat.None)
+			{
+				IntPtr depthAttachment = mtlGetDepthAttachment(passDesc);
+				mtlSetAttachmentTexture(
+					depthAttachment,
+					currentDepthStencilBuffer
+				);
+				mtlSetAttachmentStoreAction(
+					depthAttachment,
+					MTLStoreAction.Store
+				);
+
+				// Clear?
+				if (shouldClearDepth)
+				{
+					mtlSetAttachmentLoadAction(
+						depthAttachment,
+						MTLLoadAction.Clear
+					);
+					mtlSetDepthAttachmentClearDepth(
+						depthAttachment,
+						clearDepth
+					);
+				}
+				else
+				{
+					mtlSetAttachmentLoadAction(
+						depthAttachment,
+						MTLLoadAction.Load
+					);
+				}
+			}
+
+			// Bind stencil buffer
+			if (currentDepthFormat == DepthFormat.Depth24Stencil8)
+			{
+				IntPtr stencilAttachment = mtlGetStencilAttachment(passDesc);
+				mtlSetAttachmentTexture(
+					stencilAttachment,
+					currentDepthStencilBuffer
+				);
+				mtlSetAttachmentStoreAction(
+					stencilAttachment,
+					MTLStoreAction.Store
+				);
+
+				// Clear?
+				if (shouldClearStencil)
+				{
+					mtlSetAttachmentLoadAction(
+						stencilAttachment,
+						MTLLoadAction.Clear
+					);
+					mtlSetStencilAttachmentClearStencil(
+						stencilAttachment,
+						clearStencil
+					);
+				}
+				else
+				{
+					mtlSetAttachmentLoadAction(
+						stencilAttachment,
+						MTLLoadAction.Load
+					);
+				}
+			}
+
+			// Get attachment size
+			currentAttachmentWidth = (int) mtlGetTextureWidth(
+				currentAttachments[0]
+			);
+			currentAttachmentHeight = (int) mtlGetTextureHeight(
+				currentAttachments[0]
+			);
+
+			// Attach the visibility buffer, if needed
+			if (currentVisibilityBuffer != IntPtr.Zero)
+			{
+				mtlSetVisibilityResultBuffer(
+					passDesc,
+					currentVisibilityBuffer
+				);
+			}
+
+			// Make a new encoder
+			renderCommandEncoder = mtlMakeRenderCommandEncoder(
+				commandBuffer,
+				passDesc
+			);
+
+			// Reset the flags
+			needNewRenderPass = false;
+			shouldClearColor = false;
+			shouldClearDepth = false;
+			shouldClearStencil = false;
+
+			// Apply the dynamic state
+			SetEncoderViewport();
+			SetEncoderScissorRect();
+			SetEncoderBlendColor();
+			SetEncoderStencilReferenceValue();
+			SetEncoderCullMode();
+			SetEncoderFillMode();
+			SetEncoderDepthBias();
+
+			// Start visibility buffer counting
+			if (currentVisibilityBuffer != IntPtr.Zero)
+			{
+				mtlSetVisibilityResultMode(
+					renderCommandEncoder,
+					MTLVisibilityResultMode.Counting,
+					0
+				);
+			}
+
+			// Reset the bindings
+			for (int i = 0; i < MaxTextureSlots; i += 1)
+			{
+				if (Textures[i] != MetalTexture.NullTexture)
+				{
+					textureNeedsUpdate[i] = true;
+				}
+				if (Samplers[i] != IntPtr.Zero)
+				{
+					samplerNeedsUpdate[i] = true;
+				}
+			}
+			ldDepthStencilState = IntPtr.Zero;
+			ldFragUniformBuffer = IntPtr.Zero;
+			ldFragUniformOffset = 0;
+			ldVertUniformBuffer = IntPtr.Zero;
+			ldVertUniformOffset = 0;
+			ldPipelineState = IntPtr.Zero;
+			for (int i = 0; i < MAX_BOUND_VERTEX_BUFFERS; i += 1)
+			{
+				ldVertexBuffers[i] = IntPtr.Zero;
+				ldVertexBufferOffsets[i] = 0;
+			}
+		}
+
+		private void SetEncoderStencilReferenceValue()
+		{
+			if (renderCommandEncoder != IntPtr.Zero && !needNewRenderPass)
+			{
+				mtlSetStencilReferenceValue(
+					renderCommandEncoder,
+					(uint) stencilRef
+				);
+			}
+		}
+
+		private void SetEncoderBlendColor()
+		{
+			if (renderCommandEncoder != IntPtr.Zero && !needNewRenderPass)
+			{
+				mtlSetBlendColor(
+					renderCommandEncoder,
+					blendColor.R / 255f,
+					blendColor.G / 255f,
+					blendColor.B / 255f,
+					blendColor.A / 255f
+				);
+			}
+		}
+
+		private void SetEncoderViewport()
+		{
+			if (renderCommandEncoder != IntPtr.Zero && !needNewRenderPass)
+			{
+				mtlSetViewport(
+					renderCommandEncoder,
+					viewport.X,
+					viewport.Y,
+					viewport.Width,
+					viewport.Height,
+					(double) depthRangeMin,
+					(double) depthRangeMax
+				);
+			}
+		}
+
+		private void SetEncoderCullMode()
+		{
+			if (renderCommandEncoder != IntPtr.Zero && !needNewRenderPass)
+			{
+				mtlSetCullMode(
+					renderCommandEncoder,
+					XNAToMTL.CullingEnabled[(int) cullFrontFace]
+				);
+			}
+		}
+
+		private void SetEncoderFillMode()
+		{
+			if (renderCommandEncoder != IntPtr.Zero && !needNewRenderPass)
+			{
+				mtlSetTriangleFillMode(
+					renderCommandEncoder,
+					XNAToMTL.FillMode[(int) fillMode]
+				);
+			}
+		}
+
+		private void SetEncoderDepthBias()
+		{
+			if (renderCommandEncoder != IntPtr.Zero && !needNewRenderPass)
+			{
+				mtlSetDepthBias(
+					renderCommandEncoder,
+					depthBias,
+					slopeScaleDepthBias,
+					0.0f // no clamp
+				);
+			}
+		}
+
+		private void SetEncoderScissorRect()
+		{
+			if (renderCommandEncoder != IntPtr.Zero && !needNewRenderPass)
+			{
+				if (!scissorTestEnable)
+				{
+					// Set to the default scissor rect
+					mtlSetScissorRect(
+						renderCommandEncoder,
+						0,
+						0,
+						currentAttachmentWidth,
+						currentAttachmentHeight
+					);
+				}
+				else
+				{
+					mtlSetScissorRect(
+						renderCommandEncoder,
+						scissorRectangle.X,
+						scissorRectangle.Y,
+						scissorRectangle.Width,
+						scissorRectangle.Height
+					);
+				}
+			}
+		}
+
+		#endregion
+
+		#region Metal Object Disposal Wrappers
+
+		public void AddDisposeEffect(IGLEffect effect)
+		{
+			DeleteEffect(effect);
+		}
+
+		public void AddDisposeIndexBuffer(IGLBuffer buffer)
+		{
+			DeleteBuffer(buffer);
+		}
+
+		public void AddDisposeQuery(IGLQuery query)
+		{
+			DeleteQuery(query);
+		}
+
+		public void AddDisposeRenderbuffer(IGLRenderbuffer renderbuffer)
+		{
+			DeleteRenderbuffer(renderbuffer);
+		}
+
+		public void AddDisposeTexture(IGLTexture texture)
+		{
+			DeleteTexture(texture);
+		}
+
+		public void AddDisposeVertexBuffer(IGLBuffer buffer)
+		{
+			DeleteBuffer(buffer);
+		}
+
+		#endregion
+
+		#region Pipeline Stall Method
+
+		private void Stall()
+		{
+			EndPass();
+			mtlCommitCommandBuffer(commandBuffer);
+			mtlCommandBufferWaitUntilCompleted(commandBuffer);
+
+			commandBuffer = mtlMakeCommandBuffer(queue);
+			needNewRenderPass = true;
+			committedCommandBuffers.Clear();
+
+			for (int i = 0; i < Buffers.Count; i += 1)
+			{
+				Buffers[i].Reset();
+			}
+		}
+
+		#endregion
+
+		#region String Marker Method
+
+		public void SetStringMarker(string text)
+		{
+#if DEBUG
+			if (renderCommandEncoder != IntPtr.Zero)
+			{
+				mtlInsertDebugSignpost(renderCommandEncoder, text);
+			}
+#endif
+		}
+
+		#endregion
+
+		#region Drawing Methods
+
+		public void DrawIndexedPrimitives(
+			PrimitiveType primitiveType,
+			int baseVertex,
+			int minVertexIndex,
+			int numVertices,
+			int startIndex,
+			int primitiveCount,
+			IndexBuffer indices
+		) {
+			MetalBuffer indexBuffer = indices.buffer as MetalBuffer;
+			indexBuffer.Bound();
+			int totalIndexOffset = (
+				(startIndex * XNAToMTL.IndexSize[(int) indices.IndexElementSize]) +
+				indexBuffer.InternalOffset
+			);
+			mtlDrawIndexedPrimitives(
+				renderCommandEncoder,
+				XNAToMTL.Primitive[(int) primitiveType],
+				XNAToMTL.PrimitiveVerts(primitiveType, primitiveCount),
+				XNAToMTL.IndexType[(int) indices.IndexElementSize],
+				indexBuffer.Handle,
+				totalIndexOffset,
+				1
+			);
+		}
+
+		public void DrawInstancedPrimitives(
+			PrimitiveType primitiveType,
+			int baseVertex,
+			int minVertexIndex,
+			int numVertices,
+			int startIndex,
+			int primitiveCount,
+			int instanceCount,
+			IndexBuffer indices
+		) {
+			MetalBuffer indexBuffer = indices.buffer as MetalBuffer;
+			indexBuffer.Bound();
+			int totalIndexOffset = (
+				(startIndex * XNAToMTL.IndexSize[(int) indices.IndexElementSize]) +
+				indexBuffer.InternalOffset
+			);
+			mtlDrawIndexedPrimitives(
+				renderCommandEncoder,
+				XNAToMTL.Primitive[(int) primitiveType],
+				XNAToMTL.PrimitiveVerts(primitiveType, primitiveCount),
+				XNAToMTL.IndexType[(int) indices.IndexElementSize],
+				indexBuffer.Handle,
+				totalIndexOffset,
+				instanceCount
+			);
+		}
+
+		public void DrawPrimitives(
+			PrimitiveType primitiveType,
+			int vertexStart,
+			int primitiveCount
+		) {
+			mtlDrawPrimitives(
+				renderCommandEncoder,
+				XNAToMTL.Primitive[(int) primitiveType],
+				vertexStart,
+				XNAToMTL.PrimitiveVerts(primitiveType, primitiveCount)
+			);
+		}
+
+		private void BindUserVertexBuffer(
+			IntPtr vertexData,
+			int vertexCount,
+			int vertexOffset
+		) {
+			// Update the buffer contents
+			int len = vertexCount * userVertexStride;
+			if (userVertexBuffer == null)
+			{
+				userVertexBuffer = new MetalBuffer(
+					this,
+					true,
+					BufferUsage.WriteOnly,
+					(IntPtr) len
+				);
+				Buffers.Add(userVertexBuffer);
+			}
+			userVertexBuffer.SetData(
+				vertexOffset * userVertexStride,
+				vertexData,
+				len
+			);
+
+			// Bind the buffer
+			int offset = userVertexBuffer.InternalOffset;
+			IntPtr handle = userVertexBuffer.Handle;
+			if (ldVertexBuffers[0] != handle)
+			{
+				mtlSetVertexBuffer(
+					renderCommandEncoder,
+					handle,
+					offset,
+					0
+				);
+				ldVertexBuffers[0] = handle;
+				ldVertexBufferOffsets[0] = offset;
+			}
+			else if (ldVertexBufferOffsets[0] != offset)
+			{
+				mtlSetVertexBufferOffset(
+					renderCommandEncoder,
+					offset,
+					0
+				);
+				ldVertexBufferOffsets[0] = offset;
+			}
+		}
+
+		public void DrawUserIndexedPrimitives(
+			PrimitiveType primitiveType,
+			IntPtr vertexData,
+			int vertexOffset,
+			int numVertices,
+			IntPtr indexData,
+			int indexOffset,
+			IndexElementSize indexElementSize,
+			int primitiveCount
+		) {
+			// Bind the vertex buffer
+			BindUserVertexBuffer(
+				vertexData,
+				numVertices,
+				vertexOffset
+			);
+
+			// Prepare the index buffer
+			int numIndices = XNAToMTL.PrimitiveVerts(
+				primitiveType,
+				primitiveCount
+			);
+			int indexSize = XNAToMTL.IndexSize[(int) indexElementSize];
+			int len = (int) numIndices * indexSize;
+			if (userIndexBuffer == null)
+			{
+				userIndexBuffer = new MetalBuffer(
+					this,
+					true,
+					BufferUsage.WriteOnly,
+					(IntPtr) len
+				);
+				Buffers.Add(userIndexBuffer);
+			}
+			userIndexBuffer.SetData(
+				indexOffset * indexSize,
+				indexData,
+				len
+			);
+
+			// Draw!
+			mtlDrawIndexedPrimitives(
+				renderCommandEncoder,
+				XNAToMTL.Primitive[(int) primitiveType],
+				numIndices,
+				XNAToMTL.IndexType[(int) indexElementSize],
+				userIndexBuffer.Handle,
+				userIndexBuffer.InternalOffset,
+				1
+			);
+		}
+
+		public void DrawUserPrimitives(
+			PrimitiveType primitiveType,
+			IntPtr vertexData,
+			int vertexOffset,
+			int primitiveCount
+		) {
+			// Bind the vertex buffer
+			int numVerts = XNAToMTL.PrimitiveVerts(
+				primitiveType,
+				primitiveCount
+			);
+			BindUserVertexBuffer(
+				vertexData,
+				numVerts,
+				vertexOffset
+			);
+
+			// Draw!
+			mtlDrawPrimitives(
+				renderCommandEncoder,
+				XNAToMTL.Primitive[(int) primitiveType],
+				0,
+				numVerts
+			);
+		}
+
+		#endregion
+
+		#region State Management Methods
+
+		public void SetPresentationInterval(PresentInterval interval)
+		{
+			// Toggling vsync is only supported on macOS 10.13+
+			if (!RespondsToSelector(layer, selDisplaySyncEnabled))
+			{
+				FNALoggerEXT.LogWarn(
+					"Cannot set presentation interval! " +
+					"Only vsync is supported."
+				);
+				return;
+			}
+
+			if (interval == PresentInterval.Default || interval == PresentInterval.One)
+			{
+				mtlSetDisplaySyncEnabled(layer, true);
+			}
+			else if (interval == PresentInterval.Immediate)
+			{
+				mtlSetDisplaySyncEnabled(layer, false);
+			}
+			else if (interval == PresentInterval.Two)
+			{
+				/* FIXME:
+				 * There is no built-in support for
+				 * present-every-other-frame in Metal.
+				 * We could work around this, but do
+				 * any games actually use this mode...?
+				 * -caleb
+				 */
+				mtlSetDisplaySyncEnabled(layer, true);
+			}
+			else
+			{
+				throw new NotSupportedException("Unrecognized PresentInterval!");
+			}
+		}
+
+		public void SetViewport(Viewport vp)
+		{
+			if (	vp.Bounds != viewport ||
+				vp.MinDepth != depthRangeMin ||
+				vp.MaxDepth != depthRangeMax	)
+			{
+				viewport = vp.Bounds;
+				depthRangeMin = vp.MinDepth;
+				depthRangeMax = vp.MaxDepth;
+				SetEncoderViewport(); // Dynamic state!
+			}
+		}
+
+		public void SetScissorRect(Rectangle scissorRect)
+		{
+			if (scissorRectangle != scissorRect)
+			{
+				scissorRectangle = scissorRect;
+				SetEncoderScissorRect(); // Dynamic state!
+			}
+		}
+
+		public void ApplyRasterizerState(RasterizerState rasterizerState)
+		{
+			if (rasterizerState.ScissorTestEnable != scissorTestEnable)
+			{
+				scissorTestEnable = rasterizerState.ScissorTestEnable;
+				SetEncoderScissorRect(); // Dynamic state!
+			}
+
+			if (rasterizerState.CullMode != cullFrontFace)
+			{
+				cullFrontFace = rasterizerState.CullMode;
+				SetEncoderCullMode(); // Dynamic state!
+			}
+
+			if (rasterizerState.FillMode != fillMode)
+			{
+				fillMode = rasterizerState.FillMode;
+				SetEncoderFillMode(); // Dynamic state!
+			}
+
+			float realDepthBias = rasterizerState.DepthBias;
+			realDepthBias *= XNAToMTL.DepthBiasScale(
+				GetDepthFormat(currentDepthFormat)
+			);
+			if (	realDepthBias != depthBias ||
+				rasterizerState.SlopeScaleDepthBias != slopeScaleDepthBias	)
+			{
+				depthBias = realDepthBias;
+				slopeScaleDepthBias = rasterizerState.SlopeScaleDepthBias;
+				SetEncoderDepthBias(); // Dynamic state!
+			}
+
+			if (rasterizerState.MultiSampleAntiAlias != multiSampleEnable)
+			{
+				multiSampleEnable = rasterizerState.MultiSampleAntiAlias;
+				// FIXME: Metal does not support toggling MSAA. Workarounds...?
+			}
+		}
+
+		public void VerifySampler(int index, Texture texture, SamplerState sampler)
+		{
+			if (texture == null)
+			{
+				if (Textures[index] != MetalTexture.NullTexture)
+				{
+					Textures[index] = MetalTexture.NullTexture;
+					textureNeedsUpdate[index] = true;
+				}
+				if (Samplers[index] == IntPtr.Zero)
+				{
+					/* Some shaders require non-null samplers
+					 * even if they aren't actually used.
+					 * -caleb
+					 */
+					Samplers[index] = FetchSamplerState(sampler, false);
+					samplerNeedsUpdate[index] = true;
+				}
+				return;
+			}
+
+			MetalTexture tex = texture.texture as MetalTexture;
+			if (	tex == Textures[index] &&
+				sampler.AddressU == tex.WrapS &&
+				sampler.AddressV == tex.WrapT &&
+				sampler.AddressW == tex.WrapR &&
+				sampler.Filter == tex.Filter &&
+				sampler.MaxAnisotropy == tex.Anisotropy &&
+				sampler.MaxMipLevel == tex.MaxMipmapLevel &&
+				sampler.MipMapLevelOfDetailBias == tex.LODBias	)
+			{
+				// Nothing's changing, forget it.
+				return;
+			}
+
+			// Bind the correct texture
+			if (tex != Textures[index])
+			{
+				Textures[index] = tex;
+				textureNeedsUpdate[index] = true;
+			}
+
+			// Update the texture sampler info
+			tex.WrapS = sampler.AddressU;
+			tex.WrapT = sampler.AddressV;
+			tex.WrapR = sampler.AddressW;
+			tex.Filter = sampler.Filter;
+			tex.Anisotropy = sampler.MaxAnisotropy;
+			tex.MaxMipmapLevel = sampler.MaxMipLevel;
+			tex.LODBias = sampler.MipMapLevelOfDetailBias;
+
+			// Update the sampler state, if needed
+			IntPtr ss = FetchSamplerState(sampler, tex.HasMipmaps);
+			if (ss != Samplers[index])
+			{
+				Samplers[index] = ss;
+				samplerNeedsUpdate[index] = true;
+			}
+		}
+
+		public void SetBlendState(BlendState blendState)
+		{
+			this.blendState = blendState;
+			BlendFactor = blendState.BlendFactor; // Dynamic state!
+		}
+
+		public void SetDepthStencilState(DepthStencilState depthStencilState)
+		{
+			this.depthStencilState = depthStencilState;
+			ReferenceStencil = depthStencilState.ReferenceStencil; // Dynamic state!
+		}
+
+		#endregion
+
+		#region State Creation/Retrieval Methods
+
+		private struct PipelineHash : IEquatable<PipelineHash>
+		{
+			readonly ulong a;
+			readonly ulong b;
+			readonly ulong c;
+			readonly ulong d;
+
+			public PipelineHash(
+				ulong vertexShader,
+				ulong fragmentShader,
+				ulong vertexDescriptor,
+				MTLPixelFormat[] formats,
+				DepthFormat depthFormat,
+				int sampleCount,
+				BlendState blendState
+			) {
+				this.a = vertexShader;
+				this.b = fragmentShader;
+				this.c = vertexDescriptor;
+
+				unchecked
+				{
+					this.d = (
+						((ulong) blendState.GetHashCode() << 32) |
+						((ulong) sampleCount << 22) |
+						((ulong) depthFormat << 20) |
+						((ulong) HashFormat(formats[3]) << 15) |
+						((ulong) HashFormat(formats[2]) << 10) |
+						((ulong) HashFormat(formats[1]) << 5) |
+						((ulong) HashFormat(formats[0]))
+					);
+				}
+			}
+
+			private static uint HashFormat(MTLPixelFormat format)
+			{
+				switch (format)
+				{
+					case MTLPixelFormat.Invalid:
+						return 0;
+					case MTLPixelFormat.R16Float:
+						return 1;
+					case MTLPixelFormat.R32Float:
+						return 2;
+					case MTLPixelFormat.RG16Float:
+						return 3;
+					case MTLPixelFormat.RG16Snorm:
+						return 4;
+					case MTLPixelFormat.RG16Unorm:
+						return 5;
+					case MTLPixelFormat.RG32Float:
+						return 6;
+					case MTLPixelFormat.RG8Snorm:
+						return 7;
+					case MTLPixelFormat.RGB10A2Unorm:
+						return 8;
+					case MTLPixelFormat.RGBA16Float:
+						return 9;
+					case MTLPixelFormat.RGBA16Unorm:
+						return 10;
+					case MTLPixelFormat.RGBA32Float:
+						return 11;
+					case MTLPixelFormat.RGBA8Unorm:
+						return 12;
+					case MTLPixelFormat.A8Unorm:
+						return 13;
+					case MTLPixelFormat.ABGR4Unorm:
+						return 14;
+					case MTLPixelFormat.B5G6R5Unorm:
+						return 15;
+					case MTLPixelFormat.BC1_RGBA:
+						return 16;
+					case MTLPixelFormat.BC2_RGBA:
+						return 17;
+					case MTLPixelFormat.BC3_RGBA:
+						return 18;
+					case MTLPixelFormat.BGR5A1Unorm:
+						return 19;
+					case MTLPixelFormat.BGRA8Unorm:
+						return 20;
+				}
+
+				throw new NotSupportedException();
+			}
+
+			public override int GetHashCode()
+			{
+				unchecked
+				{
+					int i1 = (int) (a ^ (a >> 32));
+					int i2 = (int) (b ^ (b >> 32));
+					int i3 = (int) (c ^ (c >> 32));
+					int i4 = (int) (d ^ (d >> 32));
+					return i1 + i2 + i3 + i4;
+				}
+			}
+
+			public bool Equals(PipelineHash other)
+			{
+				return (
+					a == other.a &&
+					b == other.b &&
+					c == other.c &&
+					d == other.d
+				);
+			}
+
+			public override bool Equals(object obj)
+			{
+				if (obj == null || obj.GetType() != GetType())
+				{
+					return false;
+				}
+
+				PipelineHash hash = (PipelineHash) obj;
+				return (
+					a == hash.a &&
+					b == hash.b &&
+					c == hash.c &&
+					d == hash.d
+				);
+			}
+		}
+
+		private IntPtr FetchRenderPipeline()
+		{
+			// Can we just reuse an existing pipeline?
+			PipelineHash hash = new PipelineHash(
+				(ulong) shaderState.vertexShader,
+				(ulong) shaderState.fragmentShader,
+				(ulong) currentVertexDescriptor,
+				currentColorFormats,
+				currentDepthFormat,
+				currentSampleCount,
+				blendState
+			);
+			IntPtr pipeline = IntPtr.Zero;
+			if (PipelineStateCache.TryGetValue(hash, out pipeline))
+			{
+				// We have this state already cached!
+				return pipeline;
+			}
+
+			// We have to make a new pipeline...
+			IntPtr pipelineDesc = mtlNewRenderPipelineDescriptor();
+			IntPtr vertHandle = MojoShader.MOJOSHADER_mtlGetFunctionHandle(
+				shaderState.vertexShader
+			);
+			IntPtr fragHandle = MojoShader.MOJOSHADER_mtlGetFunctionHandle(
+				shaderState.fragmentShader
+			);
+			mtlSetPipelineVertexFunction(
+				pipelineDesc,
+				vertHandle
+			);
+			mtlSetPipelineFragmentFunction(
+				pipelineDesc,
+				fragHandle
+			);
+			mtlSetPipelineVertexDescriptor(
+				pipelineDesc,
+				currentVertexDescriptor
+			);
+			mtlSetDepthAttachmentPixelFormat(
+				pipelineDesc,
+				GetDepthFormat(currentDepthFormat)
+			);
+			if (currentDepthFormat == DepthFormat.Depth24Stencil8)
+			{
+				mtlSetStencilAttachmentPixelFormat(
+					pipelineDesc,
+					GetDepthFormat(currentDepthFormat)
+				);
+			}
+			mtlSetPipelineSampleCount(
+				pipelineDesc,
+				Math.Max(1, currentSampleCount)
+			);
+
+			// Apply the blend state
+			bool alphaBlendEnable = !(
+				blendState.ColorSourceBlend == Blend.One &&
+				blendState.ColorDestinationBlend == Blend.Zero &&
+				blendState.AlphaSourceBlend == Blend.One &&
+				blendState.AlphaDestinationBlend == Blend.Zero
+			);
+			for (int i = 0; i < currentAttachments.Length; i += 1)
+			{
+				if (currentAttachments[i] == IntPtr.Zero)
+				{
+					// There's no attachment bound at this index.
+					continue;
+				}
+
+				IntPtr colorAttachment = mtlGetColorAttachment(
+					pipelineDesc,
+					i
+				);
+				mtlSetAttachmentPixelFormat(
+					colorAttachment,
+					currentColorFormats[i]
+				);
+				mtlSetAttachmentBlendingEnabled(
+					colorAttachment,
+					alphaBlendEnable
+				);
+				if (alphaBlendEnable)
+				{
+					mtlSetAttachmentSourceRGBBlendFactor(
+						colorAttachment,
+						XNAToMTL.BlendMode[
+							(int) blendState.ColorSourceBlend
+						]
+					);
+					mtlSetAttachmentDestinationRGBBlendFactor(
+						colorAttachment,
+						XNAToMTL.BlendMode[
+							(int) blendState.ColorDestinationBlend
+						]
+					);
+					mtlSetAttachmentSourceAlphaBlendFactor(
+						colorAttachment,
+						XNAToMTL.BlendMode[
+							(int) blendState.AlphaSourceBlend
+						]
+					);
+					mtlSetAttachmentDestinationAlphaBlendFactor(
+						colorAttachment,
+						XNAToMTL.BlendMode[
+							(int) blendState.AlphaDestinationBlend
+						]
+					);
+					mtlSetAttachmentRGBBlendOperation(
+						colorAttachment,
+						XNAToMTL.BlendOperation[
+							(int) blendState.ColorBlendFunction
+						]
+					);
+					mtlSetAttachmentAlphaBlendOperation(
+						colorAttachment,
+						XNAToMTL.BlendOperation[
+							(int) blendState.AlphaBlendFunction
+						]
+					);
+				}
+
+				/* FIXME: So how exactly do we factor in
+				 * COLORWRITEENABLE for buffer 0? Do we just assume that
+				 * the default is just buffer 0, and all other calls
+				 * update the other write masks?
+				 */
+				if (i == 0)
+				{
+					mtlSetAttachmentWriteMask(
+						colorAttachment,
+						XNAToMTL.ColorWriteMask(blendState.ColorWriteChannels)
+					);
+				}
+				else if (i == 1)
+				{
+					mtlSetAttachmentWriteMask(
+						mtlGetColorAttachment(pipelineDesc, 1),
+						XNAToMTL.ColorWriteMask(blendState.ColorWriteChannels1)
+					);
+				}
+				else if (i == 2)
+				{
+					mtlSetAttachmentWriteMask(
+						mtlGetColorAttachment(pipelineDesc, 2),
+						XNAToMTL.ColorWriteMask(blendState.ColorWriteChannels2)
+					);
+				}
+				else if (i == 3)
+				{
+					mtlSetAttachmentWriteMask(
+						mtlGetColorAttachment(pipelineDesc, 3),
+						XNAToMTL.ColorWriteMask(blendState.ColorWriteChannels3)
+					);
+				}
+			}
+
+			// Bake the render pipeline!
+			IntPtr pipelineState = mtlNewRenderPipelineStateWithDescriptor(
+				device,
+				pipelineDesc
+			);
+			PipelineStateCache[hash] = pipelineState;
+
+			// Clean up
+			objc_release(pipelineDesc);
+			objc_release(vertHandle);
+			objc_release(fragHandle);
+
+			// Return the pipeline!
+			return pipelineState;
+		}
+
+		private IntPtr FetchDepthStencilState()
+		{
+			/* Just use the default depth-stencil state
+			 * if depth and stencil testing are disabled,
+			 * or if there is no bound depth attachment.
+			 * This wards off Metal validation errors.
+			 * -caleb
+			 */
+			bool zEnable = depthStencilState.DepthBufferEnable;
+			bool sEnable = depthStencilState.StencilEnable;
+			bool zFormat = (currentDepthFormat != DepthFormat.None);
+			if ((!zEnable && !sEnable) || (!zFormat))
+			{
+				return defaultDepthStencilState;
+			}
+
+			// Can we just reuse an existing state?
+			StateHash hash = PipelineCache.GetDepthStencilHash(depthStencilState);
+			IntPtr state = IntPtr.Zero;
+			if (DepthStencilStateCache.TryGetValue(hash, out state))
+			{
+				// This state has already been cached!
+				return state;
+			}
+
+			// We have to make a new DepthStencilState...
+			IntPtr dsDesc = mtlNewDepthStencilDescriptor();
+			if (zEnable)
+			{
+				mtlSetDepthCompareFunction(
+					dsDesc,
+					XNAToMTL.CompareFunc[(int) depthStencilState.DepthBufferFunction]
+				);
+				mtlSetDepthWriteEnabled(
+					dsDesc,
+					depthStencilState.DepthBufferWriteEnable
+				);
+			}
+
+			// Create stencil descriptors
+			IntPtr front = IntPtr.Zero;
+			IntPtr back = IntPtr.Zero;
+
+			if (sEnable)
+			{
+				front = mtlNewStencilDescriptor();
+				mtlSetStencilFailureOperation(
+					front,
+					XNAToMTL.StencilOp[(int) depthStencilState.StencilFail]
+				);
+				mtlSetDepthFailureOperation(
+					front,
+					XNAToMTL.StencilOp[(int) depthStencilState.StencilDepthBufferFail]
+				);
+				mtlSetDepthStencilPassOperation(
+					front,
+					XNAToMTL.StencilOp[(int) depthStencilState.StencilPass]
+				);
+				mtlSetStencilCompareFunction(
+					front,
+					XNAToMTL.CompareFunc[(int) depthStencilState.StencilFunction]
+				);
+				mtlSetStencilReadMask(
+					front,
+					(uint) depthStencilState.StencilMask
+				);
+				mtlSetStencilWriteMask(
+					front,
+					(uint) depthStencilState.StencilWriteMask
+				);
+
+				if (!depthStencilState.TwoSidedStencilMode)
+				{
+					back = front;
+				}
+			}
+
+			if (front != back)
+			{
+				back = mtlNewStencilDescriptor();
+				mtlSetStencilFailureOperation(
+					back,
+					XNAToMTL.StencilOp[(int) depthStencilState.CounterClockwiseStencilFail]
+				);
+				mtlSetDepthFailureOperation(
+					back,
+					XNAToMTL.StencilOp[(int) depthStencilState.CounterClockwiseStencilDepthBufferFail]
+				);
+				mtlSetDepthStencilPassOperation(
+					back,
+					XNAToMTL.StencilOp[(int) depthStencilState.CounterClockwiseStencilPass]
+				);
+				mtlSetStencilCompareFunction(
+					back,
+					XNAToMTL.CompareFunc[(int) depthStencilState.CounterClockwiseStencilFunction]
+				);
+				mtlSetStencilReadMask(
+					back,
+					(uint) depthStencilState.StencilMask
+				);
+				mtlSetStencilWriteMask(
+					back,
+					(uint) depthStencilState.StencilWriteMask
+				);
+			}
+
+			mtlSetFrontFaceStencil(
+				dsDesc,
+				front
+			);
+			mtlSetBackFaceStencil(
+				dsDesc,
+				back
+			);
+
+			// Bake the state!
+			state = mtlNewDepthStencilStateWithDescriptor(
+				device,
+				dsDesc
+			);
+			DepthStencilStateCache[hash] = state;
+
+			// Clean up
+			objc_release(dsDesc);
+
+			// Return the state!
+			return state;
+		}
+
+		private IntPtr FetchSamplerState(SamplerState samplerState, bool hasMipmaps)
+		{
+			// Can we just reuse an existing state?
+			StateHash hash = PipelineCache.GetSamplerHash(samplerState);
+			IntPtr state = IntPtr.Zero;
+			if (SamplerStateCache.TryGetValue(hash, out state))
+			{
+				// The value is already cached!
+				return state;
+			}
+
+			// We have to make a new sampler state...
+			IntPtr samplerDesc = mtlNewSamplerDescriptor();
+
+			mtlSetSampler_sAddressMode(
+				samplerDesc,
+				XNAToMTL.Wrap[(int) samplerState.AddressU]
+			);
+			mtlSetSampler_tAddressMode(
+				samplerDesc,
+				XNAToMTL.Wrap[(int) samplerState.AddressV]
+			);
+			mtlSetSampler_rAddressMode(
+				samplerDesc,
+				XNAToMTL.Wrap[(int) samplerState.AddressW]
+			);
+			mtlSetSamplerMagFilter(
+				samplerDesc,
+				XNAToMTL.MagFilter[(int) samplerState.Filter]
+			);
+			mtlSetSamplerMinFilter(
+				samplerDesc,
+				XNAToMTL.MinFilter[(int) samplerState.Filter]
+			);
+			if (hasMipmaps)
+			{
+				mtlSetSamplerMipFilter(
+					samplerDesc,
+					XNAToMTL.MipFilter[(int) samplerState.Filter]
+				);
+			}
+			mtlSetSamplerLodMinClamp(
+				samplerDesc,
+				samplerState.MaxMipLevel
+			);
+			mtlSetSamplerMaxAnisotropy(
+				samplerDesc,
+				(samplerState.Filter == TextureFilter.Anisotropic) ?
+					Math.Max(1, samplerState.MaxAnisotropy) :
+					1
+			);
+
+			/* FIXME:
+			 * The only way to set lod bias in metal is via the MSL
+			 * bias() function in a shader. So we can't do:
+			 *
+			 * 	mtlSetSamplerLodBias(
+			 *		samplerDesc,
+			 *		samplerState.MipMapLevelOfDetailBias
+			 *	);
+			 *
+			 * What should we do instead?
+			 *
+			 * -caleb
+			 */
+
+			// Bake the sampler state!
+			state = mtlNewSamplerStateWithDescriptor(
+				device,
+				samplerDesc
+			);
+			SamplerStateCache[hash] = state;
+
+			// Clean up
+			objc_release(samplerDesc);
+
+			// Return the sampler state!
+			return state;
+		}
+
+		private IntPtr FetchVertexDescriptor(
+			VertexBufferBinding[] bindings,
+			int numBindings
+		) {
+			// Can we just reuse an existing descriptor?
+			ulong hash = PipelineCache.GetVertexBindingHash(
+				bindings,
+				numBindings,
+				(ulong) shaderState.vertexShader
+			);
+			IntPtr descriptor;
+			if (VertexDescriptorCache.TryGetValue(hash, out descriptor))
+			{
+				// The value is already cached!
+				return descriptor;
+			}
+
+			// We have to make a new vertex descriptor...
+			descriptor = mtlMakeVertexDescriptor();
+			objc_retain(descriptor);
+
+			/* There's this weird case where you can have overlapping
+			 * vertex usage/index combinations. It seems like the first
+			 * attrib gets priority, so whenever a duplicate attribute
+			 * exists, give it the next available index. If that fails, we
+			 * have to crash :/
+			 * -flibit
+			 */
+			Array.Clear(attrUse, 0, attrUse.Length);
+			for (int i = 0; i < numBindings; i += 1)
+			{
+				// Describe vertex attributes
+				VertexDeclaration vertexDeclaration = bindings[i].VertexBuffer.VertexDeclaration;
+				foreach (VertexElement element in vertexDeclaration.elements)
+				{
+					int usage = (int) element.VertexElementUsage;
+					int index = element.UsageIndex;
+					if (attrUse[usage, index])
+					{
+						index = -1;
+						for (int j = 0; j < 10; j += 1)
+						{
+							if (!attrUse[usage, j])
+							{
+								index = j;
+								break;
+							}
+						}
+						if (index < 0)
+						{
+							throw new InvalidOperationException("Vertex usage collision!");
+						}
+					}
+					attrUse[usage, index] = true;
+					int attribLoc = MojoShader.MOJOSHADER_mtlGetVertexAttribLocation(
+						shaderState.vertexShader,
+						XNAToMTL.VertexAttribUsage[usage],
+						index
+					);
+					if (attribLoc == -1)
+					{
+						// Stream not in use!
+						continue;
+					}
+					IntPtr attrib = mtlGetVertexAttributeDescriptor(
+						descriptor,
+						attribLoc
+					);
+					mtlSetVertexAttributeFormat(
+						attrib,
+						XNAToMTL.VertexAttribType[(int) element.VertexElementFormat]
+					);
+					mtlSetVertexAttributeOffset(
+						attrib,
+						element.Offset
+					);
+					mtlSetVertexAttributeBufferIndex(
+						attrib,
+						i
+					);
+				}
+
+				// Describe vertex buffer layout
+				IntPtr layout = mtlGetVertexBufferLayoutDescriptor(
+					descriptor,
+					i
+				);
+				mtlSetVertexBufferLayoutStride(
+					layout,
+					vertexDeclaration.VertexStride
+				);
+				if (bindings[i].InstanceFrequency > 0)
+				{
+					mtlSetVertexBufferLayoutStepFunction(
+						layout,
+						MTLVertexStepFunction.PerInstance
+					);
+					mtlSetVertexBufferLayoutStepRate(
+						layout,
+						bindings[i].InstanceFrequency
+					);
+				}
+			}
+			VertexDescriptorCache[hash] = descriptor;
+			return descriptor;
+		}
+
+		private IntPtr FetchVertexDescriptor(
+			VertexDeclaration vertexDeclaration,
+			int vertexOffset
+		) {
+			// Can we just reuse an existing descriptor?
+			ulong hash = PipelineCache.GetVertexDeclarationHash(
+				vertexDeclaration,
+				(ulong) shaderState.vertexShader
+			);
+			IntPtr descriptor;
+			if (VertexDescriptorCache.TryGetValue(hash, out descriptor))
+			{
+				// The value is already cached!
+				return descriptor;
+			}
+
+			// We have to make a new vertex descriptor...
+			descriptor = mtlMakeVertexDescriptor();
+			objc_retain(descriptor);
+
+			/* There's this weird case where you can have overlapping
+			 * vertex usage/index combinations. It seems like the first
+			 * attrib gets priority, so whenever a duplicate attribute
+			 * exists, give it the next available index. If that fails, we
+			 * have to crash :/
+			 * -flibit
+			 */
+			Array.Clear(attrUse, 0, attrUse.Length);
+			foreach (VertexElement element in vertexDeclaration.elements)
+			{
+				int usage = (int) element.VertexElementUsage;
+				int index = element.UsageIndex;
+				if (attrUse[usage, index])
+				{
+					index = -1;
+					for (int j = 0; j < 10; j += 1)
+					{
+						if (!attrUse[usage, j])
+						{
+							index = j;
+							break;
+						}
+					}
+					if (index < 0)
+					{
+						throw new InvalidOperationException("Vertex usage collision!");
+					}
+				}
+				attrUse[usage, index] = true;
+				int attribLoc = MojoShader.MOJOSHADER_mtlGetVertexAttribLocation(
+					shaderState.vertexShader,
+					XNAToMTL.VertexAttribUsage[usage],
+					index
+				);
+				if (attribLoc == -1)
+				{
+					// Stream not in use!
+					continue;
+				}
+				IntPtr attrib = mtlGetVertexAttributeDescriptor(
+					descriptor,
+					attribLoc
+				);
+				mtlSetVertexAttributeFormat(
+					attrib,
+					XNAToMTL.VertexAttribType[(int) element.VertexElementFormat]
+				);
+				mtlSetVertexAttributeOffset(
+					attrib,
+					element.Offset
+				);
+				mtlSetVertexAttributeBufferIndex(
+					attrib,
+					0
+				);
+			}
+
+			// Describe vertex buffer layout
+			IntPtr layout = mtlGetVertexBufferLayoutDescriptor(
+				descriptor,
+				0
+			);
+			mtlSetVertexBufferLayoutStride(
+				layout,
+				vertexDeclaration.VertexStride
+			);
+
+			VertexDescriptorCache[hash] = descriptor;
+			return descriptor;
+		}
+
+		private IntPtr FetchTransientTexture(MetalTexture fromTexture)
+		{
+			// Can we just reuse an existing texture?
+			for (int i = 0; i < transientTextures.Count; i += 1)
+			{
+				MetalTexture tex = transientTextures[i];
+				if (	tex.Format == fromTexture.Format &&
+					tex.Width == fromTexture.Width &&
+					tex.Height == fromTexture.Height &&
+					tex.HasMipmaps == fromTexture.HasMipmaps	)
+				{
+					mtlSetPurgeableState(
+						tex.Handle,
+						MTLPurgeableState.NonVolatile
+					);
+					return tex.Handle;
+				}
+			}
+
+			// We have to make a new texture...
+			IntPtr texDesc = mtlMakeTexture2DDescriptor(
+				XNAToMTL.TextureFormat[(int) fromTexture.Format],
+				fromTexture.Width,
+				fromTexture.Height,
+				fromTexture.HasMipmaps
+			);
+			MetalTexture ret = new MetalTexture(
+				mtlNewTextureWithDescriptor(device, texDesc),
+				fromTexture.Width,
+				fromTexture.Height,
+				fromTexture.Format,
+				fromTexture.HasMipmaps ? 2 : 0,
+				false
+			);
+			transientTextures.Add(ret);
+			return ret.Handle;
+		}
+
+		#endregion
+
+		#region DepthFormat Conversion Method
+
+		private MTLPixelFormat GetDepthFormat(DepthFormat format)
+		{
+			switch (format)
+			{
+				case DepthFormat.Depth16:		return D16Format;
+				case DepthFormat.Depth24:		return D24Format;
+				case DepthFormat.Depth24Stencil8:	return D24S8Format;
+				default:				return MTLPixelFormat.Invalid;
+			}
+		}
+
+		#endregion
+
+		#region Effect Methods
+
+		public IGLEffect CreateEffect(byte[] effectCode)
+		{
+			IntPtr effect = IntPtr.Zero;
+			IntPtr mtlEffect = IntPtr.Zero;
+
+			effect = MojoShader.MOJOSHADER_parseEffect(
+				"metal",
+				effectCode,
+				(uint) effectCode.Length,
+				null,
+				0,
+				null,
+				0,
+				null,
+				null,
+				IntPtr.Zero
+			);
+
+#if DEBUG
+			unsafe
+			{
+				MojoShader.MOJOSHADER_effect *effectPtr = (MojoShader.MOJOSHADER_effect*) effect;
+				MojoShader.MOJOSHADER_error* err = (MojoShader.MOJOSHADER_error*) effectPtr->errors;
+				for (int i = 0; i < effectPtr->error_count; i += 1)
+				{
+					// From the SDL2# LPToUtf8StringMarshaler
+					byte* endPtr = (byte*) err[i].error;
+					while (*endPtr != 0)
+					{
+						endPtr++;
+					}
+					byte[] bytes = new byte[endPtr - (byte*) err[i].error];
+					Marshal.Copy(err[i].error, bytes, 0, bytes.Length);
+
+					FNALoggerEXT.LogError(
+						"MOJOSHADER_parseEffect Error: " +
+						System.Text.Encoding.UTF8.GetString(bytes)
+					);
+				}
+			}
+#endif
+
+			mtlEffect = MojoShader.MOJOSHADER_mtlCompileEffect(
+				effect,
+				device,
+				MAX_FRAMES_IN_FLIGHT
+			);
+			if (mtlEffect == IntPtr.Zero)
+			{
+				throw new InvalidOperationException(
+					MojoShader.MOJOSHADER_mtlGetError()
+				);
+			}
+
+			return new MetalEffect(effect, mtlEffect);
+		}
+
+		private void DeleteEffect(IGLEffect effect)
+		{
+			IntPtr mtlEffectData = (effect as MetalEffect).MTLEffectData;
+			if (mtlEffectData == currentEffect)
+			{
+				MojoShader.MOJOSHADER_mtlEffectEndPass(currentEffect);
+				MojoShader.MOJOSHADER_mtlEffectEnd(
+					currentEffect,
+					ref shaderState
+				);
+				currentEffect = IntPtr.Zero;
+				currentTechnique = IntPtr.Zero;
+				currentPass = 0;
+				shaderState = new MojoShader.MOJOSHADER_mtlShaderState();
+			}
+			MojoShader.MOJOSHADER_mtlDeleteEffect(mtlEffectData);
+			MojoShader.MOJOSHADER_freeEffect(effect.EffectData);
+		}
+
+		public IGLEffect CloneEffect(IGLEffect cloneSource)
+		{
+			IntPtr effect = IntPtr.Zero;
+			IntPtr mtlEffect = IntPtr.Zero;
+
+			effect = MojoShader.MOJOSHADER_cloneEffect(cloneSource.EffectData);
+			mtlEffect = MojoShader.MOJOSHADER_mtlCompileEffect(
+				effect,
+				device,
+				1
+			);
+			if (mtlEffect == IntPtr.Zero)
+			{
+				throw new InvalidOperationException(
+					MojoShader.MOJOSHADER_mtlGetError()
+				);
+			}
+
+			return new MetalEffect(effect, mtlEffect);
+		}
+
+		public void ApplyEffect(
+			IGLEffect effect,
+			IntPtr technique,
+			uint pass,
+			IntPtr stateChanges
+		) {
+			/* If a frame isn't already in progress,
+			 * wait until one begins to avoid overwriting
+			 * the previous frame's uniform buffers.
+			 */
+			BeginFrame();
+
+			IntPtr mtlEffectData = (effect as MetalEffect).MTLEffectData;
+			if (mtlEffectData == currentEffect)
+			{
+				if (technique == currentTechnique && pass == currentPass)
+				{
+					MojoShader.MOJOSHADER_mtlEffectCommitChanges(
+						currentEffect,
+						ref shaderState
+					);
+					return;
+				}
+				MojoShader.MOJOSHADER_mtlEffectEndPass(currentEffect);
+				MojoShader.MOJOSHADER_mtlEffectBeginPass(
+					currentEffect,
+					pass,
+					ref shaderState
+				);
+				currentTechnique = technique;
+				currentPass = pass;
+				return;
+			}
+			else if (currentEffect != IntPtr.Zero)
+			{
+				MojoShader.MOJOSHADER_mtlEffectEndPass(currentEffect);
+				MojoShader.MOJOSHADER_mtlEffectEnd(
+					currentEffect,
+					ref shaderState
+				);
+			}
+			uint whatever;
+			MojoShader.MOJOSHADER_mtlEffectBegin(
+				mtlEffectData,
+				out whatever,
+				0,
+				stateChanges
+			);
+			MojoShader.MOJOSHADER_mtlEffectBeginPass(
+				mtlEffectData,
+				pass,
+				ref shaderState
+			);
+			currentEffect = mtlEffectData;
+			currentTechnique = technique;
+			currentPass = pass;
+		}
+
+		public void BeginPassRestore(IGLEffect effect, IntPtr stateChanges)
+		{
+			/* If a frame isn't already in progress,
+			 * wait until one begins to avoid overwriting
+			 * the previous frame's uniform buffers.
+			 */
+			BeginFrame();
+
+			// Store the current data
+			prevEffect = currentEffect;
+			prevShaderState = shaderState;
+
+			IntPtr mtlEffectData = (effect as MetalEffect).MTLEffectData;
+			uint whatever;
+			MojoShader.MOJOSHADER_mtlEffectBegin(
+				mtlEffectData,
+				out whatever,
+				1,
+				stateChanges
+			);
+			MojoShader.MOJOSHADER_mtlEffectBeginPass(
+				mtlEffectData,
+				0,
+				ref shaderState
+			);
+			currentEffect = mtlEffectData;
+		}
+
+		public void EndPassRestore(IGLEffect effect)
+		{
+			IntPtr mtlEffectData = (effect as MetalEffect).MTLEffectData;
+			MojoShader.MOJOSHADER_mtlEffectEndPass(mtlEffectData);
+			MojoShader.MOJOSHADER_mtlEffectEnd(
+				mtlEffectData,
+				ref shaderState
+			);
+
+			// Restore the old data
+			shaderState = prevShaderState;
+			currentEffect = prevEffect;
+		}
+
+		#endregion
+
+		#region Resource Binding Method
+
+		private void BindResources()
+		{
+			// Bind textures and their sampler states
+			for (int i = 0; i < Textures.Length; i += 1)
+			{
+				if (textureNeedsUpdate[i])
+				{
+					mtlSetFragmentTexture(
+						renderCommandEncoder,
+						Textures[i].Handle,
+						i
+					);
+					textureNeedsUpdate[i] = false;
+				}
+				if (samplerNeedsUpdate[i])
+				{
+					mtlSetFragmentSamplerState(
+						renderCommandEncoder,
+						Samplers[i],
+						i
+					);
+					samplerNeedsUpdate[i] = false;
+				}
+			}
+
+			// Bind the uniform buffers
+			const int UNIFORM_REG = 16; // In MojoShader output it's always 16
+
+			IntPtr vUniform = shaderState.vertexUniformBuffer;
+			int vOff = shaderState.vertexUniformOffset;
+			if (vUniform != ldVertUniformBuffer)
+			{
+				mtlSetVertexBuffer(
+					renderCommandEncoder,
+					vUniform,
+					vOff,
+					UNIFORM_REG
+				);
+				ldVertUniformBuffer = vUniform;
+				ldVertUniformOffset = vOff;
+			}
+			else if (vOff != ldVertUniformOffset)
+			{
+				mtlSetVertexBufferOffset(
+					renderCommandEncoder,
+					vOff,
+					UNIFORM_REG
+				);
+				ldVertUniformOffset = vOff;
+			}
+
+			IntPtr fUniform = shaderState.fragmentUniformBuffer;
+			int fOff = shaderState.fragmentUniformOffset;
+			if (fUniform != ldFragUniformBuffer)
+			{
+				mtlSetFragmentBuffer(
+					renderCommandEncoder,
+					fUniform,
+					fOff,
+					UNIFORM_REG
+				);
+				ldFragUniformBuffer = fUniform;
+				ldFragUniformOffset = fOff;
+			}
+			else if (fOff != ldFragUniformOffset)
+			{
+				mtlSetFragmentBufferOffset(
+					renderCommandEncoder,
+					fOff,
+					UNIFORM_REG
+				);
+				ldFragUniformOffset = fOff;
+			}
+
+			// Bind the depth-stencil state
+			IntPtr depthStencilState = FetchDepthStencilState();
+			if (depthStencilState != ldDepthStencilState)
+			{
+				mtlSetDepthStencilState(
+					renderCommandEncoder,
+					depthStencilState
+				);
+				ldDepthStencilState = depthStencilState;
+			}
+
+			// Finally, bind the pipeline state
+			IntPtr pipelineState = FetchRenderPipeline();
+			if (pipelineState != ldPipelineState)
+			{
+				mtlSetRenderPipelineState(
+					renderCommandEncoder,
+					pipelineState
+				);
+				ldPipelineState = pipelineState;
+			}
+		}
+
+		#endregion
+
+		#region ApplyVertexAttributes Methods
+
+		public void ApplyVertexAttributes(
+			VertexBufferBinding[] bindings,
+			int numBindings,
+			bool bindingsUpdated,
+			int baseVertex
+		) {
+			// Translate the bindings array into a descriptor
+			currentVertexDescriptor = FetchVertexDescriptor(
+				bindings,
+				numBindings
+			);
+
+			// Prepare for rendering
+			UpdateRenderPass();
+			BindResources();
+
+			// Bind the vertex buffers
+			for (int i = 0; i < bindings.Length; i += 1)
+			{
+				VertexBuffer vertexBuffer = bindings[i].VertexBuffer;
+				if (vertexBuffer != null)
+				{
+					int stride = bindings[i].VertexBuffer.VertexDeclaration.VertexStride;
+					int offset = (
+						((bindings[i].VertexOffset + baseVertex) * stride) +
+						(vertexBuffer.buffer as MetalBuffer).InternalOffset
+					);
+
+					IntPtr handle = (vertexBuffer.buffer as MetalBuffer).Handle;
+					(vertexBuffer.buffer as MetalBuffer).Bound();
+					if (ldVertexBuffers[i] != handle)
+					{
+						mtlSetVertexBuffer(
+							renderCommandEncoder,
+							handle,
+							offset,
+							i
+						);
+						ldVertexBuffers[i] = handle;
+						ldVertexBufferOffsets[i] = offset;
+					}
+					else if (ldVertexBufferOffsets[i] != offset)
+					{
+						mtlSetVertexBufferOffset(
+							renderCommandEncoder,
+							offset,
+							i
+						);
+						ldVertexBufferOffsets[i] = offset;
+					}
+				}
+			}
+		}
+
+		public void ApplyVertexAttributes(
+			VertexDeclaration vertexDeclaration,
+			IntPtr ptr,
+			int vertexOffset
+		) {
+			// Translate the declaration into a descriptor
+			currentVertexDescriptor = FetchVertexDescriptor(
+				vertexDeclaration,
+				vertexOffset
+			);
+			userVertexStride = vertexDeclaration.VertexStride;
+
+			// Prepare for rendering
+			UpdateRenderPass();
+			BindResources();
+
+			// The rest happens in DrawUser[Indexed]Primitives.
+		}
+
+		#endregion
+
+		#region GenBuffers Methods
+
+		public IGLBuffer GenIndexBuffer(
+			bool dynamic,
+			BufferUsage usage,
+			int indexCount,
+			IndexElementSize indexElementSize
+		) {
+			int elementSize = XNAToMTL.IndexSize[(int) indexElementSize];
+			MetalBuffer newbuf = new MetalBuffer(
+				this,
+				dynamic,
+				usage,
+				(IntPtr) (indexCount * elementSize)
+			);
+			Buffers.Add(newbuf);
+			return newbuf;
+		}
+
+		public IGLBuffer GenVertexBuffer(
+			bool dynamic,
+			BufferUsage usage,
+			int vertexCount,
+			int vertexStride
+		) {
+			MetalBuffer newbuf = new MetalBuffer(
+				this,
+				dynamic,
+				usage,
+				(IntPtr) (vertexCount * vertexStride)
+			);
+			Buffers.Add(newbuf);
+			return newbuf;
+		}
+
+		#endregion
+
+		#region Renderbuffer Methods
+
+		public IGLRenderbuffer GenRenderbuffer(
+			int width,
+			int height,
+			SurfaceFormat format,
+			int multiSampleCount,
+			IGLTexture texture
+		) {
+			MTLPixelFormat pixelFormat = XNAToMTL.TextureFormat[(int) format];
+			int sampleCount = GetCompatibleSampleCount(multiSampleCount);
+
+			// Generate a multisample texture
+			IntPtr desc = mtlMakeTexture2DDescriptor(
+				pixelFormat,
+				width,
+				height,
+				false
+			);
+			mtlSetStorageMode(
+				desc,
+				MTLStorageMode.Private
+			);
+			mtlSetTextureUsage(
+				desc,
+				MTLTextureUsage.RenderTarget
+			);
+			mtlSetTextureType(
+				desc,
+				MTLTextureType.Multisample2D
+			);
+			mtlSetTextureSampleCount(
+				desc,
+				sampleCount
+			);
+			IntPtr multisampleTexture = mtlNewTextureWithDescriptor(
+				device,
+				desc
+			);
+
+			// We're done!
+			return new MetalRenderbuffer(
+				(texture as MetalTexture).Handle,
+				pixelFormat,
+				sampleCount,
+				multisampleTexture
+			);
+		}
+
+		public IGLRenderbuffer GenRenderbuffer(
+			int width,
+			int height,
+			DepthFormat format,
+			int multiSampleCount
+		) {
+			MTLPixelFormat pixelFormat = GetDepthFormat(format);
+			int sampleCount = GetCompatibleSampleCount(multiSampleCount);
+
+			// Generate a depth texture
+			IntPtr desc = mtlMakeTexture2DDescriptor(
+				pixelFormat,
+				width,
+				height,
+				false
+			);
+			mtlSetStorageMode(
+				desc,
+				MTLStorageMode.Private
+			);
+			mtlSetTextureUsage(
+				desc,
+				MTLTextureUsage.RenderTarget
+			);
+			if (multiSampleCount > 0)
+			{
+				mtlSetTextureType(
+					desc,
+					MTLTextureType.Multisample2D
+				);
+				mtlSetTextureSampleCount(
+					desc,
+					sampleCount
+				);
+			}
+			IntPtr handle = mtlNewTextureWithDescriptor(
+				device,
+				desc
+			);
+
+			// We're done!
+			return new MetalRenderbuffer(
+				handle,
+				pixelFormat,
+				sampleCount,
+				IntPtr.Zero
+			);
+		}
+
+		private void DeleteRenderbuffer(IGLRenderbuffer renderbuffer)
+		{
+			MetalRenderbuffer rb = renderbuffer as MetalRenderbuffer;
+			bool isDepthStencil = rb.MultiSampleHandle == IntPtr.Zero;
+
+			if (isDepthStencil)
+			{
+				if (rb.Handle == currentDepthStencilBuffer)
+				{
+					currentDepthStencilBuffer = IntPtr.Zero;
+				}
+			}
+			else
+			{
+				for (int i = 0; i < currentAttachments.Length; i += 1)
+				{
+					if (rb.MultiSampleHandle == currentMSAttachments[i])
+					{
+						currentMSAttachments[i] = IntPtr.Zero;
+					}
+				}
+			}
+
+			rb.Dispose();
+		}
+
+		#endregion
+
+		#region SetBufferData Methods
+
+		public void SetIndexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int dataLength,
+			SetDataOptions options
+		) {
+			(buffer as MetalBuffer).SetData(
+				offsetInBytes,
+				data,
+				dataLength,
+				options
+			);
+		}
+
+		public void SetVertexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int dataLength,
+			SetDataOptions options
+		) {
+			(buffer as MetalBuffer).SetData(
+				offsetInBytes,
+				data,
+				dataLength,
+				options
+			);
+		}
+
+		#endregion
+
+		#region GetBufferData Methods
+
+		public void GetIndexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+			memcpy(
+				data + (startIndex * elementSizeInBytes),
+				(buffer as MetalBuffer).Contents + offsetInBytes,
+				(IntPtr) (elementCount * elementSizeInBytes)
+			);
+		}
+
+		public void GetVertexBufferData(
+			IGLBuffer buffer,
+			int offsetInBytes,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes,
+			int vertexStride
+		) {
+			IntPtr cpy;
+			bool useStagingBuffer = elementSizeInBytes < vertexStride;
+			if (useStagingBuffer)
+			{
+				cpy = Marshal.AllocHGlobal(elementCount * vertexStride);
+			}
+			else
+			{
+				cpy = data + (startIndex * elementSizeInBytes);
+			}
+
+			memcpy(
+				cpy,
+				(buffer as MetalBuffer).Contents + offsetInBytes,
+				(IntPtr) (elementCount * vertexStride)
+			);
+
+			if (useStagingBuffer)
+			{
+				IntPtr src = cpy;
+				IntPtr dst = data + (startIndex * elementSizeInBytes);
+				for (int i = 0; i < elementCount; i += 1)
+				{
+					memcpy(dst, src, (IntPtr) elementSizeInBytes);
+					dst += elementSizeInBytes;
+					src += vertexStride;
+				}
+				Marshal.FreeHGlobal(cpy);
+			}
+		}
+
+		#endregion
+
+		#region DeleteBuffer Methods
+
+		private void DeleteBuffer(IGLBuffer buffer)
+		{
+			Buffers.Remove(buffer as MetalBuffer);
+			(buffer as MetalBuffer).Dispose();
+		}
+
+		#endregion
+
+		#region CreateTexture Methods
+
+		public IGLTexture CreateTexture2D(
+			SurfaceFormat format,
+			int width,
+			int height,
+			int levelCount,
+			bool isRenderTarget
+		) {
+			IntPtr texDesc = mtlMakeTexture2DDescriptor(
+				XNAToMTL.TextureFormat[(int) format],
+				width,
+				height,
+				levelCount > 1
+			);
+
+			if (isRenderTarget)
+			{
+				mtlSetStorageMode(
+					texDesc,
+					MTLStorageMode.Private
+				);
+				mtlSetTextureUsage(
+					texDesc,
+					MTLTextureUsage.RenderTarget | MTLTextureUsage.ShaderRead
+				);
+			}
+
+			return new MetalTexture(
+				mtlNewTextureWithDescriptor(device, texDesc),
+				width,
+				height,
+				format,
+				levelCount,
+				isRenderTarget
+			);
+		}
+
+		public IGLTexture CreateTexture3D(
+			SurfaceFormat format,
+			int width,
+			int height,
+			int depth,
+			int levelCount
+		) {
+			IntPtr texDesc = mtlMakeTexture2DDescriptor(
+				XNAToMTL.TextureFormat[(int) format],
+				width,
+				height,
+				levelCount > 1
+			);
+
+			// Make it 3D!
+			mtlSetTextureDepth(texDesc, depth);
+			mtlSetTextureType(texDesc, MTLTextureType.Texture3D);
+
+			return new MetalTexture(
+				mtlNewTextureWithDescriptor(device, texDesc),
+				width,
+				height,
+				format,
+				levelCount,
+				false
+			);
+		}
+
+		public IGLTexture CreateTextureCube(
+			SurfaceFormat format,
+			int size,
+			int levelCount,
+			bool isRenderTarget
+		) {
+			IntPtr texDesc = mtlMakeTextureCubeDescriptor(
+				XNAToMTL.TextureFormat[(int) format],
+				size,
+				levelCount > 1
+			);
+
+			if (isRenderTarget)
+			{
+				mtlSetStorageMode(
+					texDesc,
+					MTLStorageMode.Private
+				);
+				mtlSetTextureUsage(
+					texDesc,
+					MTLTextureUsage.RenderTarget | MTLTextureUsage.ShaderRead
+				);
+			}
+
+			return new MetalTexture(
+				mtlNewTextureWithDescriptor(device, texDesc),
+				size,
+				size,
+				format,
+				levelCount,
+				isRenderTarget
+			);
+		}
+
+		#endregion
+
+		#region DeleteTexture Method
+
+		private void DeleteTexture(IGLTexture texture)
+		{
+			MetalTexture tex = texture as MetalTexture;
+			for (int i = 0; i < currentAttachments.Length; i += 1)
+			{
+				if (tex.Handle == currentAttachments[i])
+				{
+					currentAttachments[i] = IntPtr.Zero;
+				}
+			}
+			for (int i = 0; i < Textures.Length; i += 1)
+			{
+				if (tex.Handle == Textures[i].Handle)
+				{
+					Textures[i] = MetalTexture.NullTexture;
+					textureNeedsUpdate[i] = true;
+				}
+			}
+			tex.Dispose();
+		}
+
+		#endregion
+
+		#region Texture Data Helper Methods
+
+		private int BytesPerRow(int width, SurfaceFormat format)
+		{
+			int blocksPerRow = width;
+
+			if (	format == SurfaceFormat.Dxt1 ||
+				format == SurfaceFormat.Dxt3 ||
+				format == SurfaceFormat.Dxt5	)
+			{
+				blocksPerRow = (width + 3) / 4;
+			}
+
+			return blocksPerRow * Texture.GetFormatSize(format);
+		}
+
+		private int BytesPerImage(int width, int height, SurfaceFormat format)
+		{
+			int blocksPerRow = width;
+			int blocksPerColumn = height;
+			int formatSize = Texture.GetFormatSize(format);
+
+			if (	format == SurfaceFormat.Dxt1 ||
+				format == SurfaceFormat.Dxt3 ||
+				format == SurfaceFormat.Dxt5	)
+			{
+				blocksPerRow = (width + 3) / 4;
+				blocksPerColumn = (height + 3) / 4;
+			}
+
+			return blocksPerRow * blocksPerColumn * formatSize;
+		}
+
+		private int GetCompatibleSampleCount(int sampleCount)
+		{
+			/* If the device does not support the requested
+			 * multisample count, halve it until we find a
+			 * value that is supported.
+			 */
+			while (sampleCount > 0 && !mtlSupportsSampleCount(device, sampleCount))
+			{
+				sampleCount = MathHelper.ClosestMSAAPower(
+					sampleCount / 2
+				);
+			}
+			return sampleCount;
+		}
+
+		#endregion
+
+		#region SetTextureData Methods
+
+		public void SetTextureData2D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int x,
+			int y,
+			int w,
+			int h,
+			int level,
+			IntPtr data,
+			int dataLength
+		) {
+			MetalTexture tex = texture as MetalTexture;
+			IntPtr handle = tex.Handle;
+
+			MTLOrigin origin = new MTLOrigin(x, y, 0);
+			MTLSize size = new MTLSize(w, h, 1);
+
+			if (tex.IsPrivate)
+			{
+				// We need an active command buffer
+				BeginFrame();
+
+				// Fetch a CPU-accessible texture
+				handle = FetchTransientTexture(tex);
+			}
+
+			// Write the data
+			mtlReplaceRegion(
+				handle,
+				new MTLRegion(origin, size),
+				level,
+				0,
+				data,
+				BytesPerRow(w, format),
+				0
+			);
+
+			// Blit the temp texture to the actual texture
+			if (tex.IsPrivate)
+			{
+				// End the render pass
+				EndPass();
+
+				// Blit!
+				IntPtr blit = mtlMakeBlitCommandEncoder(commandBuffer);
+				mtlBlitTextureToTexture(
+					blit,
+					handle,
+					0,
+					level,
+					origin,
+					size,
+					tex.Handle,
+					0,
+					level,
+					origin
+				);
+
+				// Submit the blit command to the GPU and wait...
+				mtlEndEncoding(blit);
+				Stall();
+
+				// We're done with the temp texture
+				mtlSetPurgeableState(
+					handle,
+					MTLPurgeableState.Empty
+				);
+			}
+		}
+
+		public void SetTextureDataYUV(Texture2D[] textures, IntPtr ptr)
+		{
+			for (int i = 0; i < 3; i += 1)
+			{
+				Texture2D tex = textures[i];
+				MTLRegion region = new MTLRegion(
+					MTLOrigin.Zero,
+					new MTLSize(tex.Width, tex.Height, 1)
+				);
+				mtlReplaceRegion(
+					(tex.texture as MetalTexture).Handle,
+					region,
+					0,
+					0,
+					ptr,
+					tex.Width,
+					0
+				);
+				ptr += tex.Width * tex.Height;
+			}
+		}
+
+		public void SetTextureData3D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int level,
+			int left,
+			int top,
+			int right,
+			int bottom,
+			int front,
+			int back,
+			IntPtr data,
+			int dataLength
+		) {
+			int w = right - left;
+			int h = bottom - top;
+			int d = back - front;
+
+			MTLRegion region = new MTLRegion(
+				new MTLOrigin(left, top, front),
+				new MTLSize(w, h, d)
+			);
+			mtlReplaceRegion(
+				(texture as MetalTexture).Handle,
+				region,
+				level,
+				0,
+				data,
+				BytesPerRow(w, format),
+				BytesPerImage(w, h, format)
+			);
+		}
+
+		public void SetTextureDataCube(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int xOffset,
+			int yOffset,
+			int width,
+			int height,
+			CubeMapFace cubeMapFace,
+			int level,
+			IntPtr data,
+			int dataLength
+		) {
+			MetalTexture tex = texture as MetalTexture;
+			IntPtr handle = tex.Handle;
+
+			MTLOrigin origin = new MTLOrigin(xOffset, yOffset, 0);
+			MTLSize size = new MTLSize(width, height, 1);
+			int slice = (int) cubeMapFace;
+
+			if (tex.IsPrivate)
+			{
+				// We need an active command buffer
+				BeginFrame();
+
+				// Fetch a CPU-accessible texture
+				handle = FetchTransientTexture(tex);
+
+				// Transient textures have no slices
+				slice = 0;
+			}
+
+			// Write the data
+			mtlReplaceRegion(
+				handle,
+				new MTLRegion(origin, size),
+				level,
+				slice,
+				data,
+				BytesPerRow(width, format),
+				0
+			);
+
+			// Blit the temp texture to the actual texture
+			if (tex.IsPrivate)
+			{
+				// End the render pass
+				EndPass();
+
+				// Blit!
+				IntPtr blit = mtlMakeBlitCommandEncoder(commandBuffer);
+				mtlBlitTextureToTexture(
+					blit,
+					handle,
+					slice,
+					level,
+					origin,
+					size,
+					tex.Handle,
+					slice,
+					level,
+					origin
+				);
+
+				// Submit the blit command to the GPU and wait...
+				mtlEndEncoding(blit);
+				Stall();
+
+				// We're done with the temp texture
+				mtlSetPurgeableState(
+					handle,
+					MTLPurgeableState.Empty
+				);
+			}
+		}
+
+		#endregion
+
+		#region GetTextureData Methods
+
+		public void GetTextureData2D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int width,
+			int height,
+			int level,
+			int subX,
+			int subY,
+			int subW,
+			int subH,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+			MetalTexture tex = texture as MetalTexture;
+			IntPtr handle = tex.Handle;
+
+			MTLSize size = new MTLSize(subW, subH, 1);
+			MTLOrigin origin = new MTLOrigin(subX, subY, 0);
+
+			if (tex.IsPrivate)
+			{
+				// We need an active command buffer
+				BeginFrame();
+
+				// Fetch a CPU-accessible texture
+				handle = FetchTransientTexture(tex);
+
+				// End the render pass
+				EndPass();
+
+				// Blit the actual texture to a CPU-accessible texture
+				IntPtr blit = mtlMakeBlitCommandEncoder(commandBuffer);
+				mtlBlitTextureToTexture(
+					blit,
+					tex.Handle,
+					0,
+					level,
+					origin,
+					size,
+					handle,
+					0,
+					level,
+					origin
+				);
+
+				// Managed resources require explicit synchronization
+				if (isMac)
+				{
+					mtlSynchronizeResource(blit, handle);
+				}
+
+				// Submit the blit command to the GPU and wait...
+				mtlEndEncoding(blit);
+				Stall();
+			}
+
+			mtlGetTextureBytes(
+				handle,
+				data,
+				BytesPerRow(subW, format),
+				0,
+				new MTLRegion(origin, size),
+				level,
+				0
+			);
+
+			if (tex.IsPrivate)
+			{
+				// We're done with the temp texture
+				mtlSetPurgeableState(
+					handle,
+					MTLPurgeableState.Empty
+				);
+			}
+		}
+
+		public void GetTextureData3D(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int left,
+			int top,
+			int front,
+			int right,
+			int bottom,
+			int back,
+			int level,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+			int w = right - left;
+			int h = bottom - top;
+			int d = back - front;
+
+			MTLRegion region = new MTLRegion(
+				new MTLOrigin(left, top, front),
+				new MTLSize(w, h, d)
+			);
+			mtlGetTextureBytes(
+				(texture as MetalTexture).Handle,
+				data,
+				BytesPerRow(w, format),
+				BytesPerImage(w, h, format),
+				region,
+				level,
+				0
+			);
+		}
+
+		public void GetTextureDataCube(
+			IGLTexture texture,
+			SurfaceFormat format,
+			int size,
+			CubeMapFace cubeMapFace,
+			int level,
+			int subX,
+			int subY,
+			int subW,
+			int subH,
+			IntPtr data,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes
+		) {
+			MetalTexture tex = texture as MetalTexture;
+			IntPtr handle = tex.Handle;
+
+			MTLSize regionSize = new MTLSize(subW, subH, 1);
+			MTLOrigin origin = new MTLOrigin(subX, subY, 0);
+			int slice = (int) cubeMapFace;
+
+			if (tex.IsPrivate)
+			{
+				// We need an active command buffer
+				BeginFrame();
+
+				// Fetch a CPU-accessible texture
+				handle = FetchTransientTexture(tex);
+
+				// Transient textures have no slices
+				slice = 0;
+
+				// End the render pass
+				EndPass();
+
+				// Blit the actual texture to a CPU-accessible texture
+				IntPtr blit = mtlMakeBlitCommandEncoder(commandBuffer);
+				mtlBlitTextureToTexture(
+					blit,
+					tex.Handle,
+					(int) cubeMapFace,
+					level,
+					origin,
+					regionSize,
+					handle,
+					slice,
+					level,
+					origin
+				);
+
+				// Managed resources require explicit synchronization
+				if (isMac)
+				{
+					mtlSynchronizeResource(blit, handle);
+				}
+
+				// Submit the blit command to the GPU and wait...
+				mtlEndEncoding(blit);
+				Stall();
+			}
+
+			mtlGetTextureBytes(
+				handle,
+				data,
+				BytesPerRow(subW, format),
+				0,
+				new MTLRegion(origin, regionSize),
+				level,
+				slice
+			);
+
+			if (tex.IsPrivate)
+			{
+				// We're done with the temp texture
+				mtlSetPurgeableState(
+					handle,
+					MTLPurgeableState.Empty
+				);
+			}
+		}
+
+		#endregion
+
+		#region ReadBackbuffer Method
+
+		public void ReadBackbuffer(
+			IntPtr data,
+			int dataLen,
+			int startIndex,
+			int elementCount,
+			int elementSizeInBytes,
+			int subX,
+			int subY,
+			int subW,
+			int subH
+		) {
+			/* FIXME: Right now we're expecting one of the following:
+			 * - byte[]
+			 * - int[]
+			 * - uint[]
+			 * - Color[]
+			 * Anything else will freak out because we're using
+			 * color backbuffers. Maybe check this out when adding
+			 * support for more backbuffer types!
+			 * -flibit
+			 */
+
+			if (startIndex > 0 || elementCount != (dataLen / elementSizeInBytes))
+			{
+				throw new NotImplementedException(
+					"ReadBackbuffer startIndex/elementCount"
+				);
+			}
+
+			GetTextureData2D(
+				(Backbuffer as MetalBackbuffer).Texture,
+				SurfaceFormat.Color,
+				Backbuffer.Width,
+				Backbuffer.Height,
+				0,
+				subX,
+				subY,
+				subW,
+				subH,
+				data,
+				0,
+				dataLen,
+				1
+			);
+		}
+
+		#endregion
+
+		#region RenderTarget->Texture Method
+
+		public void ResolveTarget(RenderTargetBinding target)
+		{
+			// The target is resolved at the end of each render pass.
+
+			// If the target has mipmaps, regenerate them now
+			if (target.RenderTarget.LevelCount > 1)
+			{
+				EndPass();
+
+				IntPtr blit = mtlMakeBlitCommandEncoder(commandBuffer);
+				mtlGenerateMipmapsForTexture(
+					blit,
+					(target.RenderTarget.texture as MetalTexture).Handle
+				);
+				mtlEndEncoding(blit);
+
+				needNewRenderPass = true;
+			}
+		}
+
+		#endregion
+
+		#region Clear Method
+
+		public void Clear(
+			ClearOptions options,
+			Vector4 color,
+			float depth,
+			int stencil
+		) {
+			bool clearTarget = (options & ClearOptions.Target) == ClearOptions.Target;
+			bool clearDepth = (options & ClearOptions.DepthBuffer) == ClearOptions.DepthBuffer;
+			bool clearStencil = (options & ClearOptions.Stencil) == ClearOptions.Stencil;
+
+			if (clearTarget)
+			{
+				clearColor = color;
+				shouldClearColor = true;
+			}
+			if (clearDepth)
+			{
+				this.clearDepth = depth;
+				shouldClearDepth = true;
+			}
+			if (clearStencil)
+			{
+				this.clearStencil = stencil;
+				shouldClearStencil = true;
+			}
+
+			needNewRenderPass |= clearTarget | clearDepth | clearStencil;
+		}
+
+		#endregion
+
+		#region SetRenderTargets Methods
+
+		public void SetRenderTargets(
+			RenderTargetBinding[] renderTargets,
+			IGLRenderbuffer renderbuffer,
+			DepthFormat depthFormat
+		) {
+			// Perform any pending clears before switching render targets
+			if (shouldClearColor || shouldClearDepth || shouldClearStencil)
+			{
+				UpdateRenderPass();
+			}
+
+			// Force an update to the render pass
+			needNewRenderPass = true;
+
+			// Bind the correct framebuffer
+			ResetAttachments();
+			if (renderTargets == null)
+			{
+				BindBackbuffer();
+				return;
+			}
+
+			// Update color buffers
+			int i;
+			for (i = 0; i < renderTargets.Length; i += 1)
+			{
+				IRenderTarget rt = renderTargets[i].RenderTarget as IRenderTarget;
+				currentAttachmentSlices[i] = renderTargets[i].CubeMapFace;
+				if (rt.ColorBuffer != null)
+				{
+					MetalRenderbuffer rb = rt.ColorBuffer as MetalRenderbuffer;
+					currentAttachments[i] = rb.Handle;
+					currentColorFormats[i] = rb.PixelFormat;
+					currentSampleCount = rb.MultiSampleCount;
+					currentMSAttachments[i] = rb.MultiSampleHandle;
+				}
+				else
+				{
+					MetalTexture tex = renderTargets[i].RenderTarget.texture as MetalTexture;
+					currentAttachments[i] = tex.Handle;
+					currentColorFormats[i] = XNAToMTL.TextureFormat[(int) tex.Format];
+					currentSampleCount = 0;
+				}
+			}
+
+			// Update depth stencil buffer
+			IntPtr handle = IntPtr.Zero;
+			if (renderbuffer != null)
+			{
+				handle = (renderbuffer as MetalRenderbuffer).Handle;
+			}
+			currentDepthStencilBuffer = handle;
+			currentDepthFormat = (
+				(currentDepthStencilBuffer == IntPtr.Zero) ?
+				DepthFormat.None :
+				depthFormat
+			);
+		}
+
+		private void ResetAttachments()
+		{
+			for (int i = 0; i < currentAttachments.Length; i += 1)
+			{
+				currentAttachments[i] = IntPtr.Zero;
+				currentColorFormats[i] = MTLPixelFormat.Invalid;
+				currentMSAttachments[i] = IntPtr.Zero;
+				currentAttachmentSlices[i] = (CubeMapFace) 0;
+			}
+			currentDepthStencilBuffer = IntPtr.Zero;
+			currentDepthFormat = DepthFormat.None;
+			currentSampleCount = 0;
+		}
+
+		private void BindBackbuffer()
+		{
+			MetalBackbuffer bb = Backbuffer as MetalBackbuffer;
+			currentAttachments[0] = bb.ColorBuffer;
+			currentColorFormats[0] = bb.PixelFormat;
+			currentDepthStencilBuffer = bb.DepthStencilBuffer;
+			currentDepthFormat = bb.DepthFormat;
+			currentSampleCount = bb.MultiSampleCount;
+			currentMSAttachments[0] = bb.MultiSampleColorBuffer;
+			currentAttachmentSlices[0] = (CubeMapFace) 0;
+		}
+
+		#endregion
+
+		#region Query Object Methods
+
+		public IGLQuery CreateQuery()
+		{
+			if (!supportsOcclusionQueries)
+			{
+				throw new NotSupportedException(
+					"Occlusion queries are not supported on this device!"
+				);
+			}
+
+			IntPtr buf = mtlNewBufferWithLength(device, sizeof(ulong), 0);
+			return new MetalQuery(buf);
+		}
+
+		private void DeleteQuery(IGLQuery query)
+		{
+			(query as MetalQuery).Dispose();
+		}
+
+		public void QueryBegin(IGLQuery query)
+		{
+			// Stop the current pass
+			EndPass();
+
+			// Attach the visibility buffer to a new render pass
+			currentVisibilityBuffer = (query as MetalQuery).Handle;
+			needNewRenderPass = true;
+		}
+
+		public bool QueryComplete(IGLQuery query)
+		{
+			/* FIXME:
+			 * There's no easy way to check for completion
+			 * of the query. The only accurate way would be
+			 * to monitor the completion of the command buffer
+			 * associated with each query, but that gets tricky
+			 * since we can't use completion callbacks.
+			 * (Thank Objective-C and its stupid "block" lambdas.)
+			 *
+			 * Futhermore, I don't know how visibility queries
+			 * work across command buffers, in the event of a
+			 * stalled buffer overwrite or something similar.
+			 *
+			 * The below code is obviously wrong, but it happens
+			 * to work for the Lens Flare XNA sample. Maybe it'll
+			 * work for your game too?
+			 *
+			 * (Although if you're making a new game with FNA,
+			 * you really shouldn't be using queries anyway...)
+			 *
+			 * -caleb
+			 */
+			return true;
+		}
+
+		public void QueryEnd(IGLQuery query)
+		{
+			if (renderCommandEncoder != IntPtr.Zero)
+			{
+				// Stop counting.
+				mtlSetVisibilityResultMode(
+					renderCommandEncoder,
+					MTLVisibilityResultMode.Disabled,
+					0
+				);
+			}
+			currentVisibilityBuffer = IntPtr.Zero;
+		}
+
+		public int QueryPixelCount(IGLQuery query)
+		{
+			IntPtr contents = mtlGetBufferContentsPtr(
+				(query as MetalQuery).Handle
+			);
+			ulong result;
+			unsafe
+			{
+				result = *((ulong *) contents);
+			}
+			return (int) result;
+		}
+
+		#endregion
+
+		#region XNA->GL Enum Conversion Class
+
+		private static class XNAToMTL
+		{
+			public static readonly MTLPixelFormat[] TextureFormat = new MTLPixelFormat[]
+			{
+				MTLPixelFormat.RGBA8Unorm,	// SurfaceFormat.Color
+				MTLPixelFormat.B5G6R5Unorm,	// SurfaceFormat.Bgr565
+				MTLPixelFormat.BGR5A1Unorm,	// SurfaceFormat.Bgra5551
+				MTLPixelFormat.ABGR4Unorm,	// SurfaceFormat.Bgra4444
+				MTLPixelFormat.BC1_RGBA,	// SurfaceFormat.Dxt1
+				MTLPixelFormat.BC2_RGBA,	// SurfaceFormat.Dxt3
+				MTLPixelFormat.BC3_RGBA,	// SurfaceFormat.Dxt5
+				MTLPixelFormat.RG8Snorm,	// SurfaceFormat.NormalizedByte2
+				MTLPixelFormat.RG16Snorm,	// SurfaceFormat.NormalizedByte4
+				MTLPixelFormat.RGB10A2Unorm,	// SurfaceFormat.Rgba1010102
+				MTLPixelFormat.RG16Unorm,	// SurfaceFormat.Rg32
+				MTLPixelFormat.RGBA16Unorm,	// SurfaceFormat.Rgba64
+				MTLPixelFormat.A8Unorm,		// SurfaceFormat.Alpha8
+				MTLPixelFormat.R32Float,	// SurfaceFormat.Single
+				MTLPixelFormat.RG32Float,	// SurfaceFormat.Vector2
+				MTLPixelFormat.RGBA32Float,	// SurfaceFormat.Vector4
+				MTLPixelFormat.R16Float,	// SurfaceFormat.HalfSingle
+				MTLPixelFormat.RG16Float,	// SurfaceFormat.HalfVector2
+				MTLPixelFormat.RGBA16Float,	// SurfaceFormat.HalfVector4
+				MTLPixelFormat.RGBA16Float,	// SurfaceFormat.HdrBlendable
+				MTLPixelFormat.BGRA8Unorm	// SurfaceFormat.ColorBgraEXT
+			};
+
+			public static readonly MojoShader.MOJOSHADER_usage[] VertexAttribUsage = new MojoShader.MOJOSHADER_usage[]
+			{
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_POSITION,		// VertexElementUsage.Position
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_COLOR,		// VertexElementUsage.Color
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_TEXCOORD,		// VertexElementUsage.TextureCoordinate
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_NORMAL,		// VertexElementUsage.Normal
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_BINORMAL,		// VertexElementUsage.Binormal
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_TANGENT,		// VertexElementUsage.Tangent
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_BLENDINDICES,	// VertexElementUsage.BlendIndices
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_BLENDWEIGHT,	// VertexElementUsage.BlendWeight
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_DEPTH,		// VertexElementUsage.Depth
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_FOG,		// VertexElementUsage.Fog
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_POINTSIZE,		// VertexElementUsage.PointSize
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_SAMPLE,		// VertexElementUsage.Sample
+				MojoShader.MOJOSHADER_usage.MOJOSHADER_USAGE_TESSFACTOR		// VertexElementUsage.TessellateFactor
+			};
+
+			public static readonly MTLVertexFormat[] VertexAttribType = new MTLVertexFormat[]
+			{
+				MTLVertexFormat.Float,			// VertexElementFormat.Single
+				MTLVertexFormat.Float2,			// VertexElementFormat.Vector2
+				MTLVertexFormat.Float3,			// VertexElementFormat.Vector3
+				MTLVertexFormat.Float4,			// VertexElementFormat.Vector4
+				MTLVertexFormat.UChar4Normalized,	// VertexElementFormat.Color
+				MTLVertexFormat.UChar4,			// VertexElementFormat.Byte4
+				MTLVertexFormat.Short2,			// VertexElementFormat.Short2
+				MTLVertexFormat.Short4,			// VertexElementFormat.Short4
+				MTLVertexFormat.Short2Normalized,	// VertexElementFormat.NormalizedShort2
+				MTLVertexFormat.Short4Normalized,	// VertexElementFormat.NormalizedShort4
+				MTLVertexFormat.Half2,			// VertexElementFormat.HalfVector2
+				MTLVertexFormat.Half4			// VertexElementFormat.HalfVector4
+			};
+
+			public static readonly MTLIndexType[] IndexType = new MTLIndexType[]
+			{
+				MTLIndexType.UInt16,	// IndexElementSize.SixteenBits
+				MTLIndexType.UInt32	// IndexElementSize.ThirtyTwoBits
+			};
+
+			public static readonly int[] IndexSize = new int[]
+			{
+				2,	// IndexElementSize.SixteenBits
+				4	// IndexElementSize.ThirtyTwoBits
+			};
+
+			public static readonly MTLBlendFactor[] BlendMode = new MTLBlendFactor[]
+			{
+				MTLBlendFactor.One,			// Blend.One
+				MTLBlendFactor.Zero,			// Blend.Zero
+				MTLBlendFactor.SourceColor,		// Blend.SourceColor
+				MTLBlendFactor.OneMinusSourceColor,	// Blend.InverseSourceColor
+				MTLBlendFactor.SourceAlpha,		// Blend.SourceAlpha
+				MTLBlendFactor.OneMinusSourceAlpha,	// Blend.InverseSourceAlpha
+				MTLBlendFactor.DestinationColor,	// Blend.DestinationColor
+				MTLBlendFactor.OneMinusDestinationColor,// Blend.InverseDestinationColor
+				MTLBlendFactor.DestinationAlpha,	// Blend.DestinationAlpha
+				MTLBlendFactor.OneMinusDestinationAlpha,// Blend.InverseDestinationAlpha
+				MTLBlendFactor.BlendColor,		// Blend.BlendFactor
+				MTLBlendFactor.OneMinusBlendColor,	// Blend.InverseBlendFactor
+				MTLBlendFactor.SourceAlphaSaturated	// Blend.SourceAlphaSaturation
+			};
+
+			public static readonly MTLBlendOperation[] BlendOperation = new MTLBlendOperation[]
+			{
+				MTLBlendOperation.Add,			// BlendFunction.Add
+				MTLBlendOperation.Subtract,		// BlendFunction.Subtract
+				MTLBlendOperation.ReverseSubtract,	// BlendFunction.ReverseSubtract
+				MTLBlendOperation.Max,			// BlendFunction.Max
+				MTLBlendOperation.Min			// BlendFunction.Min
+			};
+
+			public static int ColorWriteMask(ColorWriteChannels channels)
+			{
+				if (channels == ColorWriteChannels.None)
+				{
+					return 0x0;
+				}
+				if (channels == ColorWriteChannels.All)
+				{
+					return 0xf;
+				}
+
+				int ret = 0;
+				if ((channels & ColorWriteChannels.Red) != 0)
+				{
+					ret |= (0x1 << 3);
+				}
+				if ((channels & ColorWriteChannels.Green) != 0)
+				{
+					ret |= (0x1 << 2);
+				}
+				if ((channels & ColorWriteChannels.Blue) != 0)
+				{
+					ret |= (0x1 << 1);
+				}
+				if ((channels & ColorWriteChannels.Alpha) != 0)
+				{
+					ret |= (0x1 << 0);
+				}
+				return ret;
+			}
+
+			public static readonly MTLCompareFunction[] CompareFunc = new MTLCompareFunction[]
+			{
+				MTLCompareFunction.Always,	// CompareFunction.Always
+				MTLCompareFunction.Never,	// CompareFunction.Never
+				MTLCompareFunction.Less,	// CompareFunction.Less
+				MTLCompareFunction.LessEqual,	// CompareFunction.LessEqual
+				MTLCompareFunction.Equal,	// CompareFunction.Equal
+				MTLCompareFunction.GreaterEqual,// CompareFunction.GreaterEqual
+				MTLCompareFunction.Greater,	// CompareFunction.Greater
+				MTLCompareFunction.NotEqual	// CompareFunction.NotEqual
+			};
+
+			public static readonly MTLStencilOperation[] StencilOp = new MTLStencilOperation[]
+			{
+				MTLStencilOperation.Keep,		// StencilOperation.Keep
+				MTLStencilOperation.Zero,		// StencilOperation.Zero
+				MTLStencilOperation.Replace,		// StencilOperation.Replace
+				MTLStencilOperation.IncrementWrap,	// StencilOperation.Increment
+				MTLStencilOperation.DecrementWrap,	// StencilOperation.Decrement
+				MTLStencilOperation.IncrementClamp,	// StencilOperation.IncrementSaturation
+				MTLStencilOperation.DecrementClamp,	// StencilOperation.DecrementSaturation
+				MTLStencilOperation.Invert		// StencilOperation.Invert
+			};
+
+			public static readonly MTLTriangleFillMode[] FillMode = new MTLTriangleFillMode[]
+			{
+				MTLTriangleFillMode.Fill,	// FillMode.Solid
+				MTLTriangleFillMode.Lines	// FillMode.WireFrame
+			};
+
+			public static float DepthBiasScale(MTLPixelFormat format)
+			{
+				switch (format)
+				{
+					case MTLPixelFormat.Depth16Unorm:
+						return (float) ((1 << 16) - 1);
+
+					case MTLPixelFormat.Depth24Unorm_Stencil8:
+						return (float) ((1 << 24) - 1);
+
+					case MTLPixelFormat.Depth32Float:
+					case MTLPixelFormat.Depth32Float_Stencil8:
+						return (float) ((1 << 23) - 1);
+				}
+
+				return 0.0f;
+			}
+
+			public static readonly MTLCullMode[] CullingEnabled = new MTLCullMode[]
+			{
+				MTLCullMode.None,	// CullMode.None
+				MTLCullMode.Front,	// CullMode.CullClockwiseFace
+				MTLCullMode.Back	// CullMode.CullCounterClockwiseFace
+			};
+
+			public static readonly MTLSamplerAddressMode[] Wrap = new MTLSamplerAddressMode[]
+			{
+				MTLSamplerAddressMode.Repeat,		// TextureAddressMode.Wrap
+				MTLSamplerAddressMode.ClampToEdge,	// TextureAddressMode.Clamp
+				MTLSamplerAddressMode.MirrorRepeat	// TextureAddressMode.Mirror
+			};
+
+			public static readonly MTLSamplerMinMagFilter[] MagFilter = new MTLSamplerMinMagFilter[]
+			{
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.Linear
+				MTLSamplerMinMagFilter.Nearest,	// TextureFilter.Point
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.Anisotropic
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.LinearMipPoint
+				MTLSamplerMinMagFilter.Nearest,	// TextureFilter.PointMipLinear
+				MTLSamplerMinMagFilter.Nearest,	// TextureFilter.MinLinearMagPointMipLinear
+				MTLSamplerMinMagFilter.Nearest,	// TextureFilter.MinLinearMagPointMipPoint
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.MinPointMagLinearMipLinear
+				MTLSamplerMinMagFilter.Linear	// TextureFilter.MinPointMagLinearMipPoint
+			};
+
+			public static readonly MTLSamplerMipFilter[] MipFilter = new MTLSamplerMipFilter[]
+			{
+				MTLSamplerMipFilter.Linear,	// TextureFilter.Linear
+				MTLSamplerMipFilter.Nearest,	// TextureFilter.Point
+				MTLSamplerMipFilter.Linear,	// TextureFilter.Anisotropic
+				MTLSamplerMipFilter.Nearest,	// TextureFilter.LinearMipPoint
+				MTLSamplerMipFilter.Linear,	// TextureFilter.PointMipLinear
+				MTLSamplerMipFilter.Linear,	// TextureFilter.MinLinearMagPointMipLinear
+				MTLSamplerMipFilter.Nearest,	// TextureFilter.MinLinearMagPointMipPoint
+				MTLSamplerMipFilter.Linear,	// TextureFilter.MinPointMagLinearMipLinear
+				MTLSamplerMipFilter.Nearest	// TextureFilter.MinPointMagLinearMipPoint
+			};
+
+			public static readonly MTLSamplerMinMagFilter[] MinFilter = new MTLSamplerMinMagFilter[]
+			{
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.Linear
+				MTLSamplerMinMagFilter.Nearest,	// TextureFilter.Point
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.Anisotropic
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.LinearMipPoint
+				MTLSamplerMinMagFilter.Nearest,	// TextureFilter.PointMipLinear
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.MinLinearMagPointMipLinear
+				MTLSamplerMinMagFilter.Linear,	// TextureFilter.MinLinearMagPointMipPoint
+				MTLSamplerMinMagFilter.Nearest,	// TextureFilter.MinPointMagLinearMipLinear
+				MTLSamplerMinMagFilter.Nearest	// TextureFilter.MinPointMagLinearMipPoint
+			};
+
+			public static readonly MTLPrimitiveType[] Primitive = new MTLPrimitiveType[]
+			{
+				MTLPrimitiveType.Triangle,	// PrimitiveType.TriangleList
+				MTLPrimitiveType.TriangleStrip,	// PrimitiveType.TriangleStrip
+				MTLPrimitiveType.Line,		// PrimitiveType.LineList
+				MTLPrimitiveType.LineStrip,	// PrimitiveType.LineStrip
+				MTLPrimitiveType.Point		// PrimitiveType.PointListEXT
+			};
+
+			public static int PrimitiveVerts(PrimitiveType primitiveType, int primitiveCount)
+			{
+				switch (primitiveType)
+				{
+					case PrimitiveType.TriangleList:
+						return primitiveCount * 3;
+					case PrimitiveType.TriangleStrip:
+						return primitiveCount + 2;
+					case PrimitiveType.LineList:
+						return primitiveCount * 2;
+					case PrimitiveType.LineStrip:
+						return primitiveCount + 1;
+					case PrimitiveType.PointListEXT:
+						return primitiveCount;
+				}
+				throw new NotSupportedException();
+			}
+		}
+
+		#endregion
+
+		#region The Faux-Backbuffer
+
+		private class MetalBackbuffer : IGLBackbuffer
+		{
+			public int Width
+			{
+				get;
+				private set;
+			}
+
+			public int Height
+			{
+				get;
+				private set;
+			}
+
+			public MTLPixelFormat PixelFormat
+			{
+				get;
+				private set;
+			}
+
+			public DepthFormat DepthFormat
+			{
+				get;
+				private set;
+			}
+
+			public int MultiSampleCount
+			{
+				get;
+				private set;
+			}
+
+			public MetalTexture Texture
+			{
+				get;
+				private set;
+			}
+
+			public IntPtr ColorBuffer = IntPtr.Zero;
+			public IntPtr MultiSampleColorBuffer = IntPtr.Zero;
+			public IntPtr DepthStencilBuffer = IntPtr.Zero;
+			
+			private MetalDevice mtlDevice;
+
+			public MetalBackbuffer(
+				MetalDevice device,
+				int width,
+				int height,
+				DepthFormat depthFormat,
+				int multiSampleCount
+			) {
+				Width = width;
+				Height = height;
+
+				mtlDevice = device;
+				DepthFormat = depthFormat;
+				MultiSampleCount = multiSampleCount;
+
+				PixelFormat = MTLPixelFormat.RGBA8Unorm;
+			}
+
+			public void Dispose()
+			{
+				objc_release(ColorBuffer);
+				ColorBuffer = IntPtr.Zero;
+
+				objc_release(MultiSampleColorBuffer);
+				MultiSampleColorBuffer = IntPtr.Zero;
+
+				objc_release(DepthStencilBuffer);
+				DepthStencilBuffer = IntPtr.Zero;
+			}
+
+			public void ResetFramebuffer(
+				PresentationParameters presentationParameters
+			) {
+				// Release the existing buffers
+				Dispose();
+
+				// Update the backbuffer size
+				int newWidth = presentationParameters.BackBufferWidth;
+				int newHeight = presentationParameters.BackBufferHeight;
+				if (Width != newWidth || Height != newHeight)
+				{
+					mtlDevice.fauxBackbufferSizeChanged = true;
+				}
+				Width = newWidth;
+				Height = newHeight;
+
+				// Update other presentation parameters
+				DepthFormat = presentationParameters.DepthStencilFormat;
+				MultiSampleCount = mtlDevice.GetCompatibleSampleCount(
+					presentationParameters.MultiSampleCount
+				);
+
+				// Update color buffer to the new resolution.
+				IntPtr colorBufferDesc = mtlMakeTexture2DDescriptor(
+					PixelFormat,
+					Width,
+					Height,
+					false
+				);
+				mtlSetStorageMode(
+					colorBufferDesc,
+					MTLStorageMode.Private
+				);
+				mtlSetTextureUsage(
+					colorBufferDesc,
+					MTLTextureUsage.RenderTarget | MTLTextureUsage.ShaderRead
+				);
+				ColorBuffer = mtlNewTextureWithDescriptor(
+					mtlDevice.device,
+					colorBufferDesc
+				);
+				if (MultiSampleCount > 0)
+				{
+					mtlSetTextureType(
+						colorBufferDesc,
+						MTLTextureType.Multisample2D
+					);
+					mtlSetTextureSampleCount(
+						colorBufferDesc,
+						MultiSampleCount
+					);
+					mtlSetTextureUsage(
+						colorBufferDesc,
+						MTLTextureUsage.RenderTarget
+					);
+					MultiSampleColorBuffer = mtlNewTextureWithDescriptor(
+						mtlDevice.device,
+						colorBufferDesc
+					);
+				}
+
+				// Update the depth/stencil buffer, if applicable
+				if (DepthFormat != DepthFormat.None)
+				{
+					IntPtr depthStencilBufferDesc = mtlMakeTexture2DDescriptor(
+						mtlDevice.GetDepthFormat(DepthFormat),
+						Width,
+						Height,
+						false
+					);
+					mtlSetStorageMode(
+						depthStencilBufferDesc,
+						MTLStorageMode.Private
+					);
+					mtlSetTextureUsage(
+						depthStencilBufferDesc,
+						MTLTextureUsage.RenderTarget
+					);
+					if (MultiSampleCount > 0)
+					{
+						mtlSetTextureType(
+							depthStencilBufferDesc,
+							MTLTextureType.Multisample2D
+						);
+						mtlSetTextureSampleCount(
+							depthStencilBufferDesc,
+							MultiSampleCount
+						);
+					}
+					DepthStencilBuffer = mtlNewTextureWithDescriptor(
+						mtlDevice.device,
+						depthStencilBufferDesc
+					);
+				}
+
+				// Update the Texture representation
+				Texture = new MetalTexture(
+					ColorBuffer,
+					Width,
+					Height,
+					SurfaceFormat.Color,
+					1,
+					true
+				);
+
+				// This is the default render target
+				mtlDevice.SetRenderTargets(null, null, DepthFormat.None);
+			}
+		}
+
+		private void InitializeFauxBackbuffer(
+			PresentationParameters presentationParameters
+		) {
+			Backbuffer = new MetalBackbuffer(
+				this,
+				presentationParameters.BackBufferWidth,
+				presentationParameters.BackBufferHeight,
+				presentationParameters.DepthStencilFormat,
+				presentationParameters.MultiSampleCount
+			);
+
+			/* Create a combined vertex/index buffer
+			 * for rendering the faux-backbuffer.
+			 */
+			fauxBackbufferDrawBuffer = mtlNewBufferWithLength(
+				device,
+				(16 * sizeof(float)) + (6 * sizeof(ushort)),
+				MTLResourceOptions.CPUCacheModeWriteCombined
+			);
+
+			ushort[] indices = new ushort[]
+			{
+				0, 1, 3,
+				1, 2, 3
+			};
+			GCHandle indicesPinned = GCHandle.Alloc(indices, GCHandleType.Pinned);
+			memcpy(
+				mtlGetBufferContentsPtr(fauxBackbufferDrawBuffer) + (16 * sizeof(float)),
+				indicesPinned.AddrOfPinnedObject(),
+				(IntPtr) (6 * sizeof(ushort))
+			);
+			indicesPinned.Free();
+
+			// Create vertex and fragment shaders for the faux-backbuffer pipeline
+			string shaderSource =
+			@"
+				#include <metal_stdlib>
+				using namespace metal;
+
+				struct VertexIn {
+					packed_float2 position;
+					packed_float2 texCoord;
+				};
+
+				struct VertexOut {
+					float4 position [[ position ]];
+					float2 texCoord;
+				};
+
+				vertex VertexOut
+				vertexShader(
+					uint vertexID [[ vertex_id ]],
+					constant VertexIn *vertexArray [[ buffer(0) ]]
+				) {
+					VertexOut out;
+					out.position = float4(vertexArray[vertexID].position, 0.0, 1.0);
+					out.position.y *= -1;
+					out.texCoord = vertexArray[vertexID].texCoord;
+					return out;
+				}
+
+				fragment float4
+				fragmentShader(
+					VertexOut in [[stage_in]],
+					texture2d<half> colorTexture [[ texture(0) ]],
+					sampler s0 [[sampler(0)]]
+				) {
+					const half4 colorSample = colorTexture.sample(s0, in.texCoord);
+					return float4(colorSample);
+				}
+			";
+
+			IntPtr nsShaderSource = UTF8ToNSString(shaderSource);
+			IntPtr nsVertexShader = UTF8ToNSString("vertexShader");
+			IntPtr nsFragmentShader = UTF8ToNSString("fragmentShader");
+
+			IntPtr library = mtlNewLibraryWithSource(
+				device,
+				nsShaderSource,
+				IntPtr.Zero
+			);
+			IntPtr vertexFunc = mtlNewFunctionWithName(
+				library,
+				nsVertexShader
+			);
+			IntPtr fragFunc = mtlNewFunctionWithName(
+				library,
+				nsFragmentShader
+			);
+
+			objc_release(nsShaderSource);
+			objc_release(nsVertexShader);
+			objc_release(nsFragmentShader);
+
+			// Create a sampler state
+			IntPtr samplerDescriptor = mtlNewSamplerDescriptor();
+			mtlSetSamplerMinFilter(samplerDescriptor, backbufferScaleMode);
+			mtlSetSamplerMagFilter(samplerDescriptor, backbufferScaleMode);
+			fauxBackbufferSamplerState = mtlNewSamplerStateWithDescriptor(
+				device,
+				samplerDescriptor
+			);
+			objc_release(samplerDescriptor);
+
+			// Create a render pipeline for rendering the backbuffer
+			IntPtr pipelineDesc = mtlNewRenderPipelineDescriptor();
+			mtlSetPipelineVertexFunction(pipelineDesc, vertexFunc);
+			mtlSetPipelineFragmentFunction(pipelineDesc, fragFunc);
+			mtlSetAttachmentPixelFormat(
+				mtlGetColorAttachment(pipelineDesc, 0),
+				mtlGetLayerPixelFormat(layer)
+			);
+			fauxBackbufferRenderPipeline = mtlNewRenderPipelineStateWithDescriptor(
+				device,
+				pipelineDesc
+			);
+			objc_release(pipelineDesc);
+			objc_release(vertexFunc);
+			objc_release(fragFunc);
+		}
+
+		#endregion
+	}
+}

--- a/src/FNAPlatform/MetalDevice_MTL.cs
+++ b/src/FNAPlatform/MetalDevice_MTL.cs
@@ -1,0 +1,1910 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+#region Using Statements
+using System;
+using System.Runtime.InteropServices;
+#endregion
+
+/* =============================
+ * Objective-C Runtime Reference
+ * =============================
+ * A function call takes the form of objc_msgSend(<receiver>, <message>, <args>)
+ * 
+ * To send the "quack" message to a "duck" instance, we need two things:
+ * 1) A pointer to the duck instance. This is the receiver.
+ * 2) A Selector (read: char* with extra metadata) for the "quack" message.
+ * 
+ * To create a "quack" selector, we have to call sel_registerName() with a
+ * parameter of "quack" turned into an array of UTF8 bytes. This is tedious,
+ * so we do this here by calling the convenience method Selector("quack").
+ * 
+ * To get a property of obj: objc_msgSend(obj, Selector("propertyName"))
+ * To set a property of obj: objc_msgSend(obj, Selector("setPropertyName"), val)
+ * 
+ * ===========
+ * Other notes
+ * ===========
+ * The size of NSUInteger varies depending on CPU arch (32 bit / 64 bit).
+ * Since all modern Apple devices are 64 bit, we can just use ulong (UInt64)
+ * instead of uint (UInt32). This makes the structs the correct size.
+ */
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	internal partial class MetalDevice : IGLDevice
+	{
+		#region Private ObjC Runtime Entry Points
+
+		const string objcLibrary = "/usr/lib/libobjc.A.dylib";
+
+		[DllImport(objcLibrary)]
+		private static extern IntPtr objc_getClass(string name);
+
+		[DllImport(objcLibrary)]
+		private static extern void objc_release(IntPtr obj);
+
+		[DllImport(objcLibrary)]
+		private static extern IntPtr objc_retain(IntPtr obj);
+
+		[DllImport(objcLibrary)]
+		private static extern IntPtr objc_autoreleasePoolPush();
+
+		[DllImport(objcLibrary)]
+		private static extern void objc_autoreleasePoolPop(IntPtr pool);
+
+		[DllImport(objcLibrary)]
+		private static extern IntPtr sel_registerName(byte[] name);
+
+		/* Here come the obj_msgSend overloads... */
+
+		// Void
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, ulong arg2);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, ulong arg2, ulong arg3);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg1, ulong arg2, ulong arg3);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg1, ulong arg2);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, uint arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, bool arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, double arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, MTLViewport viewport);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, MTLScissorRect scissorRect);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, MTLClearColor color);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, NSRange range);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, float arg1, float arg2, float arg3);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, float arg1, float arg2, float arg3, float arg4);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, MTLRegion region, ulong level, ulong slice, IntPtr bytes, ulong bytesPerRow, ulong bytesPerImage);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr srcTexture, ulong srcSlice, ulong srcLevel, MTLOrigin srcOrigin, MTLSize srcSize, IntPtr dstTexture, ulong dstSlice, ulong dstLevel, MTLOrigin dstOrigin);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, ulong primitiveType, ulong indexCount, ulong indexType, IntPtr indexBuffer, ulong indexBufferOffset, ulong instanceCount);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern void objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr pixelBytes, ulong bytesPerRow, ulong bytesPerImage, MTLRegion region, ulong level, ulong slice);
+
+		// IntPtr
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, string arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg1, ulong arg2);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLPixelFormat arg1, ulong arg2, bool arg3);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, MTLPixelFormat arg1, ulong arg2, ulong arg3, bool arg4);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, out IntPtr arg2);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern IntPtr intptr_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, out IntPtr arg3);
+
+		// Ulong
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern ulong ulong_objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg);
+
+		// Bool
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern bool bool_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, ulong arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg);
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern bool bool_objc_msgSend(IntPtr receiver, IntPtr selector, NSOperatingSystemVersion arg);
+
+		// CGSize
+
+		[DllImport(objcLibrary, EntryPoint = "objc_msgSend")]
+		private static extern CGSize cgsize_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+		#endregion
+
+		#region C-Style Metal Function Imports
+
+		const string metalLibrary = "/System/Library/Frameworks/Metal.framework/Metal";
+
+		[DllImport(metalLibrary)]
+		internal static extern IntPtr MTLCreateSystemDefaultDevice();
+
+		#endregion
+
+		#region Private MTL Enums
+
+		private enum MTLLoadAction : ulong
+		{
+			DontCare = 0,
+			Load = 1,
+			Clear = 2
+		}
+
+		private enum MTLStoreAction : ulong
+		{
+			DontCare = 0,
+			Store = 1,
+			MultisampleResolve = 2
+		}
+
+		private enum MTLPrimitiveType : ulong
+		{
+			Point = 0,
+			Line = 1,
+			LineStrip = 2,
+			Triangle = 3,
+			TriangleStrip = 4
+		}
+
+		private enum MTLIndexType : ulong
+		{
+			UInt16 = 0,
+			UInt32 = 1
+		}
+
+		private enum MTLPixelFormat : ulong
+		{
+			Invalid			= 0,
+			A8Unorm			= 1,
+			R16Float     		= 25,
+			RG8Snorm		= 32,
+			B5G6R5Unorm 		= 40,
+			ABGR4Unorm		= 42,
+			BGR5A1Unorm		= 43,
+			R32Float		= 55,
+			RG16Unorm		= 60,
+			RG16Snorm		= 62,
+			RG16Float		= 65,
+			RGBA8Unorm		= 70,
+			BGRA8Unorm		= 80,
+			RGB10A2Unorm		= 90,
+			RG32Float		= 105,
+			RGBA16Unorm		= 110,
+			RGBA16Float		= 115,
+			RGBA32Float		= 125,
+			BC1_RGBA		= 130,
+			BC2_RGBA		= 132,
+			BC3_RGBA		= 134,
+			Depth16Unorm		= 250,
+			Depth32Float		= 252,
+			Depth24Unorm_Stencil8	= 255,
+			Depth32Float_Stencil8	= 260,
+		}
+
+		private enum MTLSamplerMinMagFilter
+		{
+			Nearest = 0,
+			Linear = 1
+		}
+
+		private enum MTLTextureUsage
+		{
+			ShaderRead = 1,
+			RenderTarget = 4
+		}
+
+		private enum MTLTextureType
+		{
+			Multisample2D = 4,
+			Texture3D = 7
+		}
+
+		private enum MTLStorageMode
+		{
+			Private = 2
+		}
+
+		private enum MTLBlendFactor
+		{
+			Zero = 0,
+			One = 1,
+			SourceColor = 2,
+			OneMinusSourceColor = 3,
+			SourceAlpha = 4,
+			OneMinusSourceAlpha = 5,
+			DestinationColor = 6,
+			OneMinusDestinationColor = 7,
+			DestinationAlpha = 8,
+			OneMinusDestinationAlpha = 9,
+			SourceAlphaSaturated = 10,
+			BlendColor = 11,
+			OneMinusBlendColor = 12
+		}
+
+		private enum MTLBlendOperation
+		{
+			Add = 0,
+			Subtract = 1,
+			ReverseSubtract = 2,
+			Min = 3,
+			Max = 4
+		}
+
+		private enum MTLCullMode
+		{
+			None = 0,
+			Front = 1,
+			Back = 2
+		}
+
+		private enum MTLTriangleFillMode
+		{
+			Fill = 0,
+			Lines = 1
+		}
+
+		private enum MTLSamplerAddressMode
+		{
+			ClampToEdge = 0,
+			Repeat = 2,
+			MirrorRepeat = 3
+		}
+
+		private enum MTLSamplerMipFilter
+		{
+			Nearest = 1,
+			Linear = 2
+		}
+
+		private enum MTLVertexFormat
+		{
+			UChar4 = 3,
+			UChar4Normalized = 9,
+			Short2 = 16,
+			Short4 = 18,
+			Short2Normalized = 22,
+			Short4Normalized = 24,
+			Half2 = 25,
+			Half4 = 27,
+			Float = 28,
+			Float2 = 29,
+			Float3 = 30,
+			Float4 = 31
+		}
+
+		private enum MTLVertexStepFunction
+		{
+			PerInstance = 2
+		}
+
+		private enum MTLCompareFunction
+		{
+			Never = 0,
+			Less = 1,
+			Equal = 2,
+			LessEqual = 3,
+			Greater = 4,
+			NotEqual = 5,
+			GreaterEqual = 6,
+			Always = 7
+		}
+
+		private enum MTLStencilOperation
+		{
+			Keep = 0,
+			Zero = 1,
+			Replace = 2,
+			IncrementClamp = 3,
+			DecrementClamp = 4,
+			Invert = 5,
+			IncrementWrap = 6,
+			DecrementWrap = 7
+		}
+
+		private enum MTLVisibilityResultMode
+		{
+			Disabled = 0,
+			Counting = 2
+		}
+
+		private enum MTLResourceOptions
+		{
+			CPUCacheModeDefaultCache = 0,
+			CPUCacheModeWriteCombined = 1
+		}
+
+		private enum MTLPurgeableState
+		{
+			NonVolatile = 2,
+			Empty = 4
+		}
+
+		#endregion
+
+		#region Private MTL Structs
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct MTLClearColor
+		{
+			public double red;
+			public double green;
+			public double blue;
+			public double alpha;
+
+			public MTLClearColor(
+				double red,
+				double green,
+				double blue,
+				double alpha
+			) {
+				this.red = red;
+				this.green = green;
+				this.blue = blue;
+				this.alpha = alpha;
+			}
+		}
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct MTLViewport
+		{
+			public double originX;
+			public double originY;
+			public double width;
+			public double height;
+			public double znear;
+			public double zfar;
+
+			public MTLViewport(
+				double originX,
+				double originY,
+				double width,
+				double height,
+				double znear,
+				double zfar
+			) {
+				this.originX = originX;
+				this.originY = originY;
+				this.width = width;
+				this.height = height;
+				this.znear = znear;
+				this.zfar = zfar;
+			}
+		}
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct MTLScissorRect
+		{
+			ulong x;
+			ulong y;
+			ulong width;
+			ulong height;
+
+			public MTLScissorRect(
+				int x,
+				int y,
+				int width,
+				int height
+			) {
+				this.x = (ulong) x;
+				this.y = (ulong) y;
+				this.width = (ulong) width;
+				this.height = (ulong) height;
+			}
+		}
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct MTLOrigin
+		{
+			ulong x;
+			ulong y;
+			ulong z;
+
+			public MTLOrigin(int x, int y, int z)
+			{
+				this.x = (ulong) x;
+				this.y = (ulong) y;
+				this.z = (ulong) z;
+			}
+
+			public static MTLOrigin Zero = new MTLOrigin(0, 0, 0);
+		}
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct MTLSize
+		{
+			ulong width;
+			ulong height;
+			ulong depth;
+
+			public MTLSize(int width, int height, int depth)
+			{
+				this.width = (ulong) width;
+				this.height = (ulong) height;
+				this.depth = (ulong) depth;
+			}
+		}
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct MTLRegion
+		{
+			MTLOrigin origin;
+			MTLSize size;
+
+			public MTLRegion(MTLOrigin origin, MTLSize size)
+			{
+				this.origin = origin;
+				this.size = size;
+			}
+		}
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct CGSize
+		{
+			public double width;
+			public double height;
+		}
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct NSRange
+		{
+			public ulong loc;
+			public ulong len;
+
+			public NSRange(int loc, int len)
+			{
+				this.loc = (ulong) loc;
+				this.len = (ulong) len;
+			}
+		}
+
+		#endregion
+
+		#region Selectors
+
+		private static IntPtr Selector(string name)
+		{
+			name += Char.MinValue; // null terminator
+			return sel_registerName(System.Text.Encoding.UTF8.GetBytes(name));
+		}
+
+		private static IntPtr selRespondsToSelector = Selector("respondsToSelector:");
+		private static bool RespondsToSelector(IntPtr obj, IntPtr selector)
+		{
+			return bool_objc_msgSend(obj, selRespondsToSelector, selector);
+		}
+
+		#endregion
+
+		#region ObjC Class References
+
+		private static IntPtr classTextureDescriptor = objc_getClass("MTLTextureDescriptor");
+		private static IntPtr classRenderPassDescriptor = objc_getClass("MTLRenderPassDescriptor");
+		private static IntPtr classRenderPipelineDescriptor = objc_getClass("MTLRenderPipelineDescriptor");
+		private static IntPtr classDepthStencilDescriptor = objc_getClass("MTLDepthStencilDescriptor");
+		private static IntPtr classStencilDescriptor = objc_getClass("MTLStencilDescriptor");
+		private static IntPtr classMTLSamplerDescriptor = objc_getClass("MTLSamplerDescriptor");
+		private static IntPtr classMTLVertexDescriptor = objc_getClass("MTLVertexDescriptor");
+		private static IntPtr classNSProcessInfo = objc_getClass("NSProcessInfo");
+		private static IntPtr classNSString = objc_getClass("NSString");
+
+		#endregion
+
+		#region NSString <-> C# String
+
+		private static IntPtr selUtf8 = Selector("UTF8String");
+		private static string NSStringToUTF8(IntPtr nsstr)
+		{
+			return Marshal.PtrToStringAnsi(
+				intptr_objc_msgSend(nsstr, selUtf8)
+			);
+		}
+
+		private static IntPtr selAlloc = Selector("alloc");
+		private static IntPtr selInitWithUtf8 = Selector("initWithUTF8String:");
+		private static IntPtr UTF8ToNSString(string str)
+		{
+			return intptr_objc_msgSend(
+				intptr_objc_msgSend(classNSString, selAlloc),
+				selInitWithUtf8,
+				str
+			);
+		}
+
+		#endregion
+
+		#region iOS/tvOS GPU Check
+
+		private static IntPtr selSupportsFamily = Selector("supportsFamily:");
+		private static IntPtr selSupportsFeatureSet = Selector("supportsFeatureSet:");
+		private bool HasModernAppleGPU()
+		{
+			// "Modern" = A9 or later
+			const ulong GPUFamilyCommon2 = 3002;
+			const ulong iOS_GPUFamily3_v1 = 4;
+			const ulong tvOS_GPUFamily2_v1 = 30003;
+
+			// Can we use the GPUFamily API?
+			if (RespondsToSelector(device, selSupportsFamily))
+			{
+				return bool_objc_msgSend(
+					device,
+					selSupportsFamily,
+					GPUFamilyCommon2
+				);
+			}
+
+			// Fall back to checking FeatureSets...
+			bool iosCompat = bool_objc_msgSend(
+				device,
+				selSupportsFeatureSet,
+				iOS_GPUFamily3_v1
+			);
+			bool tvosCompat = bool_objc_msgSend(
+				device,
+				selSupportsFeatureSet,
+				tvOS_GPUFamily2_v1
+			);
+			return iosCompat || tvosCompat;
+		}
+
+		#endregion
+
+		#region OS Version Check
+
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct NSOperatingSystemVersion
+		{
+			public long major;
+			public long minor;
+			public long patch;
+		}
+
+		private static IntPtr selOperatingSystemAtLeast = Selector("isOperatingSystemAtLeastVersion:");
+		private static IntPtr selProcessInfo = Selector("processInfo");
+		private static bool OperatingSystemAtLeast(long major, long minor, long patch)
+		{
+			NSOperatingSystemVersion version = new NSOperatingSystemVersion
+			{
+				major = major,
+				minor = minor,
+				patch = patch
+			};
+			IntPtr processInfo = intptr_objc_msgSend(
+				classNSProcessInfo,
+				selProcessInfo
+			);
+			return bool_objc_msgSend(
+				processInfo,
+				selOperatingSystemAtLeast,
+				version
+			);
+		}
+
+		#endregion
+
+		#region MTLDevice
+
+		private static IntPtr selName = Selector("name");
+		private static string mtlGetDeviceName(IntPtr device)
+		{
+			return NSStringToUTF8(intptr_objc_msgSend(device, selName));
+		}
+
+		private static IntPtr selSupportsSampleCount = Selector("supportsSampleCount:");
+		private static bool mtlSupportsSampleCount(IntPtr device, int count)
+		{
+			return bool_objc_msgSend(device, selSupportsSampleCount, (ulong) count);
+		}
+
+		private static IntPtr selCommandQueue = Selector("newCommandQueue");
+		private static IntPtr mtlNewCommandQueue(IntPtr device)
+		{
+			return intptr_objc_msgSend(device, selCommandQueue);
+		}
+
+		private static IntPtr selNewBufferWithLength = Selector("newBufferWithLength:options:");
+		private static IntPtr mtlNewBufferWithLength(IntPtr device, int length, MTLResourceOptions options)
+		{
+			return intptr_objc_msgSend(
+				device,
+				selNewBufferWithLength,
+				(ulong) length,
+				(ulong) options
+			);
+		}
+
+		private static IntPtr selNewTextureWithDescriptor = Selector("newTextureWithDescriptor:");
+		private static IntPtr mtlNewTextureWithDescriptor(IntPtr device, IntPtr texDesc)
+		{
+			return intptr_objc_msgSend(
+				device,
+				selNewTextureWithDescriptor,
+				texDesc
+			);
+		}
+
+		private static IntPtr selNewSamplerStateWithDescriptor = Selector("newSamplerStateWithDescriptor:");
+		private static IntPtr mtlNewSamplerStateWithDescriptor(IntPtr device, IntPtr sampDesc)
+		{
+			return intptr_objc_msgSend(
+				device,
+				selNewSamplerStateWithDescriptor,
+				sampDesc
+			);
+		}
+
+		private static IntPtr selSupportsDepth24Stencil8 = Selector("isDepth24Stencil8PixelFormatSupported");
+		private static bool mtlSupportsDepth24Stencil8(IntPtr device)
+		{
+			return bool_objc_msgSend(device, selSupportsDepth24Stencil8);
+		}
+
+		#endregion
+
+		#region MTLBuffer
+
+		private static IntPtr selContents = Selector("contents");
+		private static IntPtr mtlGetBufferContentsPtr(IntPtr buffer)
+		{
+			return intptr_objc_msgSend(buffer, selContents);
+		}
+
+		#endregion
+
+		#region MTLCommandBuffer
+
+		private static IntPtr selRenderCommandEncoder = Selector("renderCommandEncoderWithDescriptor:");
+		private static IntPtr mtlMakeRenderCommandEncoder(
+			IntPtr commandBuffer,
+			IntPtr renderPassDesc
+		) {
+			return intptr_objc_msgSend(
+				commandBuffer,
+				selRenderCommandEncoder,
+				renderPassDesc
+			);
+		}
+
+		private static IntPtr selPresentDrawable = Selector("presentDrawable:");
+		private static void mtlPresentDrawable(
+			IntPtr commandBuffer,
+			IntPtr drawable
+		) {
+			objc_msgSend(
+				commandBuffer,
+				selPresentDrawable,
+				drawable
+			);
+		}
+
+		private static IntPtr selCommit = Selector("commit");
+		private static void mtlCommitCommandBuffer(IntPtr commandBuffer)
+		{
+			objc_msgSend(commandBuffer, selCommit);
+		}
+
+		private static IntPtr selWaitUntilCompleted = Selector("waitUntilCompleted");
+		private static void mtlCommandBufferWaitUntilCompleted(IntPtr commandBuffer)
+		{
+			objc_msgSend(commandBuffer, selWaitUntilCompleted);
+		}
+
+		#endregion
+
+		#region MTLCommandQueue
+
+		private static IntPtr selCommandBuffer = Selector("commandBuffer");
+		private static IntPtr mtlMakeCommandBuffer(IntPtr queue)
+		{
+			return intptr_objc_msgSend(queue, selCommandBuffer);
+		}
+
+		#endregion
+
+		#region Attachment Methods
+
+		private static IntPtr selColorAttachments = Selector("colorAttachments");
+		private static IntPtr selObjectAtIndexedSubscript = Selector("objectAtIndexedSubscript:");
+		private static IntPtr mtlGetColorAttachment(IntPtr desc, int index)
+		{
+			IntPtr attachments = intptr_objc_msgSend(
+				desc,
+				selColorAttachments
+			);
+
+			return intptr_objc_msgSend(
+				attachments, 
+				selObjectAtIndexedSubscript,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selDepthAttachment = Selector("depthAttachment");
+		private static IntPtr mtlGetDepthAttachment(IntPtr desc)
+		{
+			return intptr_objc_msgSend(desc, selDepthAttachment);
+		}
+
+		private static IntPtr selStencilAttachment = Selector("stencilAttachment");
+		private static IntPtr mtlGetStencilAttachment(IntPtr desc)
+		{
+			return intptr_objc_msgSend(desc, selStencilAttachment);
+		}
+
+		private static IntPtr selSetLoadAction = Selector("setLoadAction:");
+		private static void mtlSetAttachmentLoadAction(
+			IntPtr attachment,
+			MTLLoadAction loadAction
+		) {
+			objc_msgSend(attachment, selSetLoadAction, (ulong) loadAction);
+		}
+
+		private static IntPtr selSetStoreAction = Selector("setStoreAction:");
+		private static void mtlSetAttachmentStoreAction(
+			IntPtr attachment,
+			MTLStoreAction storeAction
+		) {
+			objc_msgSend(attachment, selSetStoreAction, (ulong) storeAction);
+		}
+
+		private static IntPtr selSetTexture = Selector("setTexture:");
+		private static void mtlSetAttachmentTexture(
+			IntPtr attachment,
+			IntPtr texture
+		) {
+			objc_msgSend(attachment, selSetTexture, texture);
+		}
+
+		private static IntPtr selSetSlice = Selector("setSlice:");
+		private static void mtlSetAttachmentSlice(
+			IntPtr attachment,
+			int slice
+		) {
+			objc_msgSend(attachment, selSetSlice, (ulong) slice);
+		}
+
+		private static IntPtr selSetPixelFormat = Selector("setPixelFormat:");
+		private static void mtlSetAttachmentPixelFormat(
+			IntPtr attachment,
+			MTLPixelFormat pixelFormat
+		) {
+			objc_msgSend(attachment, selSetPixelFormat, (ulong) pixelFormat);
+		}
+
+		private static IntPtr selSetResolveTexture = Selector("setResolveTexture:");
+		private static void mtlSetAttachmentResolveTexture(
+			IntPtr attachment,
+			IntPtr resolveTexture
+		) {
+			objc_msgSend(attachment, selSetResolveTexture, resolveTexture);
+		}
+
+		private static IntPtr selSetResolveSlice = Selector("setResolveSlice:");
+		private static void mtlSetAttachmentResolveSlice(
+			IntPtr attachment,
+			int resolveSlice
+		) {
+			objc_msgSend(attachment, selSetResolveSlice, (ulong) resolveSlice);
+		}
+
+		private static IntPtr selSetClearColor = Selector("setClearColor:");
+		private static void mtlSetColorAttachmentClearColor(
+			IntPtr colorAttachment,
+			float r,
+			float g,
+			float b,
+			float a
+		) {
+			MTLClearColor clearColor = new MTLClearColor(r, g, b, a);
+			objc_msgSend(colorAttachment, selSetClearColor, clearColor);
+		}
+
+		private static IntPtr selSetClearDepth = Selector("setClearDepth:");
+		private static void mtlSetDepthAttachmentClearDepth(
+			IntPtr depthAttachment,
+			float clearDepth
+		) {
+			objc_msgSend(depthAttachment, selSetClearDepth, clearDepth);
+		}
+
+		private static IntPtr selSetClearStencil = Selector("setClearStencil:");
+		private static void mtlSetStencilAttachmentClearStencil(
+			IntPtr stencilAttachment,
+			int clearStencil
+		) {
+			objc_msgSend(stencilAttachment, selSetClearStencil, (ulong) clearStencil);
+		}
+
+		private static IntPtr selBlendingEnabled = Selector("setBlendingEnabled:");
+		private static void mtlSetAttachmentBlendingEnabled(
+			IntPtr colorAttachment,
+			bool enabled
+		) {
+			objc_msgSend(colorAttachment, selBlendingEnabled, enabled);
+		}
+
+		private static IntPtr selSetAlphaBlendOperation = Selector("setAlphaBlendOperation:");
+		private static void mtlSetAttachmentAlphaBlendOperation(
+			IntPtr colorAttachment,
+			MTLBlendOperation op
+		) {
+			objc_msgSend(colorAttachment, selSetAlphaBlendOperation, (ulong) op);
+		}
+
+		private static IntPtr selSetRGBBlendOperation = Selector("setRgbBlendOperation:");
+		private static void mtlSetAttachmentRGBBlendOperation(
+			IntPtr colorAttachment,
+			MTLBlendOperation op
+		) {
+			objc_msgSend(colorAttachment, selSetRGBBlendOperation, (ulong) op);
+		}
+
+		private static IntPtr selSetDestinationAlphaBlendFactor = Selector("setDestinationAlphaBlendFactor:");
+		private static void mtlSetAttachmentDestinationAlphaBlendFactor(
+			IntPtr colorAttachment,
+			MTLBlendFactor blend
+		) {
+			objc_msgSend(colorAttachment, selSetDestinationAlphaBlendFactor, (ulong) blend);
+		}
+
+		private static IntPtr selSetDestinationRGBBlendFactor = Selector("setDestinationRGBBlendFactor:");
+		private static void mtlSetAttachmentDestinationRGBBlendFactor(
+			IntPtr colorAttachment,
+			MTLBlendFactor blend
+		) {
+			objc_msgSend(colorAttachment, selSetDestinationRGBBlendFactor, (ulong) blend);
+		}
+
+		private static IntPtr selSetSourceAlphaBlendFactor = Selector("setSourceAlphaBlendFactor:");
+		private static void mtlSetAttachmentSourceAlphaBlendFactor(
+			IntPtr colorAttachment,
+			MTLBlendFactor blend
+		) {
+			objc_msgSend(colorAttachment, selSetSourceAlphaBlendFactor, (ulong) blend);
+		}
+
+		private static IntPtr selSetSourceRGBBlendFactor = Selector("setSourceRGBBlendFactor:");
+		private static void mtlSetAttachmentSourceRGBBlendFactor(
+			IntPtr colorAttachment,
+			MTLBlendFactor blend
+		) {
+			objc_msgSend(colorAttachment, selSetSourceRGBBlendFactor, (ulong) blend);
+		}
+
+		private static IntPtr selSetWriteMask = Selector("setWriteMask:");
+		private static void mtlSetAttachmentWriteMask(
+			IntPtr colorAttachment,
+			int mask
+		) {
+			objc_msgSend(colorAttachment, selSetWriteMask, (ulong) mask);
+		}
+
+		#endregion
+
+		#region MTLRenderPassDescriptor
+
+		private static IntPtr selRenderPassDescriptor = Selector("renderPassDescriptor");
+		private static IntPtr mtlMakeRenderPassDescriptor()
+		{
+			return intptr_objc_msgSend(classRenderPassDescriptor, selRenderPassDescriptor);
+		}
+
+		private static IntPtr selSetVisibilityBuffer = Selector("setVisibilityResultBuffer:");
+		private static void mtlSetVisibilityResultBuffer(
+			IntPtr renderPassDesc,
+			IntPtr buffer
+		) {
+			objc_msgSend(renderPassDesc, selSetVisibilityBuffer, buffer);
+		}
+
+		#endregion
+
+		#region MTLRenderCommandEncoder
+
+		private static IntPtr selSetBlendColor = Selector("setBlendColorRed:green:blue:alpha:");
+		private static void mtlSetBlendColor(
+			IntPtr renderCommandEncoder,
+			float red,
+			float green,
+			float blue,
+			float alpha
+		) {
+			objc_msgSend(renderCommandEncoder, selSetBlendColor, red, green, blue, alpha);
+		}
+
+		private static IntPtr selSetStencilReference = Selector("setStencilReferenceValue:");
+		private static void mtlSetStencilReferenceValue(
+			IntPtr renderCommandEncoder,
+			uint referenceValue
+		) {
+			objc_msgSend(renderCommandEncoder, selSetStencilReference, referenceValue);
+		}
+
+		private static IntPtr selSetViewport = Selector("setViewport:");
+		private static void mtlSetViewport(
+			IntPtr renderCommandEncoder,
+			int x,
+			int y,
+			int w,
+			int h,
+			double minDepth,
+			double maxDepth
+		) {
+			MTLViewport viewport = new MTLViewport(x, y, w, h, minDepth, maxDepth);
+			objc_msgSend(renderCommandEncoder, selSetViewport, viewport);
+		}
+
+		private static IntPtr selSetScissorRect = Selector("setScissorRect:");
+		private static void mtlSetScissorRect(
+			IntPtr renderCommandEncoder,
+			int x,
+			int y,
+			int w,
+			int h
+		) {
+			MTLScissorRect rect = new MTLScissorRect(x, y, w, h);
+			objc_msgSend(renderCommandEncoder, selSetScissorRect, rect);
+		}
+
+		private static IntPtr selEndEncoding = Selector("endEncoding");
+		private static void mtlEndEncoding(IntPtr commandEncoder)
+		{
+			objc_msgSend(commandEncoder, selEndEncoding);
+		}
+
+		private static IntPtr selDrawIndexedPrimitives = Selector("drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:");
+		private static void mtlDrawIndexedPrimitives(
+			IntPtr renderCommandEncoder,
+			MTLPrimitiveType primitiveType,
+			int indexCount,
+			MTLIndexType indexType,
+			IntPtr indexBuffer,
+			int indexBufferOffset,
+			int instanceCount
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selDrawIndexedPrimitives,
+				(ulong) primitiveType,
+				(ulong) indexCount,
+				(ulong) indexType,
+				indexBuffer,
+				(ulong) indexBufferOffset,
+				(ulong) instanceCount
+			);
+		}
+
+		private static IntPtr selDrawPrimitives = Selector("drawPrimitives:vertexStart:vertexCount:");
+		private static void mtlDrawPrimitives(
+			IntPtr renderCommandEncoder,
+			MTLPrimitiveType primitive,
+			int vertexStart,
+			int vertexCount
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selDrawPrimitives,
+				(ulong) primitive,
+				(ulong) vertexStart,
+				(ulong) vertexCount
+			);
+		}
+
+		private static IntPtr selSetCullMode = Selector("setCullMode:");
+		private static void mtlSetCullMode(
+			IntPtr renderCommandEncoder,
+			MTLCullMode cullMode
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetCullMode,
+				(ulong) cullMode
+			);
+		}
+
+		private static IntPtr selSetTriangleFillMode = Selector("setTriangleFillMode:");
+		private static void mtlSetTriangleFillMode(
+			IntPtr renderCommandEncoder,
+			MTLTriangleFillMode fillMode
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetTriangleFillMode,
+				(ulong) fillMode
+			);
+		}
+
+		private static IntPtr selSetDepthBias = Selector("setDepthBias:slopeScale:clamp:");
+		private static void mtlSetDepthBias(
+			IntPtr renderCommandEncoder,
+			float depthBias,
+			float slopeScaleDepthBias,
+			float clamp
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetDepthBias,
+				depthBias,
+				slopeScaleDepthBias,
+				clamp
+			);
+		}
+
+		private static IntPtr selSetDepthStencilState = Selector("setDepthStencilState:");
+		private static void mtlSetDepthStencilState(
+			IntPtr renderCommandEncoder,
+			IntPtr depthStencilState
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetDepthStencilState,
+				depthStencilState
+			);
+		}
+
+		private static IntPtr selInsertDebugSignpost = Selector("insertDebugSignpost:");
+		private static void mtlInsertDebugSignpost(
+			IntPtr renderCommandEncoder,
+			string message
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selInsertDebugSignpost,
+				UTF8ToNSString(message)
+			);
+		}
+
+		private static IntPtr selSetRenderPipelineState = Selector("setRenderPipelineState:");
+		private static void mtlSetRenderPipelineState(
+			IntPtr renderCommandEncoder,
+			IntPtr pipelineState
+		) {
+			objc_msgSend(renderCommandEncoder, selSetRenderPipelineState, pipelineState);
+		}
+
+		private static IntPtr selSetVertexBuffer = Selector("setVertexBuffer:offset:atIndex:");
+		private static void mtlSetVertexBuffer(
+			IntPtr renderCommandEncoder,
+			IntPtr vertexBuffer,
+			int offset,
+			int index
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetVertexBuffer,
+				vertexBuffer,
+				(ulong) offset,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetVertexBufferOffset = Selector("setVertexBufferOffset:atIndex:");
+		private static void mtlSetVertexBufferOffset(
+			IntPtr renderCommandEncoder,
+			int offset,
+			int index
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetVertexBufferOffset,
+				(ulong) offset,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetFragmentBuffer = Selector("setFragmentBuffer:offset:atIndex:");
+		private static void mtlSetFragmentBuffer(
+			IntPtr renderCommandEncoder,
+			IntPtr fragmentBuffer,
+			int offset,
+			int index
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetFragmentBuffer,
+				fragmentBuffer,
+				(ulong) offset,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetFragmentBufferOffset = Selector("setFragmentBufferOffset:atIndex:");
+		private static void mtlSetFragmentBufferOffset(
+			IntPtr renderCommandEncoder,
+			int offset,
+			int index
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetFragmentBufferOffset,
+				(ulong) offset,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetFragmentTexture = Selector("setFragmentTexture:atIndex:");
+		private static void mtlSetFragmentTexture(
+			IntPtr renderCommandEncoder,
+			IntPtr fragmentTexture,
+			int index
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetFragmentTexture,
+				fragmentTexture,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetFragmentSamplerState = Selector("setFragmentSamplerState:atIndex:");
+		private static void mtlSetFragmentSamplerState(
+			IntPtr renderCommandEncoder,
+			IntPtr samplerState,
+			int index
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetFragmentSamplerState,
+				samplerState,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetVisibilityResultMode = Selector("setVisibilityResultMode:offset:");
+		private static void mtlSetVisibilityResultMode(
+			IntPtr renderCommandEncoder,
+			MTLVisibilityResultMode mode,
+			int offset
+		) {
+			objc_msgSend(
+				renderCommandEncoder,
+				selSetVisibilityResultMode,
+				(ulong) mode,
+				(ulong) offset
+			);
+		}
+
+		#endregion
+
+		#region CAMetalLayer
+
+		private static IntPtr selLayer = Selector("layer");
+		private static IntPtr mtlGetLayer(IntPtr view)
+		{
+			return intptr_objc_msgSend(view, selLayer);
+		}
+
+		private static IntPtr selSetDevice = Selector("setDevice:");
+		private static void mtlSetLayerDevice(IntPtr layer, IntPtr device)
+		{
+			objc_msgSend(layer, selSetDevice, device);
+		}
+
+		private static IntPtr selNextDrawable = Selector("nextDrawable");
+		private static IntPtr mtlNextDrawable(IntPtr layer)
+		{
+			return intptr_objc_msgSend(layer, selNextDrawable);
+		}
+
+		private static IntPtr selPixelFormat = Selector("pixelFormat");
+		private static MTLPixelFormat mtlGetLayerPixelFormat(IntPtr layer)
+		{
+			return (MTLPixelFormat) ulong_objc_msgSend(layer, selPixelFormat);
+		}
+
+		private static IntPtr selDrawableSize = Selector("drawableSize");
+		private static CGSize mtlGetDrawableSize(IntPtr layer)
+		{
+			return (CGSize) cgsize_objc_msgSend(layer, selDrawableSize);
+		}
+
+		private static IntPtr selDisplaySyncEnabled = Selector("setDisplaySyncEnabled:");
+		private static void mtlSetDisplaySyncEnabled(
+			IntPtr layer,
+			bool enabled
+		) {
+			objc_msgSend(layer, selDisplaySyncEnabled, enabled);
+		}
+
+		private static IntPtr selSetFramebufferOnly = Selector("setFramebufferOnly:");
+		private static void mtlSetLayerFramebufferOnly(
+			IntPtr layer,
+			bool framebufferOnly
+		) {
+			objc_msgSend(layer, selSetFramebufferOnly, framebufferOnly);
+		}
+
+		private static IntPtr selSetMagnificationFilter = Selector("setMagnificationFilter:");
+		private static void mtlSetLayerMagnificationFilter(
+			IntPtr layer,
+			IntPtr val
+		) {
+			objc_msgSend(layer, selSetMagnificationFilter, val);
+		}
+
+		#endregion
+
+		#region CAMetalDrawable
+
+		private static IntPtr selTexture = Selector("texture");
+		private static IntPtr mtlGetTextureFromDrawable(IntPtr drawable)
+		{
+			return intptr_objc_msgSend(drawable, selTexture);
+		}
+
+		#endregion
+
+		#region MTLTextureDescriptor
+
+		private static IntPtr selTexture2DDescriptor = Selector("texture2DDescriptorWithPixelFormat:width:height:mipmapped:");
+		private static IntPtr mtlMakeTexture2DDescriptor(
+			MTLPixelFormat pixelFormat,
+			int width,
+			int height,
+			bool mipmapped
+		) {
+			return intptr_objc_msgSend(
+				classTextureDescriptor,
+				selTexture2DDescriptor,
+				pixelFormat,
+				(ulong) width,
+				(ulong) height,
+				mipmapped
+			);
+		}
+
+		private static IntPtr selTextureCubeDescriptor = Selector("textureCubeDescriptorWithPixelFormat:size:mipmapped:");
+		private static IntPtr mtlMakeTextureCubeDescriptor(
+			MTLPixelFormat pixelFormat,
+			int size,
+			bool mipmapped
+		) {
+			return intptr_objc_msgSend(
+				classTextureDescriptor,
+				selTextureCubeDescriptor,
+				pixelFormat,
+				(ulong) size,
+				mipmapped
+			);
+		}
+
+		private static IntPtr selSetUsage = Selector("setUsage:");
+		private static void mtlSetTextureUsage(
+			IntPtr texDesc,
+			MTLTextureUsage usage
+		) {
+			objc_msgSend(texDesc, selSetUsage, (ulong) usage);
+		}
+
+		private static IntPtr selSetTextureType = Selector("setTextureType:");
+		private static void mtlSetTextureType(
+			IntPtr texDesc,
+			MTLTextureType type
+		) {
+			objc_msgSend(texDesc, selSetTextureType, (ulong) type);
+		}
+
+		private static IntPtr selSetSampleCount = Selector("setSampleCount:");
+		private static void mtlSetTextureSampleCount(
+			IntPtr texDesc,
+			int sampleCount
+		) {
+			objc_msgSend(texDesc, selSetSampleCount, (ulong) sampleCount);
+		}
+
+		private static IntPtr selSetDepth = Selector("setDepth:");
+		private static void mtlSetTextureDepth(
+			IntPtr texDesc,
+			int depth
+		) {
+			objc_msgSend(texDesc, selSetDepth, (ulong) depth);
+		}
+
+		#endregion
+
+		#region MTLTexture
+
+		private static IntPtr selReplaceRegion = Selector("replaceRegion:mipmapLevel:slice:withBytes:bytesPerRow:bytesPerImage:");
+		private static void mtlReplaceRegion(
+			IntPtr texture,
+			MTLRegion region,
+			int level,
+			int slice,
+			IntPtr pixelBytes,
+			int bytesPerRow,
+			int bytesPerImage
+		) {
+			objc_msgSend(
+				texture,
+				selReplaceRegion,
+				region,
+				(ulong) level,
+				(ulong) slice,
+				pixelBytes,
+				(ulong) bytesPerRow,
+				(ulong) bytesPerImage
+			);
+		}
+
+		private static IntPtr selGetBytes = Selector("getBytes:bytesPerRow:bytesPerImage:fromRegion:mipmapLevel:slice:");
+		private static void mtlGetTextureBytes(
+			IntPtr texture,
+			IntPtr pixelBytes,
+			int bytesPerRow,
+			int bytesPerImage,
+			MTLRegion region,
+			int level,
+			int slice
+		) {
+			objc_msgSend(
+				texture,
+				selGetBytes,
+				pixelBytes,
+				(ulong) bytesPerRow,
+				(ulong) bytesPerImage,
+				region,
+				(ulong) level,
+				(ulong) slice
+			);
+		}
+
+		private static IntPtr selWidth = Selector("width");
+		private static ulong mtlGetTextureWidth(IntPtr texture)
+		{
+			return ulong_objc_msgSend(texture, selWidth);
+		}
+
+		private static IntPtr selHeight = Selector("height");
+		private static ulong mtlGetTextureHeight(IntPtr texture)
+		{
+			return ulong_objc_msgSend(texture, selHeight);
+		}
+
+		private static IntPtr selSetPurgeableState = Selector("setPurgeableState:");
+		private static MTLPurgeableState mtlSetPurgeableState(
+			IntPtr resource,
+			MTLPurgeableState state
+		) {
+			return (MTLPurgeableState) ulong_objc_msgSend(
+				resource,
+				selSetPurgeableState,
+				(ulong) state
+			);
+		}
+
+		#region MTLBlitCommandEncoder
+
+		private static IntPtr selBlitCommandEncoder = Selector("blitCommandEncoder");
+		private static IntPtr mtlMakeBlitCommandEncoder(IntPtr commandBuffer)
+		{
+			return intptr_objc_msgSend(commandBuffer, selBlitCommandEncoder);
+		}
+
+		private static IntPtr selCopyFromTexture = Selector("copyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:");
+		private static void mtlBlitTextureToTexture(
+			IntPtr blitCommandEncoder,
+			IntPtr srcTexture,
+			int srcSlice,
+			int srcLevel,
+			MTLOrigin srcOrigin,
+			MTLSize srcSize,
+			IntPtr dstTexture,
+			int dstSlice,
+			int dstLevel,
+			MTLOrigin dstOrigin
+		) {
+			objc_msgSend(
+				blitCommandEncoder,
+				selCopyFromTexture,
+				srcTexture,
+				(ulong) srcSlice,
+				(ulong) srcLevel,
+				srcOrigin,
+				srcSize,
+				dstTexture,
+				(ulong) dstSlice,
+				(ulong) dstLevel,
+				dstOrigin
+			);
+		}
+
+		private static IntPtr selSynchronizeResource = Selector("synchronizeResource:");
+		private static void mtlSynchronizeResource(
+			IntPtr blitCommandEncoder,
+			IntPtr resource
+		) {
+			objc_msgSend(blitCommandEncoder, selSynchronizeResource, resource);
+		}
+
+		private static IntPtr selGenerateMipmaps = Selector("generateMipmapsForTexture:");
+		private static void mtlGenerateMipmapsForTexture(
+			IntPtr blitCommandEncoder,
+			IntPtr texture
+		) {
+			objc_msgSend(blitCommandEncoder, selGenerateMipmaps, texture);
+		}
+
+		#endregion
+
+		#region MTLRenderPipelineState
+
+		private static IntPtr selNew = Selector("new");
+		private static IntPtr mtlNewRenderPipelineDescriptor()
+		{
+			return intptr_objc_msgSend(classRenderPipelineDescriptor, selNew);
+		}
+
+		private static IntPtr selSetVertexFunction = Selector("setVertexFunction:");
+		private static void mtlSetPipelineVertexFunction(
+			IntPtr pipelineDescriptor,
+			IntPtr vertexFunction
+		) {
+			objc_msgSend(pipelineDescriptor, selSetVertexFunction, vertexFunction);
+		}
+
+		private static IntPtr selSetFragmentFunction = Selector("setFragmentFunction:");
+		private static void mtlSetPipelineFragmentFunction(
+			IntPtr pipelineDescriptor,
+			IntPtr fragmentFunction
+		) {
+			objc_msgSend(pipelineDescriptor, selSetFragmentFunction, fragmentFunction);
+		}
+
+		private static IntPtr selSetVertexDescriptor = Selector("setVertexDescriptor:");
+		private static void mtlSetPipelineVertexDescriptor(
+			IntPtr pipelineDescriptor,
+			IntPtr vertexDescriptor
+		) {
+			objc_msgSend(pipelineDescriptor, selSetVertexDescriptor, vertexDescriptor);
+		}
+
+		private static IntPtr selNewRenderPipelineState = Selector("newRenderPipelineStateWithDescriptor:error:");
+		private static IntPtr mtlNewRenderPipelineStateWithDescriptor(
+			IntPtr device,
+			IntPtr pipelineDescriptor
+		) {
+			IntPtr error = IntPtr.Zero;
+			IntPtr pipeline = intptr_objc_msgSend(
+				device,
+				selNewRenderPipelineState,
+				pipelineDescriptor,
+				out error
+			);
+			if (error != IntPtr.Zero)
+			{
+				throw new Exception("Metal Error: " + GetNSErrorDescription(error));
+			}
+			return pipeline;
+		}
+
+		private static IntPtr selSetDepthAttachmentPixelFormat = Selector("setDepthAttachmentPixelFormat:");
+		private static void mtlSetDepthAttachmentPixelFormat(
+			IntPtr pipelineDescriptor,
+			MTLPixelFormat format
+		) {
+			objc_msgSend(pipelineDescriptor, selSetDepthAttachmentPixelFormat, (ulong) format);
+		}
+
+		private static IntPtr selSetStencilAttachmentPixelFormat = Selector("setStencilAttachmentPixelFormat:");
+		private static void mtlSetStencilAttachmentPixelFormat(
+			IntPtr pipelineDescriptor,
+			MTLPixelFormat format
+		) {
+			objc_msgSend(pipelineDescriptor, selSetStencilAttachmentPixelFormat, (ulong) format);
+		}
+
+		private static void mtlSetPipelineSampleCount(
+			IntPtr pipelineDescriptor,
+			int sampleCount
+		) {
+			objc_msgSend(pipelineDescriptor, selSetSampleCount, (ulong) sampleCount);
+		}
+
+		#endregion
+
+		#region Sampler Descriptor
+
+		// selNew already defined
+		private static IntPtr mtlNewSamplerDescriptor()
+		{
+			return intptr_objc_msgSend(classMTLSamplerDescriptor, selNew);
+		}
+
+		private static IntPtr selSetMinFilter = Selector("setMinFilter:");
+		private static void mtlSetSamplerMinFilter(
+			IntPtr samplerDesc,
+			MTLSamplerMinMagFilter filter
+		) {
+			objc_msgSend(samplerDesc, selSetMinFilter, (uint) filter);
+		}
+
+		private static IntPtr selSetMagFilter = Selector("setMagFilter:");
+		private static void mtlSetSamplerMagFilter(
+			IntPtr samplerDesc,
+			MTLSamplerMinMagFilter filter
+		) {
+			objc_msgSend(samplerDesc, selSetMagFilter, (uint) filter);
+		}
+
+		private static IntPtr selSetMipFilter = Selector("setMipFilter:");
+		private static void mtlSetSamplerMipFilter(
+			IntPtr samplerDesc,
+			MTLSamplerMipFilter filter
+		) {
+			objc_msgSend(samplerDesc, selSetMipFilter, (uint) filter);
+		}
+
+		private static IntPtr selSetLodMinClamp = Selector("setLodMinClamp:");
+		private static void mtlSetSamplerLodMinClamp(
+			IntPtr samplerDesc,
+			float clamp
+		) {
+			objc_msgSend(samplerDesc, selSetLodMinClamp, clamp);
+		}
+
+		private static IntPtr selSetMaxAnisotropy = Selector("setMaxAnisotropy:");
+		private static void mtlSetSamplerMaxAnisotropy(
+			IntPtr samplerDesc,
+			int maxAnisotropy
+		) {
+			objc_msgSend(samplerDesc, selSetMaxAnisotropy, (ulong) maxAnisotropy);
+		}
+
+		private static IntPtr selSetRAddressMode = Selector("setRAddressMode:");
+		private static void mtlSetSampler_rAddressMode(
+			IntPtr samplerDesc,
+			MTLSamplerAddressMode mode
+		) {
+			objc_msgSend(samplerDesc, selSetRAddressMode, (ulong) mode);
+		}
+
+		private static IntPtr selSetSAddressMode = Selector("setSAddressMode:");
+		private static void mtlSetSampler_sAddressMode(
+			IntPtr samplerDesc,
+			MTLSamplerAddressMode mode
+		) {
+			objc_msgSend(samplerDesc, selSetSAddressMode, (ulong) mode);
+		}
+		
+		private static IntPtr selSetTAddressMode = Selector("setTAddressMode:");
+		private static void mtlSetSampler_tAddressMode(
+			IntPtr samplerDesc,
+			MTLSamplerAddressMode mode
+		) {
+			objc_msgSend(samplerDesc, selSetTAddressMode, (ulong) mode);
+		}
+
+		#endregion
+
+		#region Vertex Descriptor
+
+		private static IntPtr selVertexDescriptor = Selector("vertexDescriptor");
+		private static IntPtr mtlMakeVertexDescriptor()
+		{
+			return intptr_objc_msgSend(classMTLVertexDescriptor, selVertexDescriptor);
+		}
+
+		private static IntPtr selAttributes = Selector("attributes");
+		private static IntPtr mtlGetVertexAttributeDescriptor(
+			IntPtr vertexDesc,
+			int index
+		) {
+			IntPtr attributes = intptr_objc_msgSend(
+				vertexDesc,
+				selAttributes
+			);
+
+			return intptr_objc_msgSend(
+				attributes, 
+				selObjectAtIndexedSubscript,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetFormat = Selector("setFormat:");
+		private static void mtlSetVertexAttributeFormat(
+			IntPtr vertexAttribute,
+			MTLVertexFormat format
+		) {
+			objc_msgSend(vertexAttribute, selSetFormat, (ulong) format);
+		}
+
+		private static IntPtr selSetOffset = Selector("setOffset:");
+		private static void mtlSetVertexAttributeOffset(
+			IntPtr vertexAttribute,
+			int offset
+		) {
+			objc_msgSend(vertexAttribute, selSetOffset, (ulong) offset);
+		}
+
+		private static IntPtr selSetBufferIndex = Selector("setBufferIndex:");
+		private static void mtlSetVertexAttributeBufferIndex(
+			IntPtr vertexAttribute,
+			int bufferIndex
+		) {
+			objc_msgSend(vertexAttribute, selSetBufferIndex, (ulong) bufferIndex);
+		}
+
+		private static IntPtr selLayouts = Selector("layouts");
+		private static IntPtr mtlGetVertexBufferLayoutDescriptor(
+			IntPtr vertexDesc,
+			int index
+		) {
+			IntPtr layouts = intptr_objc_msgSend(
+				vertexDesc,
+				selLayouts
+			);
+
+			return intptr_objc_msgSend(
+				layouts, 
+				selObjectAtIndexedSubscript,
+				(ulong) index
+			);
+		}
+
+		private static IntPtr selSetStride = Selector("setStride:");
+		private static void mtlSetVertexBufferLayoutStride(
+			IntPtr vertexBufferLayout,
+			int stride
+		) {
+			objc_msgSend(vertexBufferLayout, selSetStride, (ulong) stride);
+		}
+
+		private static IntPtr selSetStepFunction = Selector("setStepFunction:");
+		private static void mtlSetVertexBufferLayoutStepFunction(
+			IntPtr vertexBufferLayout,
+			MTLVertexStepFunction stepFunc
+		) {
+			objc_msgSend(vertexBufferLayout, selSetStepFunction, (ulong) stepFunc);
+		}
+
+		private static IntPtr selSetStepRate = Selector("setStepRate:");
+		private static void mtlSetVertexBufferLayoutStepRate(
+			IntPtr vertexBufferLayout,
+			int stepRate
+		) {
+			objc_msgSend(vertexBufferLayout, selSetStepRate, (ulong) stepRate);
+		}
+
+		#endregion
+
+		#region Storage Modes
+
+		private static IntPtr selSetStorageMode = Selector("setStorageMode:");
+		private static void mtlSetStorageMode(
+			IntPtr resource,
+			MTLStorageMode mode
+		) {
+			objc_msgSend(resource, selSetStorageMode, (ulong) mode);
+		}
+
+		#endregion
+
+		#region MTLLibrary
+
+		private static IntPtr selNewLibraryWithSource = Selector("newLibraryWithSource:options:error:");
+		private static IntPtr mtlNewLibraryWithSource(
+			IntPtr device,
+			IntPtr shaderSourceNSString,
+			IntPtr compileOptions
+		) {
+			IntPtr error = IntPtr.Zero;
+			IntPtr library = intptr_objc_msgSend(
+				device,
+				selNewLibraryWithSource,
+				shaderSourceNSString,
+				compileOptions,
+				out error
+			);
+			if (error != IntPtr.Zero)
+			{
+				throw new Exception("Metal Error: " + GetNSErrorDescription(error));
+			}
+			return library;
+		}
+
+		private static IntPtr selNewFunctionWithName = Selector("newFunctionWithName:");
+		private static IntPtr mtlNewFunctionWithName(
+			IntPtr library,
+			IntPtr shaderNameNSString
+		) {
+			return intptr_objc_msgSend(
+				library,
+				selNewFunctionWithName,
+				shaderNameNSString
+			);
+		}
+
+		#endregion
+
+		#region Depth-Stencil State
+
+		private static IntPtr mtlNewDepthStencilDescriptor()
+		{
+			return intptr_objc_msgSend(classDepthStencilDescriptor, selNew);
+		}
+
+		private static IntPtr mtlNewStencilDescriptor()
+		{
+			return intptr_objc_msgSend(classStencilDescriptor, selNew);
+		}
+
+		private static IntPtr selSetDepthCompareFunction = Selector("setDepthCompareFunction:");
+		private static void mtlSetDepthCompareFunction(
+			IntPtr depthStencilDescriptor,
+			MTLCompareFunction func
+		) {
+			objc_msgSend(depthStencilDescriptor, selSetDepthCompareFunction, (ulong) func);
+		}
+
+		private static IntPtr selSetDepthWriteEnabled = Selector("setDepthWriteEnabled:");
+		private static void mtlSetDepthWriteEnabled(
+			IntPtr depthStencilDescriptor,
+			bool enabled
+		) {
+			objc_msgSend(depthStencilDescriptor, selSetDepthWriteEnabled, enabled);
+		}
+
+		private static IntPtr selSetBackFaceStencil = Selector("setBackFaceStencil:");
+		private static void mtlSetBackFaceStencil(
+			IntPtr depthStencilDescriptor,
+			IntPtr stencilDescriptor
+		) {
+			objc_msgSend(depthStencilDescriptor, selSetBackFaceStencil, stencilDescriptor);
+		}
+
+		private static IntPtr selSetFrontFaceStencil = Selector("setFrontFaceStencil:");
+		private static void mtlSetFrontFaceStencil(
+			IntPtr depthStencilDescriptor,
+			IntPtr stencilDescriptor
+		) {
+			objc_msgSend(depthStencilDescriptor, selSetFrontFaceStencil, stencilDescriptor);
+		}
+
+		private static IntPtr selNewDepthStencilStateWithDescriptor = Selector("newDepthStencilStateWithDescriptor:");
+		private static IntPtr mtlNewDepthStencilStateWithDescriptor(
+			IntPtr device,
+			IntPtr descriptor
+		) {
+			return intptr_objc_msgSend(
+				device,
+				selNewDepthStencilStateWithDescriptor,
+				descriptor
+			);
+		}
+
+		private static IntPtr selSetStencilFailureOperation = Selector("setStencilFailureOperation:");
+		private static void mtlSetStencilFailureOperation(
+			IntPtr stencilDescriptor,
+			MTLStencilOperation op
+		) {
+			objc_msgSend(stencilDescriptor, selSetStencilFailureOperation, (ulong) op);
+		}
+
+		private static IntPtr selSetDepthFailureOperation = Selector("setDepthFailureOperation:");
+		private static void mtlSetDepthFailureOperation(
+			IntPtr stencilDescriptor,
+			MTLStencilOperation op
+		) {
+			objc_msgSend(stencilDescriptor, selSetDepthFailureOperation, (ulong) op);
+		}
+
+		private static IntPtr selSetDepthStencilPassOperation = Selector("setDepthStencilPassOperation:");
+		private static void mtlSetDepthStencilPassOperation(
+			IntPtr stencilDescriptor,
+			MTLStencilOperation op
+		) {
+			objc_msgSend(stencilDescriptor, selSetDepthStencilPassOperation, (ulong) op);
+		}
+
+		private static IntPtr selSetStencilCompareFunction = Selector("setStencilCompareFunction:");
+		private static void mtlSetStencilCompareFunction(
+			IntPtr stencilDescriptor,
+			MTLCompareFunction func
+		) {
+			objc_msgSend(stencilDescriptor, selSetStencilCompareFunction, (ulong) func);
+		}
+
+		private static IntPtr selSetStencilReadMask = Selector("setReadMask:");
+		private static void mtlSetStencilReadMask(
+			IntPtr stencilDescriptor,
+			uint mask
+		) {
+			objc_msgSend(stencilDescriptor, selSetStencilReadMask, mask);
+		}
+
+		private static IntPtr selSetStencilWriteMask = Selector("setWriteMask:");
+		private static void mtlSetStencilWriteMask(
+			IntPtr stencilDescriptor,
+			uint mask
+		) {
+			objc_msgSend(stencilDescriptor, selSetStencilWriteMask, mask);
+		}
+
+		#endregion
+
+		#region Error Handling
+
+		private static IntPtr selLocalizedDescription = Selector("localizedDescription");
+		private static string GetNSErrorDescription(IntPtr error)
+		{
+			return NSStringToUTF8(intptr_objc_msgSend(error, selLocalizedDescription));
+		}
+
+		#endregion
+
+		#endregion
+	}
+}

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 
 				/* SPIR-V is very new and not really necessary. */
-				if (shaderProfile == "spirv" && !useCoreProfile)
+				if (shaderProfile == "glspirv" && !useCoreProfile)
 				{
 					shaderProfile = "glsl120";
 				}

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -641,6 +641,12 @@ namespace Microsoft.Xna.Framework.Graphics
 					null,
 					IntPtr.Zero
 				);
+
+				/* SPIR-V is very new and not really necessary. */
+				if (shaderProfile == "spirv" && !useCoreProfile)
+				{
+					shaderProfile = "glsl120";
+				}
 			}
 			shaderContext = MojoShader.MOJOSHADER_glCreateContext(
 				shaderProfile,

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -4131,18 +4131,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			public static readonly int[] VertexAttribSize = new int[]
 			{
-					1,	// VertexElementFormat.Single
-					2,	// VertexElementFormat.Vector2
-					3,	// VertexElementFormat.Vector3
-					4,	// VertexElementFormat.Vector4
-					4,	// VertexElementFormat.Color
-					4,	// VertexElementFormat.Byte4
-					2,	// VertexElementFormat.Short2
-					4,	// VertexElementFormat.Short4
-					2,	// VertexElementFormat.NormalizedShort2
-					4,	// VertexElementFormat.NormalizedShort4
-					2,	// VertexElementFormat.HalfVector2
-					4	// VertexElementFormat.HalfVector4
+				1,	// VertexElementFormat.Single
+				2,	// VertexElementFormat.Vector2
+				3,	// VertexElementFormat.Vector3
+				4,	// VertexElementFormat.Vector4
+				4,	// VertexElementFormat.Color
+				4,	// VertexElementFormat.Byte4
+				2,	// VertexElementFormat.Short2
+				4,	// VertexElementFormat.Short4
+				2,	// VertexElementFormat.NormalizedShort2
+				4,	// VertexElementFormat.NormalizedShort4
+				2,	// VertexElementFormat.HalfVector2
+				4	// VertexElementFormat.HalfVector4
 			};
 
 			public static readonly GLenum[] VertexAttribType = new GLenum[]

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -558,27 +558,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region memcpy Export
-
-		/* This is used a lot for GetData/Read calls... -flibit */
-#if NETSTANDARD2_0
-		private static unsafe void memcpy(IntPtr dst, IntPtr src, IntPtr len)
-		{
-			long size = len.ToInt64();
-			Buffer.MemoryCopy(
-				(void*) src,
-				(void*) dst,
-				size,
-				size
-			);
-		}
-#else
-		[DllImport("msvcrt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void memcpy(IntPtr dst, IntPtr src, IntPtr len);
-#endif
-
-		#endregion
-
 		#region Public Constructor
 
 		public ModernGLDevice(
@@ -2406,7 +2385,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 			}
 
-			memcpy(
+			SDL.SDL_memcpy(
 				buf.Pin + offsetInBytes,
 				data,
 				(IntPtr) dataLength
@@ -2463,7 +2442,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 			}
 
-			memcpy(
+			SDL.SDL_memcpy(
 				buf.Pin + offsetInBytes,
 				data,
 				(IntPtr) dataLength
@@ -2500,7 +2479,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				/* Buffers can't get written to by anyone other than the
 				 * application, so we can just memcpy here... right?
 				 */
-				memcpy(
+				SDL.SDL_memcpy(
 					cpy,
 					buf.Pin + offsetInBytes,
 					(IntPtr) (elementCount * elementSizeInBytes)
@@ -2528,7 +2507,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				IntPtr dst = data + (startIndex * elementSizeInBytes);
 				for (int i = 0; i < elementCount; i += 1)
 				{
-					memcpy(dst, src, (IntPtr) elementSizeInBytes);
+					SDL.SDL_memcpy(dst, src, (IntPtr) elementSizeInBytes);
 					dst += elementSizeInBytes;
 					src += vertexStride;
 				}
@@ -2550,7 +2529,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				/* Buffers can't get written to by anyone other than the
 				 * application, so we can just memcpy here... right?
 				 */
-				memcpy(
+				SDL.SDL_memcpy(
 					data + (startIndex * elementSizeInBytes),
 					(buffer as ModernGLBuffer).Pin + offsetInBytes,
 					(IntPtr) (elementCount * elementSizeInBytes)
@@ -3242,9 +3221,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			for (int row = 0; row < subH / 2; row += 1)
 			{
 				// Top to temp, bottom to top, temp to bottom
-				memcpy(temp, data + (row * pitch), (IntPtr) pitch);
-				memcpy(data + (row * pitch), data + ((subH - row - 1) * pitch), (IntPtr) pitch);
-				memcpy(data + ((subH - row - 1) * pitch), temp, (IntPtr) pitch);
+				SDL.SDL_memcpy(temp, data + (row * pitch), (IntPtr) pitch);
+				SDL.SDL_memcpy(data + (row * pitch), data + ((subH - row - 1) * pitch), (IntPtr) pitch);
+				SDL.SDL_memcpy(data + ((subH - row - 1) * pitch), temp, (IntPtr) pitch);
 			}
 			Marshal.FreeHGlobal(temp);
 		}

--- a/src/FNAPlatform/ModernGLDevice.cs
+++ b/src/FNAPlatform/ModernGLDevice.cs
@@ -905,6 +905,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region BeginFrame Method
+
+		public void BeginFrame()
+		{
+			// Do nothing.
+		}
+
+		#endregion
+
 		#region Window SwapBuffers Method
 
 		public void SwapBuffers(

--- a/src/FNAPlatform/ModernGLDevice_GL.cs
+++ b/src/FNAPlatform/ModernGLDevice_GL.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -578,27 +578,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region memcpy Export
-
-		/* This is used a lot for GetData/Read calls... -flibit */
-#if NETSTANDARD2_0
-		private static unsafe void memcpy(IntPtr dst, IntPtr src, IntPtr len)
-		{
-			long size = len.ToInt64();
-			Buffer.MemoryCopy(
-				(void*) src,
-				(void*) dst,
-				size,
-				size
-			);
-		}
-#else
-		[DllImport("msvcrt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void memcpy(IntPtr dst, IntPtr src, IntPtr len);
-#endif
-
-		#endregion
-
 		#region Public Constructor
 
 		public OpenGLDevice(
@@ -2609,7 +2588,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				IntPtr dst = data + (startIndex * elementSizeInBytes);
 				for (int i = 0; i < elementCount; i += 1)
 				{
-					memcpy(dst, src, (IntPtr) elementSizeInBytes);
+					SDL.SDL_memcpy(dst, src, (IntPtr) elementSizeInBytes);
 					dst += elementSizeInBytes;
 					src += vertexStride;
 				}
@@ -3200,7 +3179,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							return;
 						}
 						// FIXME: Can we copy via pitch instead, or something? -flibit
-						memcpy(
+						SDL.SDL_memcpy(
 							data + ((curPixel - startIndex) * elementSizeInBytes),
 							texData + (((row * width) + col) * elementSizeInBytes),
 							(IntPtr) elementSizeInBytes
@@ -3299,7 +3278,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							return;
 						}
 						// FIXME: Can we copy via pitch instead, or something? -flibit
-						memcpy(
+						SDL.SDL_memcpy(
 							data + ((curPixel - startIndex) * elementSizeInBytes),
 							texData + (((row * size) + col) * elementSizeInBytes),
 							(IntPtr) elementSizeInBytes
@@ -3457,9 +3436,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			for (int row = 0; row < subH / 2; row += 1)
 			{
 				// Top to temp, bottom to top, temp to bottom
-				memcpy(temp, data + (row * pitch), (IntPtr) pitch);
-				memcpy(data + (row * pitch), data + ((subH - row - 1) * pitch), (IntPtr) pitch);
-				memcpy(data + ((subH - row - 1) * pitch), temp, (IntPtr) pitch);
+				SDL.SDL_memcpy(temp, data + (row * pitch), (IntPtr) pitch);
+				SDL.SDL_memcpy(data + (row * pitch), data + ((subH - row - 1) * pitch), (IntPtr) pitch);
+				SDL.SDL_memcpy(data + ((subH - row - 1) * pitch), temp, (IntPtr) pitch);
 			}
 			Marshal.FreeHGlobal(temp);
 		}

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -703,7 +703,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 
 				/* SPIR-V is very new and not really necessary. */
-				if (shaderProfile == "spirv")
+				if (shaderProfile == "spirv" && !useCoreProfile)
 				{
 					shaderProfile = "glsl120";
 				}

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -703,7 +703,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 
 				/* SPIR-V is very new and not really necessary. */
-				if (shaderProfile == "spirv" && !useCoreProfile)
+				if (shaderProfile == "glspirv" && !useCoreProfile)
 				{
 					shaderProfile = "glsl120";
 				}

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -967,6 +967,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region BeginFrame Method
+
+		public void BeginFrame()
+		{
+			// Do nothing.
+		}
+
+		#endregion
+
 		#region Window SwapBuffers Method
 
 		public void SwapBuffers(

--- a/src/FNAPlatform/OpenGLDevice.cs
+++ b/src/FNAPlatform/OpenGLDevice.cs
@@ -4397,18 +4397,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			public static readonly int[] VertexAttribSize = new int[]
 			{
-					1,	// VertexElementFormat.Single
-					2,	// VertexElementFormat.Vector2
-					3,	// VertexElementFormat.Vector3
-					4,	// VertexElementFormat.Vector4
-					4,	// VertexElementFormat.Color
-					4,	// VertexElementFormat.Byte4
-					2,	// VertexElementFormat.Short2
-					4,	// VertexElementFormat.Short4
-					2,	// VertexElementFormat.NormalizedShort2
-					4,	// VertexElementFormat.NormalizedShort4
-					2,	// VertexElementFormat.HalfVector2
-					4	// VertexElementFormat.HalfVector4
+				1,	// VertexElementFormat.Single
+				2,	// VertexElementFormat.Vector2
+				3,	// VertexElementFormat.Vector3
+				4,	// VertexElementFormat.Vector4
+				4,	// VertexElementFormat.Color
+				4,	// VertexElementFormat.Byte4
+				2,	// VertexElementFormat.Short2
+				4,	// VertexElementFormat.Short4
+				2,	// VertexElementFormat.NormalizedShort2
+				4,	// VertexElementFormat.NormalizedShort4
+				2,	// VertexElementFormat.HalfVector2
+				4	// VertexElementFormat.HalfVector4
 			};
 
 			public static readonly GLenum[] VertexAttribType = new GLenum[]

--- a/src/FNAPlatform/OpenGLDevice_GL.cs
+++ b/src/FNAPlatform/OpenGLDevice_GL.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1411,6 +1411,7 @@ namespace Microsoft.Xna.Framework
 		{
 			if (Environment.GetEnvironmentVariable("FNA_SDL2_FORCE_BASE_PATH") != "1")
 			{
+				// If your platform uses a CLR, you want to be in this list!
 				if (	OSVersion.Equals("Windows") ||
 					OSVersion.Equals("Mac OS X") ||
 					OSVersion.Equals("Linux") ||
@@ -1418,15 +1419,6 @@ namespace Microsoft.Xna.Framework
 					OSVersion.Equals("OpenBSD") ||
 					OSVersion.Equals("NetBSD")	)
 				{
-					/* This is mostly here for legacy compatibility.
-					 * For most platforms this should be the same as
-					 * SDL_GetBasePath, but some platforms (Apple's)
-					 * will have a separate Resources folder that is
-					 * the "base" directory for applications.
-					 *
-					 * TODO: Remove this and endure the breakage.
-					 * -flibit
-					 */
 					return AppDomain.CurrentDomain.BaseDirectory;
 				}
 			}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -252,7 +252,38 @@ namespace Microsoft.Xna.Framework
 
 		private static bool PrepareMTLAttributes()
 		{
-			// Coming soon to an FNA near you!
+			if (	String.IsNullOrEmpty(ForcedGLDevice) ||
+				!ForcedGLDevice.Equals(METAL)		)
+			{
+				return false;
+			}
+
+			if (OSVersion.Equals("Mac OS X"))
+			{
+				// Let's find out if the OS supports Metal...
+				try
+				{
+					if (MetalDevice.MTLCreateSystemDefaultDevice() != IntPtr.Zero)
+					{
+						// We're good to go!
+						return true;
+					}
+				}
+				catch
+				{
+					// The OS is too old for Metal!
+					return false;
+				}
+			}
+			else if (OSVersion.Equals("iOS") || OSVersion.Equals("tvOS"))
+			{
+				/* We only support iOS/tvOS 11.0+ so
+				 * Metal is guaranteed to be supported.
+				 */
+				return true;
+			}
+
+			// Oh well, to OpenGL we go!
 			return false;
 		}
 
@@ -408,7 +439,12 @@ namespace Microsoft.Xna.Framework
 			}
 			else if (metal = PrepareMTLAttributes())
 			{
-				// FIXME: SDL_WINDOW_METAL?
+				if (MetalDevice.UsingSDL2_0_11())
+				{
+					SDL.SDL_SetHint(MetalDevice.SDL_HINT_VIDEO_EXTERNAL_CONTEXT, "1");
+				}
+
+				// Metal doesn't require a window flag
 				ActualGLDevice = METAL;
 			}
 			else if (opengl = PrepareGLAttributes())
@@ -457,14 +493,33 @@ namespace Microsoft.Xna.Framework
 			// We hide the mouse cursor by default.
 			OnIsMouseVisibleChanged(false);
 
-			/* iOS and tvOS require an active GL context
-			 * to get the drawable size of the screen.
-			 * -caleb
+			/* When using OpenGL, iOS and tvOS require
+			 * an active GL context to get the drawable
+			 * size of the screen.
+			 *
+			 * When using Metal, all Apple platforms
+			 * require a view to get the drawable size.
 			 */
 			IntPtr tempContext = IntPtr.Zero;
 			if (opengl && (OSVersion.Equals("iOS") || OSVersion.Equals("tvOS")))
 			{
 				tempContext = SDL.SDL_GL_CreateContext(window);
+			}
+			else if (metal)
+			{
+				if (MetalDevice.UsingSDL2_0_11())
+				{
+					tempContext = MetalDevice.SDL_Metal_CreateView(window);
+				}
+				else
+				{
+					SDL.SDL_SetHint(SDL.SDL_HINT_RENDER_DRIVER, "metal");
+					tempContext = SDL.SDL_CreateRenderer(
+						window,
+						-1,
+						SDL.SDL_RendererFlags.SDL_RENDERER_ACCELERATED
+					);
+				}
 			}
 
 			/* If high DPI is not found, unset the HIGHDPI var.
@@ -478,8 +533,15 @@ namespace Microsoft.Xna.Framework
 			}
 			else if (metal)
 			{
-				// FIXME: This will be fixed when MetalDevice gets here.
-				drawX = drawY = 0;
+				if (MetalDevice.UsingSDL2_0_11())
+				{
+					MetalDevice.GetDrawableSizeFromView(tempContext, out drawX, out drawY);
+				}
+				else
+				{
+					IntPtr layer = SDL.SDL_RenderGetMetalLayer(tempContext);
+					MetalDevice.GetDrawableSize(layer, out drawX, out drawY);
+				}
 			}
 			else if (opengl)
 			{
@@ -504,7 +566,21 @@ namespace Microsoft.Xna.Framework
 			// We're done with that temporary context.
 			if (tempContext != IntPtr.Zero)
 			{
-				SDL.SDL_GL_DeleteContext(tempContext);
+				if (opengl)
+				{
+					SDL.SDL_GL_DeleteContext(tempContext);
+				}
+				else if (metal)
+				{
+					if (MetalDevice.UsingSDL2_0_11())
+					{
+						MetalDevice.SDL_Metal_DestroyView(tempContext);
+					}
+					else
+					{
+						SDL.SDL_DestroyRenderer(tempContext);
+					}
+				}
 			}
 
 			return new FNAWindow(
@@ -1265,7 +1341,8 @@ namespace Microsoft.Xna.Framework
 			switch (ActualGLDevice)
 			{
 			case VULKAN:	break; // Maybe some day!
-			case METAL:	break; // Coming soon!
+			case METAL:
+				return new MetalDevice(presentationParameters, adapter);
 			case MODERNGL:
 				// FIXME: This is still experimental! -flibit
 				return new ModernGLDevice(presentationParameters, adapter);

--- a/src/FNAPlatform/ThreadedGLDevice.cs
+++ b/src/FNAPlatform/ThreadedGLDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/FNAPlatform/ThreadedGLDevice.cs
+++ b/src/FNAPlatform/ThreadedGLDevice.cs
@@ -271,6 +271,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region BeginFrame Operations
+
+		public void BeginFrame()
+		{
+			ForceToMainThread(() =>
+			{
+				GLDevice.BeginFrame();
+			}); // End ForceToMainThread
+		}
+
+		#endregion
+
 		#region Backbuffer Operations
 
 		public void ResetBackbuffer(

--- a/src/FrameworkDispatcher.cs
+++ b/src/FrameworkDispatcher.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameComponent.cs
+++ b/src/GameComponent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameComponentCollection.cs
+++ b/src/GameComponentCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameComponentCollectionEventArgs.cs
+++ b/src/GameComponentCollectionEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameServiceContainer.cs
+++ b/src/GameServiceContainer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameTime.cs
+++ b/src/GameTime.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GameWindow.cs
+++ b/src/GameWindow.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ClearOptions.cs
+++ b/src/Graphics/ClearOptions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ColorWriteChannels.cs
+++ b/src/Graphics/ColorWriteChannels.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/CubeMapFace.cs
+++ b/src/Graphics/CubeMapFace.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DepthFormat.cs
+++ b/src/Graphics/DepthFormat.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DeviceLostException.cs
+++ b/src/Graphics/DeviceLostException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DeviceNotResetException.cs
+++ b/src/Graphics/DeviceNotResetException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DirectionalLight.cs
+++ b/src/Graphics/DirectionalLight.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DisplayMode.cs
+++ b/src/Graphics/DisplayMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DisplayModeCollection.cs
+++ b/src/Graphics/DisplayModeCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/DxtUtil.cs
+++ b/src/Graphics/DxtUtil.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -286,15 +286,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region Destructor
-
-		~Effect()
-		{
-			Dispose();
-		}
-
-		#endregion
-
 		#region Public Methods
 
 		public virtual Effect Clone()

--- a/src/Graphics/Effect/EffectAnnotation.cs
+++ b/src/Graphics/Effect/EffectAnnotation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectAnnotationCollection.cs
+++ b/src/Graphics/Effect/EffectAnnotationCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectMaterial.cs
+++ b/src/Graphics/Effect/EffectMaterial.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameterClass.cs
+++ b/src/Graphics/Effect/EffectParameterClass.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameterCollection.cs
+++ b/src/Graphics/Effect/EffectParameterCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectParameterType.cs
+++ b/src/Graphics/Effect/EffectParameterType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectPass.cs
+++ b/src/Graphics/Effect/EffectPass.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectPassCollection.cs
+++ b/src/Graphics/Effect/EffectPassCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectTechnique.cs
+++ b/src/Graphics/Effect/EffectTechnique.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/EffectTechniqueCollection.cs
+++ b/src/Graphics/Effect/EffectTechniqueCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/IEffectFog.cs
+++ b/src/Graphics/Effect/IEffectFog.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/IEffectLights.cs
+++ b/src/Graphics/Effect/IEffectLights.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/IEffectMatrices.cs
+++ b/src/Graphics/Effect/IEffectMatrices.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Effect/Resources.cs
+++ b/src/Graphics/Effect/Resources.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsAdapter.cs
+++ b/src/Graphics/GraphicsAdapter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsDeviceStatus.cs
+++ b/src/Graphics/GraphicsDeviceStatus.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsProfile.cs
+++ b/src/Graphics/GraphicsProfile.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -102,8 +102,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void Dispose()
 		{
-			// Dispose of managed objects as well
+			// Dispose of unmanaged objects as well
 			Dispose(true);
+
 			// Since we have been manually disposed, do not call the finalizer on this object
 			GC.SuppressFinalize(this);
 		}

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -91,9 +91,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		~GraphicsResource()
 		{
-			// Pass false so the managed objects are not released
-			// FIXME: This can lock up your game from the GC! -flibit
-			// Dispose(false);
+			// FIXME: We really should call Dispose() here! -flibit
 		}
 
 		#endregion

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				 * lifetime. But only one GraphicsDevice should
 				 * retain ownership.
 				 */
-				if (graphicsDevice != null)
+				if (graphicsDevice != null && selfReference != null)
 				{
 					graphicsDevice.RemoveResourceReference(selfReference);
 					selfReference = null;
@@ -154,13 +154,12 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 
 				// Remove from the list of graphics resources
-				if (graphicsDevice != null)
+				if (graphicsDevice != null && selfReference != null)
 				{
 					graphicsDevice.RemoveResourceReference(selfReference);
+					selfReference = null;
 				}
 
-				selfReference = null;
-				graphicsDevice = null;
 				IsDisposed = true;
 			}
 		}

--- a/src/Graphics/IGraphicsDeviceService.cs
+++ b/src/Graphics/IGraphicsDeviceService.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/IRenderTarget.cs
+++ b/src/Graphics/IRenderTarget.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Model.cs
+++ b/src/Graphics/Model.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelBone.cs
+++ b/src/Graphics/ModelBone.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelBoneCollection.cs
+++ b/src/Graphics/ModelBoneCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelEffectCollection.cs
+++ b/src/Graphics/ModelEffectCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMesh.cs
+++ b/src/Graphics/ModelMesh.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMeshCollection.cs
+++ b/src/Graphics/ModelMeshCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMeshPart.cs
+++ b/src/Graphics/ModelMeshPart.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ModelMeshPartCollection.cs
+++ b/src/Graphics/ModelMeshPartCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/NoSuitableGraphicsDeviceException.cs
+++ b/src/Graphics/NoSuitableGraphicsDeviceException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Alpha8.cs
+++ b/src/Graphics/PackedVector/Alpha8.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Bgr565.cs
+++ b/src/Graphics/PackedVector/Bgr565.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Bgra4444.cs
+++ b/src/Graphics/PackedVector/Bgra4444.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Bgra5551.cs
+++ b/src/Graphics/PackedVector/Bgra5551.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Byte4.cs
+++ b/src/Graphics/PackedVector/Byte4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfSingle.cs
+++ b/src/Graphics/PackedVector/HalfSingle.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfTypeHelper.cs
+++ b/src/Graphics/PackedVector/HalfTypeHelper.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfVector2.cs
+++ b/src/Graphics/PackedVector/HalfVector2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/HalfVector4.cs
+++ b/src/Graphics/PackedVector/HalfVector4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/IPackedVector.cs
+++ b/src/Graphics/PackedVector/IPackedVector.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedByte2.cs
+++ b/src/Graphics/PackedVector/NormalizedByte2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedByte4.cs
+++ b/src/Graphics/PackedVector/NormalizedByte4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedShort2.cs
+++ b/src/Graphics/PackedVector/NormalizedShort2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/NormalizedShort4.cs
+++ b/src/Graphics/PackedVector/NormalizedShort4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Rg32.cs
+++ b/src/Graphics/PackedVector/Rg32.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Rgba1010102.cs
+++ b/src/Graphics/PackedVector/Rgba1010102.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Rgba64.cs
+++ b/src/Graphics/PackedVector/Rgba64.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Short2.cs
+++ b/src/Graphics/PackedVector/Short2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PackedVector/Short4.cs
+++ b/src/Graphics/PackedVector/Short4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -682,6 +682,59 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Vertex Declaration Hashing Methods
+
+		/* The algorithm for these hashing methods
+		 * is taken from Josh Bloch's "Effective Java".
+		 * (https://stackoverflow.com/a/113600/12492383)
+		 *
+		 * FIXME: Is there a better way to hash this?
+		 * -caleb
+		 */
+
+		private const ulong HASH_FACTOR = 39;
+
+		public static ulong GetVertexDeclarationHash(
+			VertexDeclaration declaration,
+			ulong vertexShader
+		) {
+			ulong hash = vertexShader;
+			unchecked
+			{
+				for (int i = 0; i < declaration.elements.Length; i += 1)
+				{
+					hash = hash * HASH_FACTOR + (
+						(ulong) declaration.elements[i].GetHashCode()
+					);
+				}
+				hash = hash * HASH_FACTOR + (ulong) declaration.VertexStride;
+			}
+			return hash;
+		}
+
+		public static ulong GetVertexBindingHash(
+			VertexBufferBinding[] bindings,
+			int numBindings,
+			ulong vertexShader
+		) {
+			ulong hash = vertexShader;
+			unchecked
+			{
+				for (int i = 0; i < numBindings; i += 1)
+				{
+					VertexBufferBinding binding = bindings[i];
+					hash = hash * HASH_FACTOR + (ulong) binding.InstanceFrequency;
+					hash = hash * HASH_FACTOR + GetVertexDeclarationHash(
+						binding.VertexBuffer.VertexDeclaration,
+						vertexShader
+					);
+				}
+			}
+			return hash;
+		}
+
+		#endregion
+
 		#region Private Helper Methods
 
 		private static unsafe ulong FloatToULong(float f)

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -26,33 +26,27 @@ namespace Microsoft.Xna.Framework.Graphics
 {
 	#region Internal PSO Hash Struct
 
-	[StructLayout(LayoutKind.Sequential, Pack = 4, Size = 128)]
+	[StructLayout(LayoutKind.Sequential)]
 	internal struct StateHash : IEquatable<StateHash>
 	{
-		readonly int i1;
-		readonly int i2;
-		readonly int i3;
-		readonly int i4;
+		readonly ulong a;
+		readonly ulong b;
 
-		public StateHash(int i1, int i2, int i3, int i4)
+		public StateHash(ulong a, ulong b)
 		{
-			this.i1 = i1;
-			this.i2 = i2;
-			this.i3 = i3;
-			this.i4 = i4;
+			this.a = a;
+			this.b = b;
 		}
 
 		public override string ToString()
 		{
-			return	Convert.ToString(i1, 2).PadLeft(32, '0') +
-				Convert.ToString(i2, 2).PadLeft(32, '0') +
-				Convert.ToString(i3, 2).PadLeft(32, '0') +
-				Convert.ToString(i4, 2).PadLeft(32, '0');
+			return	Convert.ToString((long) a, 2).PadLeft(64, '0') + "|" +
+				Convert.ToString((long) b, 2).PadLeft(64, '0');
 		}
 
 		bool IEquatable<StateHash>.Equals(StateHash hash)
 		{
-			return i1 == hash.i1 && i2 == hash.i2 && i3 == hash.i3 && i4 == hash.i4;
+			return a == hash.a && b == hash.b;
 		}
 
 		public override bool Equals(object obj)
@@ -63,12 +57,17 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			StateHash hash = (StateHash) obj;
-			return i1 == hash.i1 && i2 == hash.i2 && i3 == hash.i3 && i4 == hash.i4;
+			return a == hash.a && b == hash.b;
 		}
 
 		public override int GetHashCode()
 		{
-			return unchecked(i1 + i2 + i3 + i4);
+			unchecked
+			{
+				int i1 = (int) (a ^ (a >> 32));
+				int i2 = (int) (b ^ (b >> 32));
+				return i1 + i2;
+			}
 		}
 	}
 
@@ -137,21 +136,22 @@ namespace Microsoft.Xna.Framework.Graphics
 		) {
 			int funcs = ((int) alphaBlendFunc << 4) | ((int) colorBlendFunc);
 			int blendsAndColorWriteChannels =
-				  ((int) alphaDestBlend	<< (32 - 4))
-				| ((int) alphaSrcBlend	<< (32 - 8))
-				| ((int) colorDestBlend	<< (32 - 12))
-				| ((int) colorSrcBlend	<< (32 - 16))
-				| ((int) channels	<< (32 - 20))
-				| ((int) channels1	<< (32 - 24))
-				| ((int) channels2	<< (32 - 28))
+				  ((int) alphaDestBlend	<< 28)
+				| ((int) alphaSrcBlend	<< 24)
+				| ((int) colorDestBlend	<< 20)
+				| ((int) colorSrcBlend	<< 16)
+				| ((int) channels	<< 12)
+				| ((int) channels1	<< 8)
+				| ((int) channels2	<< 4)
 				| ((int) channels3);
 
-			return new StateHash(
-				funcs,
-				blendsAndColorWriteChannels,
-				(int) blendFactor.PackedValue,
-				multisampleMask
-			);
+			unchecked
+			{
+				return new StateHash(
+					((ulong) funcs << 32) | ((ulong) blendsAndColorWriteChannels << 0),
+					((ulong) multisampleMask << 32) | ((ulong) blendFactor.PackedValue << 0)
+				);
+			}
 		}
 
 		/* Public Functions */
@@ -308,26 +308,27 @@ namespace Microsoft.Xna.Framework.Graphics
 			int twoSided = twoSidedStencil ? 1 : 0;
 
 			int packedProperties =
-				  ((int) zEnable		<< 32 - 2)
-				| ((int) zWriteEnable		<< 32 - 3)
-				| ((int) sEnable		<< 32 - 4)
-				| ((int) twoSided		<< 32 - 5)
-				| ((int) depthFunc		<< 32 - 8)
-				| ((int) stencilFunc		<< 32 - 11)
-				| ((int) ccwStencilFunc		<< 32 - 14)
-				| ((int) stencilPass		<< 32 - 17)
-				| ((int) stencilFail		<< 32 - 20)
-				| ((int) stencilDepthFail	<< 32 - 23)
-				| ((int) ccwStencilFail		<< 32 - 26)
-				| ((int) ccwStencilPass		<< 32 - 29)
+				  ((int) zEnable		<< 30)
+				| ((int) zWriteEnable		<< 29)
+				| ((int) sEnable		<< 28)
+				| ((int) twoSided		<< 27)
+				| ((int) depthFunc		<< 24)
+				| ((int) stencilFunc		<< 21)
+				| ((int) ccwStencilFunc		<< 18)
+				| ((int) stencilPass		<< 15)
+				| ((int) stencilFail		<< 12)
+				| ((int) stencilDepthFail	<< 9)
+				| ((int) ccwStencilFail		<< 6)
+				| ((int) ccwStencilPass		<< 3)
 				| ((int) ccwStencilDepthFail);
 
-			return new StateHash(
-				packedProperties,
-				stencilMask,
-				stencilWriteMask,
-				referenceStencil
-			);
+			unchecked
+			{
+				return new StateHash(
+					((ulong) stencilMask << 32) | ((ulong) packedProperties << 0),
+					((ulong) referenceStencil << 32) | ((ulong) stencilWriteMask << 0)
+				);
+			}
 		}
 
 		/* Public Functions */
@@ -479,12 +480,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				| ((int) cullMode		<< 1)
 				| ((int) fillMode);
 
-			return new StateHash(
-				0,
-				packedProperties,
-				FloatToInt32(depthBias),
-				FloatToInt32(slopeScaleDepthBias)
-			);
+			unchecked
+			{
+				return new StateHash(
+					(ulong) packedProperties,
+					(FloatToULong(slopeScaleDepthBias) << 32) | FloatToULong(depthBias)
+				);
+			}
 		}
 
 		/* Public Functions */
@@ -594,12 +596,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				| ((int) addressV	<< 2)
 				| ((int) addressW);
 
-			return new StateHash(
-				filterAndAddresses,
-				maxAnisotropy,
-				maxMipLevel,
-				FloatToInt32(mipLODBias)
-			);
+			unchecked
+			{
+				return new StateHash(
+					((ulong) maxAnisotropy << 32) | ((ulong) filterAndAddresses << 0),
+					(FloatToULong(mipLODBias) << 32) | ((ulong) maxMipLevel << 0)
+				);
+			}
 		}
 
 		/* Public Functions */
@@ -681,9 +684,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Private Helper Methods
 
-		private static unsafe int FloatToInt32(float f)
+		private static unsafe ulong FloatToULong(float f)
 		{
-			return *((int *) &f);
+			uint uintRep = *((uint *) &f);
+			return unchecked((ulong) uintRep);
 		}
 
 		#endregion

--- a/src/Graphics/PresentInterval.cs
+++ b/src/Graphics/PresentInterval.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PresentationParameters.cs
+++ b/src/Graphics/PresentationParameters.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/PrimitiveType.cs
+++ b/src/Graphics/PrimitiveType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTarget2D.cs
+++ b/src/Graphics/RenderTarget2D.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTargetBinding.cs
+++ b/src/Graphics/RenderTargetBinding.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTargetCube.cs
+++ b/src/Graphics/RenderTargetCube.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/RenderTargetCube.cs
+++ b/src/Graphics/RenderTargetCube.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				if (glColorBuffer != null)
 				{
-					GraphicsDevice.GLDevice.AddDisposeRenderbuffer(glDepthStencilBuffer);
+					GraphicsDevice.GLDevice.AddDisposeRenderbuffer(glColorBuffer);
 				}
 
 				if (glDepthStencilBuffer != null)

--- a/src/Graphics/RenderTargetCube.cs
+++ b/src/Graphics/RenderTargetCube.cs
@@ -229,8 +229,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					GraphicsDevice.GLDevice.AddDisposeRenderbuffer(glDepthStencilBuffer);
 				}
-				base.Dispose(disposing);
 			}
+			base.Dispose(disposing);
 		}
 
 		#endregion

--- a/src/Graphics/RenderTargetUsage.cs
+++ b/src/Graphics/RenderTargetUsage.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ResourceCreatedEventArgs.cs
+++ b/src/Graphics/ResourceCreatedEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/ResourceDestroyedEventArgs.cs
+++ b/src/Graphics/ResourceDestroyedEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SamplerStateCollection.cs
+++ b/src/Graphics/SamplerStateCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SetDataOptions.cs
+++ b/src/Graphics/SetDataOptions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		protected override void Dispose(bool disposing)
 		{
-			if (!IsDisposed && disposing)
+			if (!IsDisposed)
 			{
 				spriteEffect.Dispose();
 				indexBuffer.Dispose();

--- a/src/Graphics/SpriteEffects.cs
+++ b/src/Graphics/SpriteEffects.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SpriteSortMode.cs
+++ b/src/Graphics/SpriteSortMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/Blend.cs
+++ b/src/Graphics/States/Blend.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/BlendFunction.cs
+++ b/src/Graphics/States/BlendFunction.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/BlendState.cs
+++ b/src/Graphics/States/BlendState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/CompareFunction.cs
+++ b/src/Graphics/States/CompareFunction.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/CullMode.cs
+++ b/src/Graphics/States/CullMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/DepthStencilState.cs
+++ b/src/Graphics/States/DepthStencilState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/FillMode.cs
+++ b/src/Graphics/States/FillMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/RasterizerState.cs
+++ b/src/Graphics/States/RasterizerState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/SamplerState.cs
+++ b/src/Graphics/States/SamplerState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/StencilOperation.cs
+++ b/src/Graphics/States/StencilOperation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/TextureAddressMode.cs
+++ b/src/Graphics/States/TextureAddressMode.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/States/TextureFilter.cs
+++ b/src/Graphics/States/TextureFilter.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/SurfaceFormat.cs
+++ b/src/Graphics/SurfaceFormat.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Texture3D.cs
+++ b/src/Graphics/Texture3D.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/TextureCollection.cs
+++ b/src/Graphics/TextureCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/BufferUsage.cs
+++ b/src/Graphics/Vertices/BufferUsage.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/DynamicIndexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicIndexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/IVertexType.cs
+++ b/src/Graphics/Vertices/IVertexType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/IndexBuffer.cs
+++ b/src/Graphics/Vertices/IndexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/IndexElementSize.cs
+++ b/src/Graphics/Vertices/IndexElementSize.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexBufferBinding.cs
+++ b/src/Graphics/Vertices/VertexBufferBinding.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexDeclaration.cs
+++ b/src/Graphics/Vertices/VertexDeclaration.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexDeclarationCache.cs
+++ b/src/Graphics/Vertices/VertexDeclarationCache.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexElement.cs
+++ b/src/Graphics/Vertices/VertexElement.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexElementFormat.cs
+++ b/src/Graphics/Vertices/VertexElementFormat.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexElementUsage.cs
+++ b/src/Graphics/Vertices/VertexElementUsage.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionColor.cs
+++ b/src/Graphics/Vertices/VertexPositionColor.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Vertices/VertexPositionTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionTexture.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/Viewport.cs
+++ b/src/Graphics/Viewport.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Graphics/X360TexUtil.cs
+++ b/src/Graphics/X360TexUtil.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GraphicsDeviceInformation.cs
+++ b/src/GraphicsDeviceInformation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -529,6 +529,7 @@ namespace Microsoft.Xna.Framework
 				return false;
 			}
 
+			graphicsDevice.GLDevice.BeginFrame();
 			drawBegun = true;
 			return true;
 		}

--- a/src/IDrawable.cs
+++ b/src/IDrawable.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/IGameComponent.cs
+++ b/src/IGameComponent.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/IGraphicsDeviceManager.cs
+++ b/src/IGraphicsDeviceManager.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/IUpdateable.cs
+++ b/src/IUpdateable.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/ButtonState.cs
+++ b/src/Input/ButtonState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Buttons.cs
+++ b/src/Input/Buttons.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePad.cs
+++ b/src/Input/GamePad.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadButtons.cs
+++ b/src/Input/GamePadButtons.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadCapabilities.cs
+++ b/src/Input/GamePadCapabilities.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadDPad.cs
+++ b/src/Input/GamePadDPad.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadDeadZone.cs
+++ b/src/Input/GamePadDeadZone.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadState.cs
+++ b/src/Input/GamePadState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadThumbSticks.cs
+++ b/src/Input/GamePadThumbSticks.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadTriggers.cs
+++ b/src/Input/GamePadTriggers.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/GamePadType.cs
+++ b/src/Input/GamePadType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/KeyState.cs
+++ b/src/Input/KeyState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Keyboard.cs
+++ b/src/Input/Keyboard.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/KeyboardState.cs
+++ b/src/Input/KeyboardState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Keys.cs
+++ b/src/Input/Keys.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Mouse.cs
+++ b/src/Input/Mouse.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/MouseState.cs
+++ b/src/Input/MouseState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/MouseState.cs
+++ b/src/Input/MouseState.cs
@@ -44,15 +44,6 @@ namespace Microsoft.Xna.Framework.Input
 		}
 
 		/// <summary>
-		/// Gets state of the middle mouse button.
-		/// </summary>
-		public ButtonState MiddleButton
-		{
-			get;
-			internal set;
-		}
-
-		/// <summary>
 		/// Gets state of the right mouse button.
 		/// </summary>
 		public ButtonState RightButton
@@ -62,9 +53,9 @@ namespace Microsoft.Xna.Framework.Input
 		}
 
 		/// <summary>
-		/// Returns cumulative scroll wheel value since the game start.
+		/// Gets state of the middle mouse button.
 		/// </summary>
-		public int ScrollWheelValue
+		public ButtonState MiddleButton
 		{
 			get;
 			internal set;
@@ -83,6 +74,15 @@ namespace Microsoft.Xna.Framework.Input
 		/// Gets state of the XButton2.
 		/// </summary>
 		public ButtonState XButton2
+		{
+			get;
+			internal set;
+		}
+
+		/// <summary>
+		/// Returns cumulative scroll wheel value since the game start.
+		/// </summary>
+		public int ScrollWheelValue
 		{
 			get;
 			internal set;

--- a/src/Input/TextInputEXT.cs
+++ b/src/Input/TextInputEXT.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/GestureDetector.cs
+++ b/src/Input/Touch/GestureDetector.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/GestureSample.cs
+++ b/src/Input/Touch/GestureSample.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/GestureType.cs
+++ b/src/Input/Touch/GestureType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchCollection.cs
+++ b/src/Input/Touch/TouchCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchLocation.cs
+++ b/src/Input/Touch/TouchLocation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchLocationState.cs
+++ b/src/Input/Touch/TouchLocationState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchPanel.cs
+++ b/src/Input/Touch/TouchPanel.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Input/Touch/TouchPanelCapabilities.cs
+++ b/src/Input/Touch/TouchPanelCapabilities.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/LaunchParameters.cs
+++ b/src/LaunchParameters.cs
@@ -2,7 +2,7 @@
 /*
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/MathHelper.cs
+++ b/src/MathHelper.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/MediaPlayer.cs
+++ b/src/Media/MediaPlayer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/MediaQueue.cs
+++ b/src/Media/MediaQueue.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/MediaState.cs
+++ b/src/Media/MediaState.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/Song.cs
+++ b/src/Media/Song.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/SongCollection.cs
+++ b/src/Media/SongCollection.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/VideoSoundtrackType.cs
+++ b/src/Media/VideoSoundtrackType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/VisualizationData.cs
+++ b/src/Media/VisualizationData.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/Xiph/Video.cs
+++ b/src/Media/Xiph/Video.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Media/Xiph/VideoPlayer.cs
+++ b/src/Media/Xiph/VideoPlayer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/NamespaceDocs.cs
+++ b/src/NamespaceDocs.cs
@@ -1,5 +1,5 @@
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Plane.cs
+++ b/src/Plane.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/PlaneIntersectionType.cs
+++ b/src/PlaneIntersectionType.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/PlayerIndex.cs
+++ b/src/PlayerIndex.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Point.cs
+++ b/src/Point.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/PreparingDeviceSettingsEventArgs.cs
+++ b/src/PreparingDeviceSettingsEventArgs.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -39,4 +39,4 @@ using System.Resources;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("19.12.01.0")]
+[assembly: AssemblyVersion("20.01.0.0")]

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Resources;
 #endif
 [assembly: AssemblyCompany("Ethan \"flibitijibibo\" Lee")]
 [assembly: AssemblyProduct("FNA")]
-[assembly: AssemblyCopyright("Copyright (c) 2009-2019")]
+[assembly: AssemblyCopyright("Copyright (c) 2009-2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Quaternion.cs
+++ b/src/Quaternion.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Ray.cs
+++ b/src/Ray.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Rectangle.cs
+++ b/src/Rectangle.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Storage/StorageContainer.cs
+++ b/src/Storage/StorageContainer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Storage/StorageDevice.cs
+++ b/src/Storage/StorageDevice.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Storage/StorageDeviceNotConnectedException.cs
+++ b/src/Storage/StorageDeviceNotConnectedException.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/TitleContainer.cs
+++ b/src/TitleContainer.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/TitleLocation.cs
+++ b/src/TitleLocation.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Utilities/FNAInternalExtensions.cs
+++ b/src/Utilities/FNAInternalExtensions.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Utilities/XamarinHelper.cs
+++ b/src/Utilities/XamarinHelper.cs
@@ -1,6 +1,6 @@
 ﻿#region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Vector2.cs
+++ b/src/Vector2.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Vector3.cs
+++ b/src/Vector3.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.

--- a/src/Vector4.cs
+++ b/src/Vector4.cs
@@ -1,6 +1,6 @@
 #region License
 /* FNA - XNA4 Reimplementation for Desktop Platforms
- * Copyright 2009-2019 Ethan Lee and the MonoGame Team
+ * Copyright 2009-2020 Ethan Lee and the MonoGame Team
  *
  * Released under the Microsoft Public License.
  * See LICENSE for details.


### PR DESCRIPTION
The current FNA code implements this logic structure to push data to the main thread from a different one:

```csharp
public class ADevice : IGLDevice
{
    public void A_GL_MethodCall()
    {
#if !DISABLE_THREADING
        ForceToMainThread() => {
#endif
			/* ...
			/* code
			/* ...
			*/
#if !DISABLE_THREADING
			});
#endif
    }
}
```

This patch aims to remove the implicit ```new Action( () => {} );``` allocation in runtime in this way:

```csharp
public class ADevice : IGLDevice
{
    public void A_GL_MethodCall()
    {
#if !DISABLE_THREADING
	if (mainThreadId == Thread.CurrentThread.ManagedThreadId)
	{
#endif

		/* ...
		/* code
		/* ...
		*/

#if !DISABLE_THREADING
	}
	else 
	{		 
		ForceToMainThread() => {

			/* ...
			/* code
			/* ...
			*/

		});
	}
#endif
    }
}
```

The code formatting should be the same now. 