### PR TITLE
Adding support for float textures to DDS

### DIFF
--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			const uint FOURCC_DXT3 = 0x33545844;
 			const uint FOURCC_DXT5 = 0x35545844;
 			const uint FOURCC_BPTC = 0x30315844;
-			//const uint FOURCC_DX10 = 0x30315844;
+			// const uint FOURCC_DX10 = 0x30315844;
 			const uint pitchAndLinear = (
 				DDSD_PITCH | DDSD_LINEARSIZE
 			);
@@ -315,7 +315,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						break;
 					case FOURCC_BPTC:
 						format = SurfaceFormat.Bc7EXT;
-						break;						
+						break;
 					default:
 						throw new NotSupportedException(
 							"Unsupported DDS texture format"

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -166,6 +166,16 @@ namespace Microsoft.Xna.Framework.Graphics
 				return (((width * 32) + 7) / 8) * height;
 			}
 			else
+			if (format == SurfaceFormat.HalfVector4)
+			{
+				return (((width * 64) + 7) / 8) * height;
+			}
+			else
+			if (format == SurfaceFormat.Vector4)
+			{
+				return (((width * 128) + 7) / 8) * height;
+			}
+			else
 			{
 				int blockSize = 16;
 				if (format == SurfaceFormat.Dxt1)
@@ -212,7 +222,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			const uint FOURCC_DXT3 = 0x33545844;
 			const uint FOURCC_DXT5 = 0x35545844;
 			const uint FOURCC_BPTC = 0x30315844;
-			// const uint FOURCC_DX10 = 0x30315844;
+//			const uint FOURCC_DX10 = 0x30315844;
 			const uint pitchAndLinear = (
 				DDSD_PITCH | DDSD_LINEARSIZE
 			);
@@ -290,6 +300,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				switch (formatFourCC)
 				{
+					case 0x71:
+						format = SurfaceFormat.HalfVector4;
+						break;
+					case 0x74:
+						format = SurfaceFormat.Vector4;
+						break;
 					case FOURCC_DXT1:
 						format = SurfaceFormat.Dxt1;
 						break;
@@ -301,7 +317,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						break;
 					case FOURCC_BPTC:
 						format = SurfaceFormat.Bc7EXT;
-						break;
+						break;						
 					default:
 						throw new NotSupportedException(
 							"Unsupported DDS texture format"

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -165,13 +165,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				return (((width * 32) + 7) / 8) * height;
 			}
-			else
-			if (format == SurfaceFormat.HalfVector4)
+			else if (format == SurfaceFormat.HalfVector4)
 			{
 				return (((width * 64) + 7) / 8) * height;
 			}
-			else
-			if (format == SurfaceFormat.Vector4)
+			else if (format == SurfaceFormat.Vector4)
 			{
 				return (((width * 128) + 7) / 8) * height;
 			}
@@ -222,7 +220,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			const uint FOURCC_DXT3 = 0x33545844;
 			const uint FOURCC_DXT5 = 0x35545844;
 			const uint FOURCC_BPTC = 0x30315844;
-//			const uint FOURCC_DX10 = 0x30315844;
+			//const uint FOURCC_DX10 = 0x30315844;
 			const uint pitchAndLinear = (
 				DDSD_PITCH | DDSD_LINEARSIZE
 			);

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -298,10 +298,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				switch (formatFourCC)
 				{
-					case 0x71:
+					case 0x71: // D3DFMT_A16B16G16R16F
 						format = SurfaceFormat.HalfVector4;
 						break;
-					case 0x74:
+					case 0x74: // D3DFMT_A32B32G32R32F
 						format = SurfaceFormat.Vector4;
 						break;
 					case FOURCC_DXT1:


### PR DESCRIPTION
Needed to load some Cubemaps which were using 64bpp and 128bpp floats and discovered that FNA did not support this. 

I managed to get it working via these changes to Texture.cs.