### PR TITLE
Remove iOS dllmap configs

### DIFF
--- a/app.config
+++ b/app.config
@@ -11,10 +11,4 @@
 	<dllmap dll="FAudio" os="windows" target="FAudio.dll"/>
 	<dllmap dll="FAudio" os="osx" target="libFAudio.0.dylib"/>
 	<dllmap dll="FAudio" os="linux,freebsd,netbsd" target="libFAudio.so.0"/>
-
-	<dllmap dll="SDL2"		os="osx" cpu="armv8" target="__Internal"/>
-	<dllmap dll="SDL2_image" 	os="osx" cpu="armv8" target="__Internal"/>
-	<dllmap dll="mojoshader" 	os="osx" cpu="armv8" target="__Internal"/>
-	<dllmap dll="FAudio"		os="osx" cpu="armv8" target="__Internal"/>
-	<dllmap dll="libtheorafile"	os="osx" cpu="armv8" target="__Internal"/>
 </configuration>


### PR DESCRIPTION
We'll also need to update the iOS wiki page with a section about how when compiling for iOS, you should (1) replace the existing *.dylib entries with __Internal in the config file and (2) add __Internal config entries for libmojoshader and libtheorafile as well.