### PR TITLE
Disable access checks on FNA3D P/Invokes

### DIFF
--- a/src/Graphics/FNA3D.cs
+++ b/src/Graphics/FNA3D.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+	[System.Security.SuppressUnmanagedCodeSecurity]
 	internal static class FNA3D
 	{
 		#region Private Constants


### PR DESCRIPTION
In profiles of windows .netframework builds, a chunk of time is spent running StubHelpers.DemandPermission, which is the runtime icall that performs code access checks. The checks require doing a stack-walk to make sure everything on the stack is trusted to perform p/invokes. A FNA game isn't going to work without having full access to do this, so we can just disable checks for the entire FNA3D class. Doing this will cause the .NET runtime to perform the access check once when compiling the class instead of doing it every time a pinvoke gets called.

The profile timings added up to around 160ms of access checking over a 30 second period, but I think the actual cost is higher since a stackwalk like this is also going to perform syscalls and evict a bunch of stuff from the cpu icache/dcache.

We could do this for things like SDL2 and FAudio as well, but in my profiles the FNA3D functions accounted for the vast majority of the time.