### PR TITLE
Game loop timing improvements

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -444,14 +444,14 @@ namespace Microsoft.Xna.Framework
 					UpdateEstimatedSleepPrecision(timeAdvancedSinceSleeping);
 				}
 
-				/* Now that we have slept into the sleep precision threshold, we need to sleep
+				/* Now that we have slept into the sleep precision threshold, we need to wait
 				 * for just a little bit longer until the target elapsed time has been reached.
-				 * Let's just busywait and increment the timer.
-				 *
-				 * NOTE: We tried SpinWait and it increased CPU usage enormously.
+				 * SpinWait(1) works by pausing the thread for very short intervals, so it is
+				 * an efficient and time-accurate way to wait out the rest of the time.
 				 */
 				while (accumulatedElapsedTime < TargetElapsedTime)
 				{
+					System.Threading.Thread.SpinWait(1);
 					AdvanceElapsedTime();
 				}
 			}

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -888,7 +888,7 @@ namespace Microsoft.Xna.Framework
 		private void UpdateEstimatedSleepPrecision(TimeSpan timeSpentSleeping)
 		{
 			/* It is unlikely that the scheduler will actually be more imprecise than
-			 * 4ms and we don't want to get wrecked by a bad frame so we cap this
+			 * 4ms and we don't want to get wrecked by a single long sleep so we cap this
 			 * value at 4ms for sanity.
 			 */
 			var upperTimeBound = TimeSpan.FromMilliseconds(4);
@@ -900,7 +900,7 @@ namespace Microsoft.Xna.Framework
 
 			/* We know the previous worst case - it's saved in worstCaseSleepPrecision.
 			 * We also know the current index. So the only way the worst case changes
-			 * is if you either 1) just got a new worst case, or 2) the worst case was
+			 * is if we either 1) just got a new worst case, or 2) the worst case was
 			 * the oldest entry on the list.
 			 */
 			if (timeSpentSleeping >= worstCaseSleepPrecision)

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -387,13 +387,6 @@ namespace Microsoft.Xna.Framework
 				hasInitialized = true;
 			}
 
-			FNAPlatform.PollEvents(
-				this,
-				ref currentAdapter,
-				textInputControlDown,
-				textInputControlRepeat,
-				ref textInputSuppress
-			);
 			Tick();
 		}
 
@@ -450,6 +443,15 @@ namespace Microsoft.Xna.Framework
 
 				goto RetryTick;
 			}
+
+			// Now that we are going to perform an update, let's poll events.
+			FNAPlatform.PollEvents(
+				this,
+				ref currentAdapter,
+				textInputControlDown,
+				textInputControlRepeat,
+				ref textInputSuppress
+			);
 
 			// Do not allow any update to take longer than our maximum.
 			if (accumulatedElapsedTime > MaxElapsedTime)
@@ -854,13 +856,6 @@ namespace Microsoft.Xna.Framework
 
 			while (RunApplication)
 			{
-				FNAPlatform.PollEvents(
-					this,
-					ref currentAdapter,
-					textInputControlDown,
-					textInputControlRepeat,
-					ref textInputSuppress
-				);
 				Tick();
 			}
 			OnExiting(this, EventArgs.Empty);

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -914,7 +914,7 @@ namespace Microsoft.Xna.Framework
 				{
 					if (previousSleepTimes[i] > maxSleepTime)
 					{
-						maxSleepTime = timeSpentSleeping;
+						maxSleepTime = previousSleepTimes[i];
 					}
 				}
 				worstCaseSleepPrecision = maxSleepTime;


### PR DESCRIPTION
1) We were polling events before sleeping, which was causing input latency.

2) Currently our fixed timestep sleep puts us entirely at the mercy of the system scheduler, so now we sleep for 1ms intervals, checking worst case timing the system sleeps for, and making adjustments based on that. 