### PR TITLE
Fix high DPI for macOS initial window size

### DIFF
--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -337,6 +337,13 @@ namespace Microsoft.Xna.Framework
 					}
 				}
 			}
+
+			if (Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1")
+			{
+				gdi.PresentationParameters.BackBufferWidth *= 2;
+				gdi.PresentationParameters.BackBufferHeight *= 2;
+			}
+
 			gdi.PresentationParameters.DepthStencilFormat =
 				PreferredDepthStencilFormat;
 			gdi.PresentationParameters.IsFullScreen =
@@ -470,11 +477,6 @@ namespace Microsoft.Xna.Framework
 			Rectangle size = (sender as GameWindow).ClientBounds;
 			resizedBackBufferWidth = size.Width;
 			resizedBackBufferHeight = size.Height;
-			if (Environment.GetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI") == "1")
-			{
-				resizedBackBufferWidth *= 2;
-				resizedBackBufferHeight *= 2;
-			}
 			useResizedBackBuffer = true;
 			ApplyChanges();
 		}


### PR DESCRIPTION
So I think this is a good change but feel free to educate me if I'm missing the point on something. The problem I spotted was that I enabled high DPI mode for my game using `FNA_GRAPHICS_ENABLE_HIGHDPI` and in my game's constructor I initialize the GraphicsDeviceManager with a preferred size of 1280x720. When the game starts up my window is 640x360 with a 1280x720 backbuffer. While that is technically what I specified it wasn't what I expected. 

What I found was that I could move this little bit of code around from the resize event and into ApplyChanges and now I get what I would expect which is a 1280x720 window and a 2560x1440 backbuffer. This makes more sense as it ensures that my game initialization code doesn't have to know if the platform supports high DPI; whether it does or does not I still get a 720p window which is what I would hope. I guess part of the issue is that the XNA API requires setting the back buffer resolution rather than the window size.

Regardless of this change obviously the rendering has to deal make sure to read the back buffer size instead of window size to properly handle high DPI modes but that's to be expected and doesn't require any knowledge of high DPI or not; it just means using one width/height versus another.

Maybe there's a reason to not do it this way but it seems more intuitive to me. This is also kind of a breaking change, though, since games already handling high DPI mode are going to be twice as big on startup now. What do you think? 