### PR TITLE
remove SO version suffix from OpenBSD to avoid clash with OS library …

### DIFF
--- a/app.config
+++ b/app.config
@@ -3,16 +3,17 @@
 	<dllmap dll="SDL2" os="windows" target="SDL2.dll"/>
 	<dllmap dll="SDL2" os="osx" target="libSDL2-2.0.0.dylib"/>
 	<dllmap dll="SDL2" os="linux,freebsd,netbsd" target="libSDL2-2.0.so.0"/>
-	<dllmap dll="SDL2" os="openbsd" target="libSDL2.so.0"/>
+	<dllmap dll="SDL2" os="openbsd" target="libSDL2.so"/>
 
 	<dllmap dll="SDL2_image" os="windows" target="SDL2_image.dll"/>
 	<dllmap dll="SDL2_image" os="osx" target="libSDL2_image-2.0.0.dylib"/>
 	<dllmap dll="SDL2_image" os="linux,freebsd,netbsd" target="libSDL2_image-2.0.so.0"/>
-	<dllmap dll="SDL2_image" os="openbsd" target="libSDL2_image.so.0"/>
+	<dllmap dll="SDL2_image" os="openbsd" target="libSDL2_image.so"/>
 
 	<dllmap dll="FAudio" os="windows" target="FAudio.dll"/>
 	<dllmap dll="FAudio" os="osx" target="libFAudio.0.dylib"/>
-	<dllmap dll="FAudio" os="linux,freebsd,netbsd,openbsd" target="libFAudio.so.0"/>
+	<dllmap dll="FAudio" os="linux,freebsd,netbsd" target="libFAudio.so.0"/>
+	<dllmap dll="FAudio" os="openbsd" target="libFAudio.so"/>
 
 	<dllmap dll="SDL2"		os="osx" cpu="armv8" target="__Internal"/>
 	<dllmap dll="SDL2_image" 	os="osx" cpu="armv8" target="__Internal"/>


### PR DESCRIPTION
…cranks

We crank library versions pretty aggressively on OpenBSD and libFAudio is already out of sync. Better to leave out the SO version suffix on OpenBSD and leave it to the porter (me).