### PR TITLE
Bounds-check Texture2D uploads

### DIFF
--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Static SurfaceFormat Size Methods
 
-		internal static int GetBlockSize(SurfaceFormat format)
+		private static int GetBlockSizeSquared(SurfaceFormat format)
 		{
 			switch (format)
 			{

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Static SurfaceFormat Size Methods
 
-		private static int GetBlockSizeSquared(SurfaceFormat format)
+		protected static int GetBlockSizeSquared(SurfaceFormat format)
 		{
 			switch (format)
 			{

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -67,6 +67,42 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Static SurfaceFormat Size Methods
 
+		internal static int GetBlockSize(SurfaceFormat format)
+		{
+			switch (format)
+			{
+				case SurfaceFormat.Dxt1:
+				case SurfaceFormat.Dxt3:
+				case SurfaceFormat.Dxt5:
+				case SurfaceFormat.Dxt5SrgbEXT:
+				case SurfaceFormat.Bc7EXT:
+				case SurfaceFormat.Bc7SrgbEXT:
+					return 4;
+				case SurfaceFormat.Alpha8:
+				case SurfaceFormat.Bgr565:
+				case SurfaceFormat.Bgra4444:
+				case SurfaceFormat.Bgra5551:
+				case SurfaceFormat.HalfSingle:
+				case SurfaceFormat.NormalizedByte2:
+				case SurfaceFormat.Color:
+				case SurfaceFormat.Single:
+				case SurfaceFormat.Rg32:
+				case SurfaceFormat.HalfVector2:
+				case SurfaceFormat.NormalizedByte4:
+				case SurfaceFormat.Rgba1010102:
+				case SurfaceFormat.ColorBgraEXT:
+				case SurfaceFormat.ColorSrgbEXT:
+				case SurfaceFormat.HalfVector4:
+				case SurfaceFormat.Rgba64:
+				case SurfaceFormat.Vector2:
+				case SurfaceFormat.HdrBlendable:
+				case SurfaceFormat.Vector4:
+					return 1;
+				default:
+					throw new ArgumentException("Should be a value defined in SurfaceFormat", "Format");
+			}
+		}
+
 		internal static int GetFormatSize(SurfaceFormat format)
 		{
 			switch (format)

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				case SurfaceFormat.Dxt5SrgbEXT:
 				case SurfaceFormat.Bc7EXT:
 				case SurfaceFormat.Bc7SrgbEXT:
-					return 4;
+					return 16;
 				case SurfaceFormat.Alpha8:
 				case SurfaceFormat.Bgr565:
 				case SurfaceFormat.Bgra4444:

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -163,6 +163,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("data");
 			}
+			if (startIndex < 0)
+			{
+				throw new ArgumentOutOfRangeException("startIndex");
+			}
+			if (data.Length < (elementCount + startIndex))
+			{
+				throw new ArgumentOutOfRangeException("elementCount");
+			}
 
 			int x, y, w, h;
 			if (rect.HasValue)
@@ -179,7 +187,15 @@ namespace Microsoft.Xna.Framework.Graphics
 				w = Math.Max(Width >> level, 1);
 				h = Math.Max(Height >> level, 1);
 			}
-			int elementSize = Marshal.SizeOf(typeof(T));
+			int elementSize = Marshal.SizeOf(typeof(T)),
+				blockSize = GetBlockSize(Format),
+				requiredBytes = (w * h * GetFormatSize(Format) / blockSize / blockSize),
+				availableBytes = elementCount * elementSize;
+			if (requiredBytes > availableBytes)
+			{
+				throw new ArgumentOutOfRangeException("rect", "The region you are trying to upload is larger than the amount of data you provided.");
+			}
+
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetTextureData2D(
 				GraphicsDevice.GLDevice,

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -187,10 +187,9 @@ namespace Microsoft.Xna.Framework.Graphics
 				w = Math.Max(Width >> level, 1);
 				h = Math.Max(Height >> level, 1);
 			}
-			int elementSize = Marshal.SizeOf(typeof(T)),
-				blockSize = GetBlockSize(Format),
-				requiredBytes = (w * h * GetFormatSize(Format) / blockSize / blockSize),
-				availableBytes = elementCount * elementSize;
+			int elementSize = Marshal.SizeOf(typeof(T));
+			int requiredBytes = (w * h * GetFormatSize(Format)) / GetBlockSizeSquared(Format);
+			int availableBytes = elementCount * elementSize;
 			if (requiredBytes > availableBytes)
 			{
 				throw new ArgumentOutOfRangeException("rect", "The region you are trying to upload is larger than the amount of data you provided.");


### PR DESCRIPTION
Bounds-check Texture2D uploads, because not all FNA3D backends can respond correctly if asked to upload more pixels than you give them

Crash repro is to Texture2D.SetData(someSmallArray) a large texture with the D3D11 backend. Vulkan seems to quietly just upload the amount of data you handed it, while D3D11 will pull random junk out of memory.