### PR TITLE
Update FNA.sln to allow default build as Any CPU and not skip build

### DIFF
--- a/FNA.sln
+++ b/FNA.sln
@@ -9,8 +9,8 @@ Global
 		Release|x86 = Release|x86
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
-		Debug|AnyCPU = Debug|AnyCPU
-		Release|AnyCPU = Release|AnyCPU
+		Debug|AnyCPU = Debug|Any CPU
+		Release|AnyCPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.ActiveCfg = Debug|x86
@@ -21,10 +21,10 @@ Global
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x64.Build.0 = Debug|x64
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x64.ActiveCfg = Release|x64
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x64.Build.0 = Release|x64
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.Build.0 = Release|AnyCPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = FNA.csproj

--- a/FNA.sln
+++ b/FNA.sln
@@ -9,8 +9,8 @@ Global
 		Release|x86 = Release|x86
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
-		Debug|AnyCPU = Debug|Any CPU
-		Release|AnyCPU = Release|Any CPU
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.ActiveCfg = Debug|x86


### PR DESCRIPTION
Turns out there are typos in FNA.sln

"AnyCPU" as a configuration name (the values on the right hand side of the equal sign) is not valid, its "Any CPU"

Tested on VS2019 (latest 16.10), VS2022 Preview 1 (latest 17.0)

Fixes #353