### PR TITLE
Improve SpriteBatch efficiency

### DIFF
--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1090,12 +1090,6 @@ namespace Microsoft.Xna.Framework.Graphics
 					 * increase the graphics buffer sizes!
 					 * -flibit
 					 */
-
-					 /* Fix: reallocation size now increase exponentially, 
-					  * but upper bounded to 1048576. When we submit more than 
-					  * 1048576 sprites, we flush them immediately. This will make
-					  * the total running time O(n).
-					 */ 
 					int newMax = Math.Min(vertexInfo.Length * 2, MAX_ARRAYSIZE);
 					Array.Resize(ref vertexInfo, newMax);
 					Array.Resize(ref textureInfo, newMax);

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		private const int MAX_SPRITES = 2048;
 		private const int MAX_VERTICES = MAX_SPRITES * 4;
 		private const int MAX_INDICES = MAX_SPRITES * 6;
+		private const int MAX_BATCHSIZE = 1048576;
 
 		// Used to quickly flip text for DrawString
 		private static readonly float[] axisDirectionX = new float[]
@@ -1067,17 +1068,30 @@ namespace Microsoft.Xna.Framework.Graphics
 		) {
 			if (numSprites >= vertexInfo.Length)
 			{
-				/* We're out of room, add another batch max
-				 * to the total array size. This is required for
-				 * sprite sorting accuracy; note that we do NOT
-				 * increase the graphics buffer sizes!
-				 * -flibit
-				 */
-				int newMax = vertexInfo.Length + MAX_SPRITES;
-				Array.Resize(ref vertexInfo, newMax);
-				Array.Resize(ref textureInfo, newMax);
-				Array.Resize(ref spriteInfos, newMax);
-				Array.Resize(ref sortedSpriteInfos, newMax);
+				if (vertexInfo.Length >= MAX_BATCHSIZE)
+				{
+					FlushBatch();
+				}
+				else
+				{
+					/* We're out of room, add another batch max
+					 * to the total array size. This is required for
+					 * sprite sorting accuracy; note that we do NOT
+					 * increase the graphics buffer sizes!
+					 * -flibit
+					 */
+
+					 /* Fix: reallocation size now increase exponentially, 
+					  * but upper bounded to 1048576. When we submit more than 
+					  * 1048576 sprites, we flush them immediately. This will make
+					  * the total running time O(n).
+					 */ 
+					int newMax = Math.Min(vertexInfo.Length * 2, MAX_BATCHSIZE);
+					Array.Resize(ref vertexInfo, newMax);
+					Array.Resize(ref textureInfo, newMax);
+					Array.Resize(ref spriteInfos, newMax);
+					Array.Resize(ref sortedSpriteInfos, newMax);
+				}
 			}
 
 			if (sortMode == SpriteSortMode.Immediate)

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -1075,6 +1075,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				if (vertexInfo.Length >= MAX_ARRAYSIZE)
 				{
+					/* FIXME: We're doing this for safety but it's possible that
+					 * XNA just keeps expanding and crashes with OutOfMemory.
+					 * Since GraphicsProfile has a buffer cap, we use that for safety.
+					 * This might change if someone depends on running out of memory(?!).
+					 */
 					FlushBatch();
 				}
 				else

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -31,7 +31,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		private const int MAX_VERTICES = MAX_SPRITES * 4;
 		private const int MAX_INDICES = MAX_SPRITES * 6;
 
-		// Max array size for cpu side buffer
+		/* This is the largest array size for a VertexBuffer using VertexPositionColorTexture.
+		 * note that we do NOT change the GPU buffer size since that would break XNA accuracy,
+		 * but if you want to optimize your batching you can make this change in a custom SpriteBatch.
+		 */
 		private const int MAX_ARRAYSIZE = 0x3FFFFFF / 96;
 
 		// Used to quickly flip text for DrawString

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Xna.Framework.Graphics
 		private const int MAX_SPRITES = 2048;
 		private const int MAX_VERTICES = MAX_SPRITES * 4;
 		private const int MAX_INDICES = MAX_SPRITES * 6;
-		private const int MAX_BATCHSIZE = 1048576;
+
+		// Max array size for cpu side buffer
+		private const int MAX_ARRAYSIZE = 0x3FFFFFF;
 
 		// Used to quickly flip text for DrawString
 		private static readonly float[] axisDirectionX = new float[]
@@ -1068,7 +1070,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		) {
 			if (numSprites >= vertexInfo.Length)
 			{
-				if (vertexInfo.Length >= MAX_BATCHSIZE)
+				if (vertexInfo.Length >= MAX_ARRAYSIZE)
 				{
 					FlushBatch();
 				}
@@ -1086,7 +1088,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					  * 1048576 sprites, we flush them immediately. This will make
 					  * the total running time O(n).
 					 */ 
-					int newMax = Math.Min(vertexInfo.Length * 2, MAX_BATCHSIZE);
+					int newMax = Math.Min(vertexInfo.Length * 2, MAX_ARRAYSIZE);
 					Array.Resize(ref vertexInfo, newMax);
 					Array.Resize(ref textureInfo, newMax);
 					Array.Resize(ref spriteInfos, newMax);

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		private const int MAX_INDICES = MAX_SPRITES * 6;
 
 		/* This is the largest array size for a VertexBuffer using VertexPositionColorTexture.
-		 * note that we do NOT change the GPU buffer size since that would break XNA accuracy,
+		 * Note that we do NOT change the GPU buffer size since that would break XNA accuracy,
 		 * but if you want to optimize your batching you can make this change in a custom SpriteBatch.
 		 */
 		private const int MAX_ARRAYSIZE = 0x3FFFFFF / 96;

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		private const int MAX_INDICES = MAX_SPRITES * 6;
 
 		// Max array size for cpu side buffer
-		private const int MAX_ARRAYSIZE = 0x3FFFFFF;
+		private const int MAX_ARRAYSIZE = 0x3FFFFFF / 96;
 
 		// Used to quickly flip text for DrawString
 		private static readonly float[] axisDirectionX = new float[]


### PR DESCRIPTION
I have changed the resize policy to doubling, which is aligned with XNA implementation. This is to avoid the O(n^2) reallocation process when we are pushing a large number of sprites. Now it only takes O(n) in any situation. In addition to that, I set the limit to a fixed number to avoid using too much memory. 