### PR TITLE
Handle early Present calls in MetalDevice

### DIFF
--- a/src/FNAPlatform/MetalDevice.cs
+++ b/src/FNAPlatform/MetalDevice.cs
@@ -980,6 +980,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			Rectangle? destinationRectangle,
 			IntPtr overrideWindowHandle
 		) {
+			/* Just in case Present() is called
+			 * before any rendering happens...
+			 */
+			BeginFrame();
+
 			// Bind the backbuffer and finalize rendering
 			SetRenderTargets(null, null, DepthFormat.None);
 			EndPass();


### PR DESCRIPTION
This fixes the libobjc segfault issue found by cosmonaut.