### PR TITLE
Check and throw SDL_Init error

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -209,10 +209,13 @@ namespace Microsoft.Xna.Framework
 			}
 
 			// This _should_ be the first real SDL call we make...
-			SDL.SDL_Init(
+			if (SDL.SDL_Init(
 				SDL.SDL_INIT_VIDEO |
 				SDL.SDL_INIT_GAMECONTROLLER
-			);
+			) != 0)
+			{
+				throw new Exception("SDL_Init failed: " + SDL.SDL_GetError());
+			}
 
 			string videoDriver = SDL.SDL_GetCurrentVideoDriver();
 


### PR DESCRIPTION
FNA does not throw errors on from `SDL_Init`, these error messages can be invaluable rather than crashes later down the line.

I had to debug a null pointer exception from the following `videoDriver` variable. 
`SDL_Init` was throwing `directx not available` because they had the environment variable `SDL_VIDEODRIVER=directx` set.