### PR TITLE
Lock FrameworkDispatcher.Streams while iterating

### DIFF
--- a/src/Audio/DynamicSoundEffectInstance.cs
+++ b/src/Audio/DynamicSoundEffectInstance.cs
@@ -134,7 +134,10 @@ namespace Microsoft.Xna.Framework.Audio
 
 			// Okay we're good
 			base.Play();
-			FrameworkDispatcher.Streams.Add(this);
+			lock (FrameworkDispatcher.Streams)
+			{
+				FrameworkDispatcher.Streams.Add(this);
+			}
 		}
 
 		public void SubmitBuffer(byte[] buffer)

--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 				if (isDynamic)
 				{
-					lock (FrameworkDispatcher.Stream)
+					lock (FrameworkDispatcher.Streams)
 					{
 						FrameworkDispatcher.Streams.Remove(
 							this as DynamicSoundEffectInstance

--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -402,9 +402,12 @@ namespace Microsoft.Xna.Framework.Audio
 
 				if (isDynamic)
 				{
-					FrameworkDispatcher.Streams.Remove(
-						this as DynamicSoundEffectInstance
-					);
+					lock (FrameworkDispatcher.Stream)
+					{
+						FrameworkDispatcher.Streams.Remove(
+							this as DynamicSoundEffectInstance
+						);
+					}
 					(this as DynamicSoundEffectInstance).ClearBuffers();
 				}
 			}

--- a/src/FrameworkDispatcher.cs
+++ b/src/FrameworkDispatcher.cs
@@ -34,13 +34,16 @@ namespace Microsoft.Xna.Framework
 			/* Updates the status of various framework components
 			 * (such as power state and media), and raises related events.
 			 */
-			for (int i = 0; i < Streams.Count; i += 1)
+			lock (Streams)
 			{
-				DynamicSoundEffectInstance dsfi = Streams[i];
-				dsfi.Update();
-				if (dsfi.IsDisposed)
+				for (int i = 0; i < Streams.Count; i += 1)
 				{
-					i -= 1;
+					DynamicSoundEffectInstance dsfi = Streams[i];
+					dsfi.Update();
+					if (dsfi.IsDisposed)
+					{
+						i -= 1;
+					}
 				}
 			}
 			if (Microphone.micList != null)


### PR DESCRIPTION
Addresses possible null reference when a DynamicSoundEffect instance is disposed in another thread while FrameworkDispatcher.Update() is running. See issue #316