### PR TITLE
Add @rpath/ prefix to OSX as workaround to changes in ordering

### DIFF
--- a/app.config
+++ b/app.config
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<dllmap dll="SDL2" os="windows" target="SDL2.dll"/>
-	<dllmap dll="SDL2" os="osx" target="libSDL2-2.0.0.dylib"/>
+	<dllmap dll="SDL2" os="osx" target="@rpath/libSDL2-2.0.0.dylib"/>
 	<dllmap dll="SDL2" os="linux,freebsd,netbsd" target="libSDL2-2.0.so.0"/>
 
 	<dllmap dll="FNA3D" os="windows" target="FNA3D.dll"/>
-	<dllmap dll="FNA3D" os="osx" target="libFNA3D.0.dylib"/>
+	<dllmap dll="FNA3D" os="osx" target="@rpath/libFNA3D.0.dylib"/>
 	<dllmap dll="FNA3D" os="linux,freebsd,netbsd" target="libFNA3D.so.0"/>
 
 	<dllmap dll="FAudio" os="windows" target="FAudio.dll"/>
-	<dllmap dll="FAudio" os="osx" target="libFAudio.0.dylib"/>
+	<dllmap dll="FAudio" os="osx" target="@rpath/libFAudio.0.dylib"/>
 	<dllmap dll="FAudio" os="linux,freebsd,netbsd" target="libFAudio.so.0"/>
 </configuration>


### PR DESCRIPTION
Tested this change on a Catalina, Big Sur, and Monterey box. Seems to work correctly.