### PR TITLE
Fix D3D11 warnings by calling ApplyState more frequently

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -729,7 +729,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
 		{
-			ApplyState();
 			DepthFormat dsFormat;
 			if (renderTargetCount == 0)
 			{
@@ -853,7 +852,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void SetRenderTargets(params RenderTargetBinding[] renderTargets)
 		{
-			ApplyState();
+			// D3D11 requires our sampler state to be valid (i.e. not point to any of our new RTs)
+			//  before we call SetRenderTargets. At this point FNA3D does not have a current copy
+            //  of the managed sampler state, so we need to apply our current state now instead of
+            //  before our next Clear or Draw operation.
+			ApplySamplers();
+
 			// Checking for redundant SetRenderTargets...
 			if (renderTargets == null && renderTargetCount == 0)
 			{
@@ -1481,6 +1485,11 @@ namespace Microsoft.Xna.Framework.Graphics
 				ref RasterizerState.state
 			);
 
+			ApplySamplers();
+		}
+
+		private void ApplySamplers()
+		{
 			for (int sampler = 0; sampler < modifiedSamplers.Length; sampler += 1)
 			{
 				if (!modifiedSamplers[sampler])

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -729,6 +729,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
 		{
+			ApplyState();
 			DepthFormat dsFormat;
 			if (renderTargetCount == 0)
 			{
@@ -852,6 +853,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void SetRenderTargets(params RenderTargetBinding[] renderTargets)
 		{
+			ApplyState();
 			// Checking for redundant SetRenderTargets...
 			if (renderTargets == null && renderTargetCount == 0)
 			{

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -854,8 +854,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			// D3D11 requires our sampler state to be valid (i.e. not point to any of our new RTs)
 			//  before we call SetRenderTargets. At this point FNA3D does not have a current copy
-            //  of the managed sampler state, so we need to apply our current state now instead of
-            //  before our next Clear or Draw operation.
+			//  of the managed sampler state, so we need to apply our current state now instead of
+			//  before our next Clear or Draw operation.
 			ApplySamplers();
 
 			// Checking for redundant SetRenderTargets...


### PR DESCRIPTION
In a few of my test cases, the last thing I do is blit my UI render target to the screen, and the first thing I do is set it as my RT and paint to it. This is valid (and I clear the sampler states explicitly before even setting the RTs) but because we only apply state on draw calls, the device state is invalid at the point where FNA sets the render targets.

I added ApplyState calls to SetRenderTargets and Clear because I believe we need to flush them there. There might be other spots too but none occurred to me.