### PR TITLE
Rename `GLDevice` -> `NativeDevice`

### DIFF
--- a/src/Content/ContentReaders/Texture2DReader.cs
+++ b/src/Content/ContentReaders/Texture2DReader.cs
@@ -101,13 +101,13 @@ namespace Microsoft.Xna.Framework.Content
 			// Check to see if we need to convert the surface data
 			SurfaceFormat convertedFormat = surfaceFormat;
 			if (	surfaceFormat == SurfaceFormat.Dxt1 &&
-				FNA3D.FNA3D_SupportsDXT1(device.GLDevice) == 0	)
+				FNA3D.FNA3D_SupportsDXT1(device.NativeDevice) == 0	)
 			{
 				convertedFormat = SurfaceFormat.Color;
 			}
 			else if (	(	surfaceFormat == SurfaceFormat.Dxt3 ||
 						surfaceFormat == SurfaceFormat.Dxt5	) &&
-					FNA3D.FNA3D_SupportsS3TC(device.GLDevice) == 0	)
+					FNA3D.FNA3D_SupportsS3TC(device.NativeDevice) == 0	)
 			{
 				convertedFormat = SurfaceFormat.Color;
 			}

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			set
 			{
 				FNA3D.FNA3D_SetEffectTechnique(
-					GraphicsDevice.GLDevice,
+					GraphicsDevice.NativeDevice,
 					glEffect,
 					value.TechniquePointer
 				);
@@ -217,10 +217,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			GraphicsDevice = graphicsDevice;
 
-			// Send the blob to the GLDevice to be parsed/compiled
+			// Send the blob to the NativeDevice to be parsed/compiled
 			IntPtr effectData;
 			FNA3D.FNA3D_CreateEffect(
-				graphicsDevice.GLDevice,
+				graphicsDevice.NativeDevice,
 				effectCode,
 				effectCode.Length,
 				out glEffect,
@@ -258,7 +258,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			// Send the parsed data to be cloned and recompiled by MojoShader
 			IntPtr effectData;
 			FNA3D.FNA3D_CloneEffect(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				cloneSource.glEffect,
 				out glEffect,
 				out effectData
@@ -316,7 +316,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (glEffect != IntPtr.Zero)
 				{
 					FNA3D.FNA3D_AddDisposeEffect(
-						GraphicsDevice.GLDevice,
+						GraphicsDevice.NativeDevice,
 						glEffect
 					);
 				}
@@ -340,7 +340,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		internal unsafe void INTERNAL_applyEffect(uint pass)
 		{
 			FNA3D.FNA3D_ApplyEffect(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				glEffect,
 				pass,
 				stateChangesPtr

--- a/src/Graphics/GraphicsAdapter.cs
+++ b/src/Graphics/GraphicsAdapter.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			/* TODO: This method could be genuinely useful!
 			 * Maybe look into the difference between Reach/HiDef and add the
-			 * appropriate properties to the GLDevice.
+			 * appropriate properties to the NativeDevice.
 			 * -flibit
 			 */
 			return true;

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (PresentationParameters.IsFullScreen)
 				{
 					int w, h;
-					FNA3D.FNA3D_GetBackbufferSize(GLDevice, out w, out h);
+					FNA3D.FNA3D_GetBackbufferSize(NativeDevice, out w, out h);
 					return new DisplayMode(
 						w,
 						h,
-						FNA3D.FNA3D_GetBackbufferSurfaceFormat(GLDevice)
+						FNA3D.FNA3D_GetBackbufferSurfaceFormat(NativeDevice)
 					);
 				}
 				return Adapter.CurrentDisplayMode;
@@ -158,7 +158,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				INTERNAL_scissorRectangle = value;
 				FNA3D.FNA3D_SetScissorRect(
-					GLDevice,
+					NativeDevice,
 					ref value
 				);
 			}
@@ -179,7 +179,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				INTERNAL_viewport = value;
 				FNA3D.FNA3D_SetViewport(
-					GLDevice,
+					NativeDevice,
 					ref value.viewport
 				);
 			}
@@ -190,7 +190,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			get
 			{
 				Color result;
-				FNA3D.FNA3D_GetBlendFactor(GLDevice, out result);
+				FNA3D.FNA3D_GetBlendFactor(NativeDevice, out result);
 				return result;
 			}
 			set
@@ -199,7 +199,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				 * BlendState?
 				 * -flibit
 				 */
-				FNA3D.FNA3D_SetBlendFactor(GLDevice, ref value);
+				FNA3D.FNA3D_SetBlendFactor(NativeDevice, ref value);
 			}
 		}
 
@@ -207,7 +207,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return FNA3D.FNA3D_GetMultiSampleMask(GLDevice);
+				return FNA3D.FNA3D_GetMultiSampleMask(NativeDevice);
 			}
 			set
 			{
@@ -215,7 +215,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				 * BlendState?
 				 * -flibit
 				 */
-				FNA3D.FNA3D_SetMultiSampleMask(GLDevice, value);
+				FNA3D.FNA3D_SetMultiSampleMask(NativeDevice, value);
 			}
 		}
 
