### PR TITLE
Fix for repeating non-text input speed issue.

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -232,7 +232,6 @@ namespace Microsoft.Xna.Framework
 			Game game,
 			ref GraphicsAdapter currentAdapter,
 			bool[] textInputControlDown,
-			int[] textInputControlRepeat,
 			ref bool textInputSuppress
 		);
 		public static readonly PollEventsFunc PollEvents;

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -875,7 +875,7 @@ namespace Microsoft.Xna.Framework
 						}
 					}
 					else if (evt.key.repeat > 0)
-                    {
+					{
 						int textIndex;
 						if (FNAPlatform.TextInputBindings.TryGetValue(key, out textIndex))
 						{

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -847,7 +847,6 @@ namespace Microsoft.Xna.Framework
 			Game game,
 			ref GraphicsAdapter currentAdapter,
 			bool[] textInputControlDown,
-			int[] textInputControlRepeat,
 			ref bool textInputSuppress
 		) {
 			SDL.SDL_Event evt;
@@ -865,15 +864,21 @@ namespace Microsoft.Xna.Framework
 						if (FNAPlatform.TextInputBindings.TryGetValue(key, out textIndex))
 						{
 							textInputControlDown[textIndex] = true;
-							textInputControlRepeat[textIndex] = Environment.TickCount + 400;
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
 						else if (Keyboard.keys.Contains(Keys.LeftControl) && key == Keys.V)
 						{
 							textInputControlDown[6] = true;
-							textInputControlRepeat[6] = Environment.TickCount + 400;
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[6]);
 							textInputSuppress = true;
+						}
+					}
+					else if (evt.key.repeat > 0)
+                    {
+						int textIndex;
+						if (FNAPlatform.TextInputBindings.TryGetValue(key, out textIndex))
+						{
+							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
 					}
 				}
@@ -1122,14 +1127,6 @@ namespace Microsoft.Xna.Framework
 				{
 					game.RunApplication = false;
 					break;
-				}
-			}
-			// Text Input Controls Key Handling
-			for (int i = 0; i < FNAPlatform.TextInputCharacters.Length; i += 1)
-			{
-				if (textInputControlDown[i] && textInputControlRepeat[i] <= Environment.TickCount)
-				{
-					TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[i]);
 				}
 			}
 		}

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -880,6 +880,10 @@ namespace Microsoft.Xna.Framework
 						{
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
+						else if (Keyboard.keys.Contains(Keys.LeftControl) && key == Keys.V)
+						{
+							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[6]);
+						}
 					}
 				}
 				else if (evt.type == SDL.SDL_EventType.SDL_KEYUP)

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -866,7 +866,8 @@ namespace Microsoft.Xna.Framework
 							textInputControlDown[textIndex] = true;
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
-						else if (Keyboard.keys.Contains(Keys.LeftControl) && key == Keys.V)
+						else if ((Keyboard.keys.Contains(Keys.LeftControl) || Keyboard.keys.Contains(Keys.RightControl))
+							&& key == Keys.V)
 						{
 							textInputControlDown[6] = true;
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[6]);
@@ -880,7 +881,8 @@ namespace Microsoft.Xna.Framework
 						{
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
-						else if (Keyboard.keys.Contains(Keys.LeftControl) && key == Keys.V)
+						else if ((Keyboard.keys.Contains(Keys.LeftControl) || Keyboard.keys.Contains(Keys.RightControl))
+							&& key == Keys.V)
 						{
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[6]);
 						}
@@ -896,7 +898,8 @@ namespace Microsoft.Xna.Framework
 						{
 							textInputControlDown[value] = false;
 						}
-						else if ((!Keyboard.keys.Contains(Keys.LeftControl) && textInputControlDown[6]) || key == Keys.V)
+						else if (((!Keyboard.keys.Contains(Keys.LeftControl) && !Keyboard.keys.Contains(Keys.RightControl)) && textInputControlDown[6])
+							|| key == Keys.V)
 						{
 							textInputControlDown[6] = false;
 							textInputSuppress = false;

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -223,7 +223,6 @@ namespace Microsoft.Xna.Framework
 		private static readonly TimeSpan MaxElapsedTime = TimeSpan.FromMilliseconds(500);
 
 		private bool[] textInputControlDown;
-		private int[] textInputControlRepeat;
 		private bool textInputSuppress;
 
 		#endregion
@@ -263,7 +262,6 @@ namespace Microsoft.Xna.Framework
 			}
 
 			textInputControlDown = new bool[FNAPlatform.TextInputCharacters.Length];
-			textInputControlRepeat = new int[FNAPlatform.TextInputCharacters.Length];
 
 			hasInitialized = false;
 			suppressDraw = false;
@@ -462,7 +460,6 @@ namespace Microsoft.Xna.Framework
 				this,
 				ref currentAdapter,
 				textInputControlDown,
-				textInputControlRepeat,
 				ref textInputSuppress
 			);
 


### PR DESCRIPTION
The current code handles non-text repeating inside FNA, however it doesn't delay the repeat which can cause timing issues when running at higher frame rates (Backspace deletes text faster than a user would expect).  Per Ethan's recommendation using the repeat field from the sdl event allows repeating using the expected OS behavior/speed.  

As part of this change I also removed the repeat array which is no longer used.  Additionally added support to paste using right control as well as left, as is expected behavior on Windows (Do not have immediate access to Linux/Mac to test).

This does alter the parameters of public PollEvents function + delegate so could potentially cause issues for folks touching PollEvents (Not sure why anyone would).  