### PR TITLE
Fix some false negatives coming from bbox-sphere intersection test

### DIFF
--- a/src/BoundingBox.cs
+++ b/src/BoundingBox.cs
@@ -422,14 +422,7 @@ namespace Microsoft.Xna.Framework
 				dmin += (sphere.Center.Z - Max.Z) * (sphere.Center.Z - Max.Z);
 			}
 
-			if (dmin <= radiusSq)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			return (dmin <= radiusSq);
 		}
 
 		public void Intersects(ref Plane plane, out PlaneIntersectionType result)


### PR DESCRIPTION
I was getting some false negatives from the bounding box - bounding sphere intersection test. In my game (Miasma 2) this was causing the headquarters to flash in and out, i.e. not render for some frames from certain camera angles. It was ok 99% of the time, but sometimes I could find a combination of positions and angles where it would fail a (thoroughly tested for what I think was an optimisation at the time) frustum check. Essentially, we did a rough bbox-sphere test before doing a more complicated frustum test.

I've re-written the check using code from Graphics Gems which I actually found on StackOverflow: https://stackoverflow.com/questions/4578967/cube-sphere-intersection-test

And it's working ok for me now.