@@ -223,7 +223,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return FNA3D.FNA3D_GetReferenceStencil(GLDevice);
+				return FNA3D.FNA3D_GetReferenceStencil(NativeDevice);
 			}
 			set
 			{
@@ -231,7 +231,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				 * DepthStencilState?
 				 * -flibit
 				 */
-				FNA3D.FNA3D_SetReferenceStencil(GLDevice, value);
+				FNA3D.FNA3D_SetReferenceStencil(NativeDevice, value);
 			}
 		}
 
@@ -249,7 +249,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Internal FNA3D_Device
 
-		internal readonly IntPtr GLDevice;
+		internal readonly IntPtr NativeDevice;
 
 		#endregion
 
@@ -398,7 +398,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			// Set up the FNA3D Device
 			try
 			{
-				GLDevice = FNA3D.FNA3D_CreateDevice(
+				NativeDevice = FNA3D.FNA3D_CreateDevice(
 					ref PresentationParameters.parameters,
 #if DEBUG
 					1
@@ -430,7 +430,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			// Initialize the Texture/Sampler state containers
 			int maxTextures, maxVertexTextures;
 			FNA3D.FNA3D_GetMaxTextureSlots(
-				GLDevice,
+				NativeDevice,
 				out maxTextures,
 				out maxVertexTextures
 			);
@@ -501,20 +501,20 @@ namespace Microsoft.Xna.Framework.Graphics
 					if (userVertexBuffer != IntPtr.Zero)
 					{
 						FNA3D.FNA3D_AddDisposeVertexBuffer(
-							GLDevice,
+							NativeDevice,
 							userVertexBuffer
 						);
 					}
 					if (userIndexBuffer != IntPtr.Zero)
 					{
 						FNA3D.FNA3D_AddDisposeIndexBuffer(
-							GLDevice,
+							NativeDevice,
 							userIndexBuffer
 						);
 					}
 
 					// Dispose of the GL Device/Context
-					FNA3D.FNA3D_DestroyDevice(GLDevice);
+					FNA3D.FNA3D_DestroyDevice(NativeDevice);
 				}
 
 				IsDisposed = true;
@@ -548,7 +548,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public void Present()
 		{
 			FNA3D.FNA3D_SwapBuffers(
-				GLDevice,
+				NativeDevice,
 				IntPtr.Zero,
 				IntPtr.Zero,
 				PresentationParameters.DeviceWindowHandle
@@ -569,7 +569,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				Rectangle src = sourceRectangle.Value;
 				Rectangle dst = destinationRectangle.Value;
 				FNA3D.FNA3D_SwapBuffers(
-					GLDevice,
+					NativeDevice,
 					ref src,
 					ref dst,
 					overrideWindowHandle
@@ -579,7 +579,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				Rectangle src = sourceRectangle.Value;
 				FNA3D.FNA3D_SwapBuffers(
-					GLDevice,
+					NativeDevice,
 					ref src,
 					IntPtr.Zero,
 					overrideWindowHandle
@@ -589,7 +589,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				Rectangle dst = destinationRectangle.Value;
 				FNA3D.FNA3D_SwapBuffers(
-					GLDevice,
+					NativeDevice,
 					IntPtr.Zero,
 					ref dst,
 					overrideWindowHandle
@@ -598,7 +598,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			else
 			{
 				FNA3D.FNA3D_SwapBuffers(
-					GLDevice,
+					NativeDevice,
 					IntPtr.Zero,
 					IntPtr.Zero,
 					overrideWindowHandle
@@ -633,7 +633,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			// Verify MSAA before we really start...
 			PresentationParameters.MultiSampleCount = FNA3D.FNA3D_GetMaxMultiSampleCount(
-				GLDevice,
+				NativeDevice,
 				PresentationParameters.BackBufferFormat,
 				MathHelper.ClosestMSAAPower(PresentationParameters.MultiSampleCount)
 			);
@@ -662,11 +662,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			*/
 
 			/* Reset the backbuffer first, before doing anything else.
-			 * The GLDevice needs to know what we're up to right away.
+			 * The NativeDevice needs to know what we're up to right away.
 			 * -flibit
 			 */
 			FNA3D.FNA3D_ResetBackbuffer(
-				GLDevice,
+				NativeDevice,
 				ref PresentationParameters.parameters
 			);
 
@@ -734,7 +734,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				 * a more accurate value here, but the Backbuffer may disagree.
 				 * -flibit
 				 */
-				dsFormat = FNA3D.FNA3D_GetBackbufferDepthFormat(GLDevice);
+				dsFormat = FNA3D.FNA3D_GetBackbufferDepthFormat(NativeDevice);
 			}
 			else
 			{
@@ -749,7 +749,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				options &= ~ClearOptions.Stencil;
 			}
 			FNA3D.FNA3D_Clear(
-				GLDevice,
+				NativeDevice,
 				options,
 				ref color,
 				depth,
@@ -786,7 +786,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				x = 0;
 				y = 0;
 				FNA3D.FNA3D_GetBackbufferSize(
-					GLDevice,
+					NativeDevice,
 					out w,
 					out h
 				);
@@ -801,13 +801,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
 			Texture.ValidateGetDataFormat(
-				FNA3D.FNA3D_GetBackbufferSurfaceFormat(GLDevice),
+				FNA3D.FNA3D_GetBackbufferSurfaceFormat(NativeDevice),
 				elementSizeInBytes
 			);
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_ReadBackbuffer(
-				GLDevice,
+				NativeDevice,
 				x,
 				y,
 				w,
@@ -879,7 +879,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (renderTargets == null || renderTargets.Length == 0)
 			{
 				FNA3D.FNA3D_SetRenderTargets(
-					GLDevice,
+					NativeDevice,
 					IntPtr.Zero,
 					0,
 					IntPtr.Zero,
@@ -895,7 +895,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				// Resolve previous targets, if needed
 				for (int i = 0; i < renderTargetCount; i += 1)
 				{
-					FNA3D.FNA3D_ResolveTarget(GLDevice, ref nativeTargetBindings[i]);
+					FNA3D.FNA3D_ResolveTarget(NativeDevice, ref nativeTargetBindings[i]);
 				}
 				Array.Clear(renderTargetBindings, 0, renderTargetBindings.Length);
 				Array.Clear(nativeTargetBindings, 0, nativeTargetBindings.Length);
@@ -910,7 +910,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					{
 						PrepareRenderTargetBindings(rt, renderTargets);
 						FNA3D.FNA3D_SetRenderTargets(
-							GLDevice,
+							NativeDevice,
 							rt,
 							renderTargets.Length,
 							target.DepthStencilBuffer,
@@ -942,7 +942,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					{
 						continue;
 					}
-					FNA3D.FNA3D_ResolveTarget(GLDevice, ref nativeTargetBindings[i]);
+					FNA3D.FNA3D_ResolveTarget(NativeDevice, ref nativeTargetBindings[i]);
 				}
 				Array.Clear(renderTargetBindings, 0, renderTargetBindings.Length);
 				Array.Copy(renderTargets, renderTargetBindings, renderTargets.Length);
@@ -1123,7 +1123,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			PrepareVertexBindingArray(baseVertex);
 
 			FNA3D.FNA3D_DrawIndexedPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				baseVertex,
 				minVertexIndex,
@@ -1145,7 +1145,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int instanceCount
 		) {
 			// If this device doesn't have the support, just explode now before it's too late.
-			if (FNA3D.FNA3D_SupportsHardwareInstancing(GLDevice) == 0)
+			if (FNA3D.FNA3D_SupportsHardwareInstancing(NativeDevice) == 0)
 			{
 				throw new NoSuitableGraphicsDeviceException("Your hardware does not support hardware instancing!");
 			}
@@ -1155,7 +1155,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			PrepareVertexBindingArray(baseVertex);
 
 			FNA3D.FNA3D_DrawInstancedPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				baseVertex,
 				minVertexIndex,
@@ -1182,7 +1182,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			PrepareVertexBindingArray(0);
 
 			FNA3D.FNA3D_DrawPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				vertexStart,
 				primitiveCount
@@ -1226,7 +1226,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			vbHandle.Free();
 
 			FNA3D.FNA3D_DrawIndexedPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				0,
 				0,
@@ -1272,7 +1272,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			vbHandle.Free();
 
 			FNA3D.FNA3D_DrawIndexedPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				0,
 				0,
@@ -1317,7 +1317,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			vbHandle.Free();
 
 			FNA3D.FNA3D_DrawIndexedPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				0,
 				0,
@@ -1363,7 +1363,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			vbHandle.Free();
 
 			FNA3D.FNA3D_DrawIndexedPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				0,
 				0,
@@ -1401,7 +1401,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			vbHandle.Free();
 
 			FNA3D.FNA3D_DrawPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				0,
 				primitiveCount
@@ -1431,7 +1431,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			vbHandle.Free();
 
 			FNA3D.FNA3D_DrawPrimitives(
-				GLDevice,
+				NativeDevice,
 				primitiveType,
 				0,
 				primitiveCount
@@ -1444,7 +1444,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void SetStringMarkerEXT(string text)
 		{
-			FNA3D.FNA3D_SetStringMarker(GLDevice, text);
+			FNA3D.FNA3D_SetStringMarker(NativeDevice, text);
 		}
 
 		#endregion
@@ -1457,7 +1457,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (currentBlend != nextBlend)
 			{
 				FNA3D.FNA3D_SetBlendState(
-					GLDevice,
+					NativeDevice,
 					ref nextBlend.state
 				);
 				currentBlend = nextBlend;
@@ -1465,7 +1465,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (currentDepthStencil != nextDepthStencil)
 			{
 				FNA3D.FNA3D_SetDepthStencilState(
-					GLDevice,
+					NativeDevice,
 					ref nextDepthStencil.state
 				);
 				currentDepthStencil = nextDepthStencil;
@@ -1473,7 +1473,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			// Always update RasterizerState, as it depends on other device states
 			FNA3D.FNA3D_ApplyRasterizerState(
-				GLDevice,
+				NativeDevice,
 				ref RasterizerState.state
 			);
 
@@ -1487,7 +1487,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				modifiedSamplers[sampler] = false;
 
 				FNA3D.FNA3D_VerifySampler(
-					GLDevice,
+					NativeDevice,
 					sampler,
 					(Textures[sampler] != null) ?
 						Textures[sampler].texture :
@@ -1512,7 +1512,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				 * -flibit
 				 */
 				FNA3D.FNA3D_VerifyVertexSampler(
-					GLDevice,
+					NativeDevice,
 					sampler,
 					(VertexTextures[sampler] != null) ?
 						VertexTextures[sampler].texture :
@@ -1537,7 +1537,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					b[i].instanceFrequency = vertexBufferBindings[i].InstanceFrequency;
 				}
 				FNA3D.FNA3D_ApplyVertexBufferBindings(
-					GLDevice,
+					NativeDevice,
 					b,
 					vertexBufferCount,
 					(byte) (vertexBuffersUpdated ? 1 : 0),
@@ -1562,13 +1562,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (userVertexBuffer != IntPtr.Zero)
 				{
 					FNA3D.FNA3D_AddDisposeVertexBuffer(
-						GLDevice,
+						NativeDevice,
 						userVertexBuffer
 					);
 				}
 
 				userVertexBuffer = FNA3D.FNA3D_GenVertexBuffer(
-					GLDevice,
+					NativeDevice,
 					1,
 					BufferUsage.WriteOnly,
 					len
@@ -1577,7 +1577,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			FNA3D.FNA3D_SetVertexBufferData(
-				GLDevice,
+				NativeDevice,
 				userVertexBuffer,
 				0,
 				vertexData + offset,
@@ -1595,7 +1595,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				b->vertexDeclaration.elements = vertexDeclaration.elementsPin;
 				b->vertexOffset = 0;
 				b->instanceFrequency = 0;
-				FNA3D.FNA3D_ApplyVertexBufferBindings(GLDevice, b, 1, 1, 0);
+				FNA3D.FNA3D_ApplyVertexBufferBindings(NativeDevice, b, 1, 1, 0);
 			}
 			vertexBuffersUpdated = true;
 		}
@@ -1612,13 +1612,13 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (userIndexBuffer != IntPtr.Zero)
 				{
 					FNA3D.FNA3D_AddDisposeIndexBuffer(
-						GLDevice,
+						NativeDevice,
 						userIndexBuffer
 					);
 				}
 
 				userIndexBuffer = FNA3D.FNA3D_GenIndexBuffer(
-					GLDevice,
+					NativeDevice,
 					1,
 					BufferUsage.WriteOnly,
 					len
@@ -1627,7 +1627,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			FNA3D.FNA3D_SetIndexBufferData(
-				GLDevice,
+				NativeDevice,
 				userIndexBuffer,
 				0,
 				indexData + (indexOffset * indexElementSizeInBytes),

--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			get
 			{
 				return FNA3D.FNA3D_QueryComplete(
-					GraphicsDevice.GLDevice,
+					GraphicsDevice.NativeDevice,
 					query
 				) == 1;
 			}
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			get
 			{
 				return FNA3D.FNA3D_QueryPixelCount(
-					GraphicsDevice.GLDevice,
+					GraphicsDevice.NativeDevice,
 					query
 				);
 			}
@@ -52,7 +52,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public OcclusionQuery(GraphicsDevice graphicsDevice)
 		{
 			GraphicsDevice = graphicsDevice;
-			query = FNA3D.FNA3D_CreateQuery(GraphicsDevice.GLDevice);
+			query = FNA3D.FNA3D_CreateQuery(GraphicsDevice.NativeDevice);
 		}
 
 		#endregion
@@ -63,7 +63,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			if (!IsDisposed)
 			{
-				FNA3D.FNA3D_AddDisposeQuery(GraphicsDevice.GLDevice, query);
+				FNA3D.FNA3D_AddDisposeQuery(GraphicsDevice.NativeDevice, query);
 			}
 			base.Dispose(disposing);
 		}
@@ -74,12 +74,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void Begin()
 		{
-			FNA3D.FNA3D_QueryBegin(GraphicsDevice.GLDevice, query);
+			FNA3D.FNA3D_QueryBegin(GraphicsDevice.NativeDevice, query);
 		}
 
 		public void End()
 		{
-			FNA3D.FNA3D_QueryEnd(GraphicsDevice.GLDevice, query);
+			FNA3D.FNA3D_QueryEnd(GraphicsDevice.NativeDevice, query);
 		}
 
 		#endregion

--- a/src/Graphics/RenderTarget2D.cs
+++ b/src/Graphics/RenderTarget2D.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		) {
 			DepthStencilFormat = preferredDepthFormat;
 			MultiSampleCount = FNA3D.FNA3D_GetMaxMultiSampleCount(
-				graphicsDevice.GLDevice,
+				graphicsDevice.NativeDevice,
 				Format,
 				MathHelper.ClosestMSAAPower(preferredMultiSampleCount)
 			);
@@ -147,7 +147,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (MultiSampleCount > 0)
 			{
 				glColorBuffer = FNA3D.FNA3D_GenColorRenderbuffer(
-					graphicsDevice.GLDevice,
+					graphicsDevice.NativeDevice,
 					Width,
 					Height,
 					Format,
@@ -163,7 +163,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			glDepthStencilBuffer = FNA3D.FNA3D_GenDepthStencilRenderbuffer(
-				graphicsDevice.GLDevice,
+				graphicsDevice.NativeDevice,
 				Width,
 				Height,
 				DepthStencilFormat,
@@ -182,7 +182,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (glColorBuffer != IntPtr.Zero)
 				{
 					FNA3D.FNA3D_AddDisposeRenderbuffer(
-						GraphicsDevice.GLDevice,
+						GraphicsDevice.NativeDevice,
 						glColorBuffer
 					);
 				}
@@ -190,7 +190,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (glDepthStencilBuffer != IntPtr.Zero)
 				{
 					FNA3D.FNA3D_AddDisposeRenderbuffer(
-						GraphicsDevice.GLDevice,
+						GraphicsDevice.NativeDevice,
 						glDepthStencilBuffer
 					);
 				}

--- a/src/Graphics/RenderTargetCube.cs
+++ b/src/Graphics/RenderTargetCube.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		) {
 			DepthStencilFormat = preferredDepthFormat;
 			MultiSampleCount = FNA3D.FNA3D_GetMaxMultiSampleCount(
-				graphicsDevice.GLDevice,
+				graphicsDevice.NativeDevice,
 				Format,
 				MathHelper.ClosestMSAAPower(preferredMultiSampleCount)
 			);
@@ -182,7 +182,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (MultiSampleCount > 0)
 			{
 				glColorBuffer = FNA3D.FNA3D_GenColorRenderbuffer(
-					graphicsDevice.GLDevice,
+					graphicsDevice.NativeDevice,
 					Size,
 					Size,
 					Format,
@@ -198,7 +198,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			glDepthStencilBuffer = FNA3D.FNA3D_GenDepthStencilRenderbuffer(
-				graphicsDevice.GLDevice,
+				graphicsDevice.NativeDevice,
 				Size,
 				Size,
 				DepthStencilFormat,
@@ -226,7 +226,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (glColorBuffer != IntPtr.Zero)
 				{
 					FNA3D.FNA3D_AddDisposeRenderbuffer(
-						GraphicsDevice.GLDevice,
+						GraphicsDevice.NativeDevice,
 						glColorBuffer
 					);
 				}
@@ -234,7 +234,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (glDepthStencilBuffer != IntPtr.Zero)
 				{
 					FNA3D.FNA3D_AddDisposeRenderbuffer(
-						GraphicsDevice.GLDevice,
+						GraphicsDevice.NativeDevice,
 						glDepthStencilBuffer
 					);
 				}

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			beginCalled = false;
 			numSprites = 0;
 			supportsNoOverwrite = FNA3D.FNA3D_SupportsNoOverwrite(
-				GraphicsDevice.GLDevice
+				GraphicsDevice.NativeDevice
 			) == 1;
 		}
 

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				GraphicsDevice.Textures.RemoveDisposedTexture(this);
 				GraphicsDevice.VertexTextures.RemoveDisposedTexture(this);
 				FNA3D.FNA3D_AddDisposeTexture(
-					GraphicsDevice.GLDevice,
+					GraphicsDevice.NativeDevice,
 					texture
 				);
 			}

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			texture = FNA3D.FNA3D_CreateTexture2D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				Format,
 				Width,
 				Height,
@@ -163,7 +163,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementSize = Marshal.SizeOf(typeof(T));
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetTextureData2D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				x,
 				y,
@@ -204,7 +204,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			FNA3D.FNA3D_SetTextureData2D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				x,
 				y,
@@ -285,7 +285,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_GetTextureData2D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				subX,
 				subY,
@@ -307,7 +307,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int len = Width * Height * GetFormatSize(Format);
 			IntPtr data = Marshal.AllocHGlobal(len);
 			FNA3D.FNA3D_GetTextureData2D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				0,
 				0,
@@ -336,7 +336,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int len = Width * Height * GetFormatSize(Format);
 			IntPtr data = Marshal.AllocHGlobal(len);
 			FNA3D.FNA3D_GetTextureData2D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				0,
 				0,

--- a/src/Graphics/Texture3D.cs
+++ b/src/Graphics/Texture3D.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			Format = format;
 
 			texture = FNA3D.FNA3D_CreateTexture3D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				Format,
 				Width,
 				Height,
@@ -122,7 +122,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetTextureData3D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				left,
 				top,
@@ -154,7 +154,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			FNA3D.FNA3D_SetTextureData3D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				left,
 				top,
@@ -261,7 +261,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_GetTextureData3D(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				left,
 				top,

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			texture = FNA3D.FNA3D_CreateTextureCube(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				Format,
 				Size,
 				LevelCount,
@@ -143,7 +143,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetTextureDataCube(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				xOffset,
 				yOffset,
@@ -186,7 +186,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			FNA3D.FNA3D_SetTextureDataCube(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				xOffset,
 				yOffset,
@@ -273,7 +273,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_GetTextureDataCube(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				texture,
 				subX,
 				subY,

--- a/src/Graphics/Vertices/DynamicIndexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicIndexBuffer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetIndexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),
@@ -102,7 +102,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetIndexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				0,
 				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),

--- a/src/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetVertexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes),
@@ -107,7 +107,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetVertexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				0,
 				handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes),

--- a/src/Graphics/Vertices/IndexBuffer.cs
+++ b/src/Graphics/Vertices/IndexBuffer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int stride = (indexElementSize == IndexElementSize.ThirtyTwoBits) ? 4 : 2;
 
 			buffer = FNA3D.FNA3D_GenIndexBuffer(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				(byte) (dynamic ? 1 : 0),
 				usage,
 				IndexCount * stride
@@ -129,7 +129,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (!IsDisposed)
 			{
 				FNA3D.FNA3D_AddDisposeIndexBuffer(
-					GraphicsDevice.GLDevice,
+					GraphicsDevice.NativeDevice,
 					buffer
 				);
 			}
@@ -188,7 +188,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_GetIndexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes),
@@ -205,7 +205,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetIndexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				0,
 				handle.AddrOfPinnedObject(),
@@ -224,7 +224,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetIndexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				0,
 				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),
@@ -244,7 +244,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetIndexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),
@@ -265,7 +265,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			SetDataOptions options
 		) {
 			FNA3D.FNA3D_SetIndexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				data,

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			buffer = FNA3D.FNA3D_GenVertexBuffer(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				(byte) (dynamic ? 1 : 0),
 				bufferUsage,
 				VertexCount * VertexDeclaration.VertexStride
@@ -118,7 +118,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (!IsDisposed)
 			{
 				FNA3D.FNA3D_AddDisposeVertexBuffer(
-					GraphicsDevice.GLDevice,
+					GraphicsDevice.NativeDevice,
 					buffer
 				);
 			}
@@ -197,7 +197,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_GetVertexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes),
@@ -249,7 +249,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetVertexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes),
@@ -272,7 +272,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			SetDataOptions options
 		) {
 			FNA3D.FNA3D_SetVertexBufferData(
-				GraphicsDevice.GLDevice,
+				GraphicsDevice.NativeDevice,
 				buffer,
 				offsetInBytes,
 				data,

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Xna.Framework
 				if (graphicsDevice != null)
 				{
 					maxMultiSampleCount = FNA3D.FNA3D_GetMaxMultiSampleCount(
-						graphicsDevice.GLDevice,
+						graphicsDevice.NativeDevice,
 						gdi.PresentationParameters.BackBufferFormat,
 						8
 					);

--- a/src/Media/Xiph/VideoPlayer.cs
+++ b/src/Media/Xiph/VideoPlayer.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Xna.Framework.Media
 		{
 			// Begin the effect, flagging to restore previous state on end
 			FNA3D.FNA3D_BeginPassRestore(
-				currentDevice.GLDevice,
+				currentDevice.NativeDevice,
 				shaderProgram.glEffect,
 				stateChangesPtr
 			);
@@ -197,7 +197,7 @@ namespace Microsoft.Xna.Framework.Media
 						videoTexture
 					);
 					FNA3D.FNA3D_SetRenderTargets(
-						currentDevice.GLDevice,
+						currentDevice.NativeDevice,
 						rt,
 						videoTexture.Length,
 						IntPtr.Zero,
@@ -218,7 +218,7 @@ namespace Microsoft.Xna.Framework.Media
 			// Prep viewport
 			prevViewport = currentDevice.Viewport;
 			FNA3D.FNA3D_SetViewport(
-				currentDevice.GLDevice,
+				currentDevice.NativeDevice,
 				ref viewport.viewport
 			);
 		}
@@ -227,7 +227,7 @@ namespace Microsoft.Xna.Framework.Media
 		{
 			// End the effect, restoring the previous shader state
 			FNA3D.FNA3D_EndPassRestore(
-				currentDevice.GLDevice,
+				currentDevice.NativeDevice,
 				shaderProgram.glEffect
 			);
 
@@ -239,13 +239,13 @@ namespace Microsoft.Xna.Framework.Media
 			prevDepthStencil = null;
 			prevRasterizer = null;
 
-			/* Restore targets using GLDevice directly.
+			/* Restore targets using NativeDevice directly.
 			 * This prevents accidental clearing of previously bound targets.
 			 */
 			if (oldTargets == null || oldTargets.Length == 0)
 			{
 				FNA3D.FNA3D_SetRenderTargets(
-					currentDevice.GLDevice,
+					currentDevice.NativeDevice,
 					IntPtr.Zero,
 					0,
 					IntPtr.Zero,
@@ -266,7 +266,7 @@ namespace Microsoft.Xna.Framework.Media
 							oldTargets
 						);
 						FNA3D.FNA3D_SetRenderTargets(
-							currentDevice.GLDevice,
+							currentDevice.NativeDevice,
 							rt,
 							oldTargets.Length,
 							oldTarget.DepthStencilBuffer,
@@ -280,7 +280,7 @@ namespace Microsoft.Xna.Framework.Media
 
 			// Set viewport AFTER setting targets!
 			FNA3D.FNA3D_SetViewport(
-				currentDevice.GLDevice,
+				currentDevice.NativeDevice,
 				ref prevViewport.viewport
 			);
 
@@ -769,7 +769,7 @@ namespace Microsoft.Xna.Framework.Media
 		{
 			// Prepare YUV GL textures with our current frame data
 			FNA3D.FNA3D_SetTextureDataYUV(
-				currentDevice.GLDevice,
+				currentDevice.NativeDevice,
 				yuvTextures[0].texture,
 				yuvTextures[1].texture,
 				yuvTextures[2].texture,


### PR DESCRIPTION
`GraphicsDevice` comes with an `internal IntPtr GLDevice` and that kept me thinking whether this is a relic from the past or exists for a reason. I hereby forward the commotion to have `GLDevice` renamed to `NativeDevice` as the latter feels more natural and `GL` keeps me thinking about OpenGL, while said device could be anything from OpenGL, to Vulkan over some Metal- or DX related device.