### PR TITLE
Expose SDL_TextEditingEvent

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1025,23 +1025,12 @@ namespace Microsoft.Xna.Framework
 			}
 		}
 
-		private unsafe static int MeasureStringLength (byte* ptr) {
-			// Based on the SDL2# LPUtf8StrMarshaler
-			byte* endPtr = ptr;
-			if (*endPtr != 0) 
-			{
-				int bytes = 0;
-				while (*endPtr != 0) 
-				{
-					endPtr++;
-					bytes += 1;
-				}
-				return bytes;
-			}
-
-			return 0;
+		private unsafe static int MeasureStringLength(byte* ptr)
+		{
+			int bytes;
+			for (bytes = 0; *ptr != 0; ptr += 1, bytes += 1);
+			return bytes;
 		}
-
 		public static bool NeedsPlatformMainLoop()
 		{
 			return SDL.SDL_GetPlatform().Equals("Emscripten");

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -998,7 +998,7 @@ namespace Microsoft.Xna.Framework
 								charsBuffer,
 								bytes
 							);
-							var text = new string(charsBuffer, 0, chars);
+							string text = new string(charsBuffer, 0, chars);
 							TextInputEXT.OnTextEditing(text, evt.edit.start, evt.edit.length);
 						} 
 						else 

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -988,7 +988,7 @@ namespace Microsoft.Xna.Framework
 				{
 					unsafe 
 					{
-						var bytes = MeasureStringLength(evt.edit.text);
+						int bytes = MeasureStringLength(evt.edit.text);
 						if (bytes > 0) 
 						{
 							char* charsBuffer = stackalloc char[bytes];

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1031,6 +1031,7 @@ namespace Microsoft.Xna.Framework
 			for (bytes = 0; *ptr != 0; ptr += 1, bytes += 1);
 			return bytes;
 		}
+
 		public static bool NeedsPlatformMainLoop()
 		{
 			return SDL.SDL_GetPlatform().Equals("Emscripten");

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -961,8 +961,9 @@ namespace Microsoft.Xna.Framework
 					// Based on the SDL2# LPUtf8StrMarshaler
 					unsafe
 					{
-						var bytes = MeasureStringLength(evt.text.text);
-						if (bytes > 0) {
+						int bytes = MeasureStringLength(evt.text.text);
+						if (bytes > 0) 
+						{
 							/* UTF8 will never encode more characters
 							 * than bytes in a string, so bytes is a
 							 * suitable upper estimate of size needed
@@ -985,9 +986,11 @@ namespace Microsoft.Xna.Framework
 
 				else if (evt.type == SDL.SDL_EventType.SDL_TEXTEDITING) 
 				{
-					unsafe {
+					unsafe 
+					{
 						var bytes = MeasureStringLength(evt.edit.text);
-						if (bytes > 0) {
+						if (bytes > 0) 
+						{
 							char* charsBuffer = stackalloc char[bytes];
 							int chars = Encoding.UTF8.GetChars(
 								evt.edit.text,
@@ -997,7 +1000,9 @@ namespace Microsoft.Xna.Framework
 							);
 							var text = new string(charsBuffer, 0, chars);
 							TextInputEXT.OnTextEditing(text, evt.edit.start, evt.edit.length);
-						} else {
+						} 
+						else 
+						{
 							TextInputEXT.OnTextEditing(null, 0, 0);
 						}
 					}
@@ -1022,19 +1027,19 @@ namespace Microsoft.Xna.Framework
 
 		private unsafe static int MeasureStringLength (byte* ptr) {
 			// Based on the SDL2# LPUtf8StrMarshaler
-			unsafe {
-				byte* endPtr = ptr;
-				if (*endPtr != 0) {
-					int bytes = 0;
-					while (*endPtr != 0) {
-						endPtr++;
-						bytes += 1;
-					}
-					return bytes;
+			byte* endPtr = ptr;
+			if (*endPtr != 0) 
+			{
+				int bytes = 0;
+				while (*endPtr != 0) 
+				{
+					endPtr++;
+					bytes += 1;
 				}
-
-				return 0;
+				return bytes;
 			}
+
+			return 0;
 		}
 
 		public static bool NeedsPlatformMainLoop()

--- a/src/Input/TextInputEXT.cs
+++ b/src/Input/TextInputEXT.cs
@@ -13,6 +13,8 @@ using System;
 
 namespace Microsoft.Xna.Framework.Input
 {
+	public delegate void TextEditingEventHandlerEXT (string text, int start, int length);
+
 	public static class TextInputEXT
 	{
 		#region Event
@@ -25,6 +27,13 @@ namespace Microsoft.Xna.Framework.Input
 		/// http://msdn.microsoft.com/en-AU/library/system.windows.forms.control.keypress.aspx
 		/// </summary>
 		public static event Action<char> TextInput;
+
+		/// <summary>
+		/// This event notifies you of in-progress text composition happening in an IME or other tool
+		///  and allows you to display the draft text appropriately before it has become input.
+		/// For more information, see SDL's tutorial: https://wiki.libsdl.org/Tutorials/TextInput
+		/// </summary>
+		public static event TextEditingEventHandlerEXT TextEditing;
 
 		#endregion
 
@@ -59,6 +68,14 @@ namespace Microsoft.Xna.Framework.Input
 			if (TextInput != null)
 			{
 				TextInput(c);
+			}
+		}
+
+		internal static void OnTextEditing(string text, int start, int length)
+		{
+			if (TextEditing != null)
+			{
+				TextEditing(text, start, length);
 			}
 		}
 

--- a/src/Input/TextInputEXT.cs
+++ b/src/Input/TextInputEXT.cs
@@ -13,8 +13,6 @@ using System;
 
 namespace Microsoft.Xna.Framework.Input
 {
-	public delegate void TextEditingEventHandlerEXT (string text, int start, int length);
-
 	public static class TextInputEXT
 	{
 		#region Event
@@ -33,7 +31,7 @@ namespace Microsoft.Xna.Framework.Input
 		///  and allows you to display the draft text appropriately before it has become input.
 		/// For more information, see SDL's tutorial: https://wiki.libsdl.org/Tutorials/TextInput
 		/// </summary>
-		public static event TextEditingEventHandlerEXT TextEditing;
+		public static event Action<string, int, int> TextEditing;
 
 		#endregion
 


### PR DESCRIPTION
Because SDL currently disables the IME's composition and candidates windows, it's up to the application to render both of them. The candidates window data is completely hidden so there's nothing we can do about that, but surfacing the composition data from this event allows rendering it correctly, at least for the Japanese IME in my testing.