### PR TITLE
Add FNA_PREFER_SDL2_BASE_PATH to prefer SDL's base path

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1409,23 +1409,26 @@ namespace Microsoft.Xna.Framework
 
 		private static string GetBaseDirectory()
 		{
-			if (	OSVersion.Equals("Windows") ||
-				OSVersion.Equals("Mac OS X") ||
-				OSVersion.Equals("Linux") ||
-				OSVersion.Equals("FreeBSD") ||
-				OSVersion.Equals("OpenBSD") ||
-				OSVersion.Equals("NetBSD")	)
+			if (Environment.GetEnvironmentVariable("FNA_PREFER_SDL2_BASE_PATH") != "1")
 			{
-				/* This is mostly here for legacy compatibility.
-				 * For most platforms this should be the same as
-				 * SDL_GetBasePath, but some platforms (Apple's)
-				 * will have a separate Resources folder that is
-				 * the "base" directory for applications.
-				 *
-				 * TODO: Remove this and endure the breakage.
-				 * -flibit
-				 */
-				return AppDomain.CurrentDomain.BaseDirectory;
+				if (	OSVersion.Equals("Windows") ||
+					OSVersion.Equals("Mac OS X") ||
+					OSVersion.Equals("Linux") ||
+					OSVersion.Equals("FreeBSD") ||
+					OSVersion.Equals("OpenBSD") ||
+					OSVersion.Equals("NetBSD")	)
+				{
+					/* This is mostly here for legacy compatibility.
+					* For most platforms this should be the same as
+					* SDL_GetBasePath, but some platforms (Apple's)
+					* will have a separate Resources folder that is
+					* the "base" directory for applications.
+					*
+					* TODO: Remove this and endure the breakage.
+					* -flibit
+					*/
+					return AppDomain.CurrentDomain.BaseDirectory;
+				}
 			}
 			string result = SDL.SDL_GetBasePath();
 			if (string.IsNullOrEmpty(result))

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1409,7 +1409,7 @@ namespace Microsoft.Xna.Framework
 
 		private static string GetBaseDirectory()
 		{
-			if (Environment.GetEnvironmentVariable("FNA_PREFER_SDL2_BASE_PATH") != "1")
+			if (Environment.GetEnvironmentVariable("FNA_SDL2_FORCE_BASE_PATH") != "1")
 			{
 				if (	OSVersion.Equals("Windows") ||
 					OSVersion.Equals("Mac OS X") ||
@@ -1419,14 +1419,14 @@ namespace Microsoft.Xna.Framework
 					OSVersion.Equals("NetBSD")	)
 				{
 					/* This is mostly here for legacy compatibility.
-					* For most platforms this should be the same as
-					* SDL_GetBasePath, but some platforms (Apple's)
-					* will have a separate Resources folder that is
-					* the "base" directory for applications.
-					*
-					* TODO: Remove this and endure the breakage.
-					* -flibit
-					*/
+					 * For most platforms this should be the same as
+					 * SDL_GetBasePath, but some platforms (Apple's)
+					 * will have a separate Resources folder that is
+					 * the "base" directory for applications.
+					 *
+					 * TODO: Remove this and endure the breakage.
+					 * -flibit
+					 */
 					return AppDomain.CurrentDomain.BaseDirectory;
 				}
 			}


### PR DESCRIPTION
Because I'm pedantic about macOS I wanted to have my content live in the Resources folder of my app bundle but FNA has logic to just use the assembly directory by default. This might be fine for most people so I thought I could add an environment variable around it such that I can skip ahead to just using the SDL2 base path (which by default is the bundle resource directory).

The comment in there makes it sound like eventually that whole chunk will go away but I have no idea the full ramifications there. Likely a lot of breaking of games that didn't seem super necessary for what I wanted to achieve right now.