### PR TITLE
Handle Emscripten main loop

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -124,6 +124,8 @@ namespace Microsoft.Xna.Framework
 			UpdateTouchPanelState =		SDL2_FNAPlatform.UpdateTouchPanelState;
 			GetNumTouchFingers =		SDL2_FNAPlatform.GetNumTouchFingers;
 			SupportsOrientationChanges =	SDL2_FNAPlatform.SupportsOrientationChanges;
+			NeedsPlatformMainLoop = 	SDL2_FNAPlatform.NeedsPlatformMainLoop;
+			RunPlatformMainLoop =		SDL2_FNAPlatform.RunPlatformMainLoop;
 
 			FNALoggerEXT.Initialize();
 
@@ -322,6 +324,12 @@ namespace Microsoft.Xna.Framework
 
 		public delegate bool SupportsOrientationChangesFunc();
 		public static readonly SupportsOrientationChangesFunc SupportsOrientationChanges;
+
+		public delegate bool NeedsPlatformMainLoopFunc();
+		public static readonly NeedsPlatformMainLoopFunc NeedsPlatformMainLoop;
+
+		public delegate void RunPlatformMainLoopFunc(Game game);
+		public static readonly RunPlatformMainLoopFunc RunPlatformMainLoop;
 
 		#endregion
 	}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1006,13 +1006,17 @@ namespace Microsoft.Xna.Framework
 					1
 				);
 			}
+			else
+			{
+				throw new NotSupportedException(
+					"Cannot run the main loop of an unknown platform"
+				);
+			}
 		}
 
 		#endregion
 
 		#region Emscripten Main Loop
-
-		// FIXME: Where do these belong?
 
 		private static Game emscriptenGame;
 		private delegate void em_callback_func();
@@ -1035,8 +1039,8 @@ namespace Microsoft.Xna.Framework
 			// FIXME: Is this even needed...?
 			if (!emscriptenGame.RunApplication)
 			{
-				emscripten_cancel_main_loop();
 				emscriptenGame.Exit();
+				emscripten_cancel_main_loop();
 			}
 		}
 

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -840,6 +840,20 @@ namespace Microsoft.Xna.Framework
 
 		private void RunLoop()
 		{
+			/* Some platforms (i.e. Emscripten) don't support
+			 * indefinite while loops, so instead we have to
+			 * surrender control to the platform's main loop.
+			 * -caleb
+			 */
+			if (FNAPlatform.NeedsPlatformMainLoop())
+			{
+				/* This breaks control flow and jumps
+				 * directly into the platform main loop.
+				 * Nothing below this call will be executed.
+				 */
+				FNAPlatform.RunPlatformMainLoop(this);
+			}
+
 			while (RunApplication)
 			{
 				FNAPlatform.PollEvents(


### PR DESCRIPTION
Implemented a couple new FNAPlatform functions for detecting when a platform-specific main loop is needed (as per discussion in the Discord), and added the necessary callbacks for hooking into the emscripten main loop. It's pretty straightforward, but there are a couple things I'm not sure about:

1. Where does the emscripten-specific code belong? It's not SDL-specific and it feels kinda weird to have it all stuffed inside SDL2_FNAPlatform. I was thinking about making a static EmscriptenHelper class and stuffing the DllImports, delegate, and static `emscriptenGame` variable in there. But then that might be getting too "platform layer"-y to belong outside of an FNAPlatform...

2. The current game exit code basically just cancels the loop and freezes all execution. Audio stops, input stops, and the last image drawn stays permanently drawn to the canvas. This seems kind of awkward but there's not really a better way to handle Game.Exit calls in a browser context. Should we keep this behavior around, or remove it entirely and tell people to not call Exit in their web builds?