### PR TITLE
Add .editorconfig to maintain FNA's required style of using tabs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+[*.cs]
+indent_style = tab
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,4 +2,5 @@
 
 [*.cs]
 indent_style = tab
-indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
May help folks contributing to FNA, and it's been kicking around my repo since 2019.  Some editors, including Visual Studio will use this information to maintain the FNA rules within the FNA sub-tree even when your editor is configured for something else.

If you accept this, then I will be one step closer to vanilla FNA repo.