### PR TITLE
Update FNA.csproj

### DIFF
--- a/FNA.csproj
+++ b/FNA.csproj
@@ -408,7 +408,7 @@
     <Compile Include="lib\Theorafile\csharp\Theorafile.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" Condition="$(MSBuildToolsVersion) == '4.8.3761.0'">
+    <None Include="app.config" Condition="$(MSBuildToolsVersion) == '4.6.1055.0'">
       <Link>$(TargetFileName).config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -408,10 +408,11 @@
     <Compile Include="lib\Theorafile\csharp\Theorafile.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config">
+    <None Include="app.config" Condition="$(MSBuildToolsVersion) == '4.8.3761.0'">
       <Link>$(TargetFileName).config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="src\Graphics\Effect\StockEffects\FXB\AlphaTestEffect.fxb">


### PR DESCRIPTION
Add condition to load app.config
VS2019 (at least 16.8.3) is unable to load app.config with the <Link> element

Version 4.8.3761.0 provided in the condition needs to be verified for vs2010 builds