### PR TITLE
Dynamically load CoreDllMap assembly

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -13,6 +13,9 @@
 	<PropertyGroup>
 		<FNASettingsPropsFilePath>$(SolutionDir)FNA.Settings.props</FNASettingsPropsFilePath>
 	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+	</ItemGroup>
 	<Import Project="$(FNASettingsPropsFilePath)" Condition="Exists('$(FNASettingsPropsFilePath)')" />
 	<Target Name="ValidatePropsFilePath" BeforeTargets="BeforeBuild">
 		<Message Importance="High" Text="No property overrides found at '$(FNASettingsPropsFilePath)'" Condition="!Exists('$(FNASettingsPropsFilePath)')" />

--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -657,6 +657,7 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				return FAudioContext.Context;
 			}
+			FNAPlatform.InitDllMap();
 			FAudioContext.Create();
 			if (FAudioContext.Context == null)
 			{

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -10,6 +10,7 @@
 #region Using Statements
 using System;
 using System.IO;
+using System.Reflection;
 
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Audio;
@@ -342,6 +343,34 @@ namespace Microsoft.Xna.Framework
 
 		public delegate bool SupportsOrientationChangesFunc();
 		public static readonly SupportsOrientationChangesFunc SupportsOrientationChanges;
+
+		#endregion
+
+		#region .NET Core DllMap Initialization
+
+		public static void InitDllMap()
+		{
+			if (Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices") != null)
+			{
+				Assembly fnaAssembly = Assembly.GetCallingAssembly();
+				string path = Path.Combine(
+					AppDomain.CurrentDomain.BaseDirectory,
+					"CoreDllMap.dll"
+				);
+				try
+				{
+					Assembly dllmap = Assembly.LoadFile(path);
+					dllmap.GetType("CoreDllMap").GetMethod("Register").Invoke(
+						null,
+						new object[] { fnaAssembly }
+					);
+				}
+				catch
+				{
+					FNALoggerEXT.LogWarn("Could not find CoreDllMap.dll!");
+				}
+			}
+		}
 
 		#endregion
 	}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Xna.Framework
 
 		public static string ProgramInit(LaunchParameters args)
 		{
+			// Initialize DllMap for .NET Core
+			FNAPlatform.InitDllMap();
+
 			// This is how we can weed out cases where fnalibs is missing
 			try
 			{

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -380,6 +380,9 @@ namespace Microsoft.Xna.Framework.Graphics
 				throw new ArgumentNullException("presentationParameters");
 			}
 
+			// Initialize DllMap for .NET Core
+			FNAPlatform.InitDllMap();
+
 			// Set the properties from the constructor parameters.
 			Adapter = adapter;
 			PresentationParameters = presentationParameters;


### PR DESCRIPTION
This code detects if the NativeLibrary type exists in the current runtime, and if so, tries to dynamically load the [CoreDllMap](https://github.com/TheSpydog/CoreDllMap) assembly in the same directory. All the DllMap reimplementation logic is contained inside the other DLL, so it removes the burden from FNA.

Still needs testing with .NET Framework, UWP, and possibly BRUTE(?) to make sure the changes didn't screw up anything.