### PR TITLE
Tweak sleep behavior to avoid oversleep

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -424,7 +424,6 @@ namespace Microsoft.Xna.Framework
 			AfterLoop();
 		}
 
-
 		public void Tick()
 		{
 			/* NOTE: This code is very sensitive and can break very badly,


### PR DESCRIPTION
We had a complaint about input latency on the FNA version of Celeste compared to the XNA version. I investigated using the Vulkan renderer and ruled out rendering and presentation. When I removed the sleep from Tick(), the reported input latency vanished. Schedulers have a tendency to wake up the thread early, so it is likely that by continuing to sleep until we reach the full timestep amount we are oversleeping by the sleep resolution amount of the operating system. However, busywaiting is not exactly ideal, so I propose a compromise.

This patch makes it so that we attempt to sleep for the full fixed timestep amount remaining. Because schedulers usually wake us up early, and sleep resolution is finite, we have a "no sleep threshold" value. If we still have time to wait, but that time is shorter than the "no sleep threshold", then we do not sleep, but we do not perform Update() either. This allows the next fixed timestep to happen accurately without wasting too many CPU cycles.

This changed behavior causes Draw() to run every loop until the next Update() is performed, which is pointless and wastes GPU resources, so Draw() is now only called from Tick() if an update has actually been performed. 