### PR TITLE
Add ToString to Touch classes that lack it

### DIFF
--- a/src/Input/Touch/GestureSample.cs
+++ b/src/Input/Touch/GestureSample.cs
@@ -119,5 +119,23 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		}
 
 		#endregion
+
+		#region Public Methods
+
+		public override string ToString()
+		{
+			return (
+				"{GestureType:" + GestureType.ToString() +
+				" Timestamp:" + Timestamp.ToString() +
+				" Position:" + Position.ToString() +
+				" Position2:" + Position2.ToString() +
+				" Delta:" + Delta.ToString() +
+				" Delta2:" + Delta2.ToString() +
+				" FingerIdEXT:" + FingerIdEXT.ToString() +
+				" FingerId2EXT:" + FingerId2EXT.ToString() + "}"
+			);
+		}
+
+		#endregion
 	}
 }

--- a/src/Input/Touch/TouchCollection.cs
+++ b/src/Input/Touch/TouchCollection.cs
@@ -144,6 +144,15 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			touches.RemoveAt(index);
 		}
 
+		public override string ToString()
+		{
+			return (
+				"{Touches:" + string.Join(",", touches) +
+				" IsConnected:" + IsConnected.ToString() +
+				" IsReadOnly:" + IsReadOnly.ToString() + "}"
+			);
+		}
+
 		#endregion
 
 		#region IEnumerator Methods

--- a/src/Input/Touch/TouchPanelCapabilities.cs
+++ b/src/Input/Touch/TouchPanelCapabilities.cs
@@ -39,5 +39,17 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		}
 
 		#endregion
+
+		#region Public Methods
+
+		public override string ToString()
+		{
+			return (
+				"{IsConnected:" + IsConnected.ToString() +
+				" MaximumTouchCount:" + MaximumTouchCount.ToString() + "}"
+			);
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
This mainly came up when testing with GestureSample, but I went ahead and added it for any non-static/non-enum class in this namespace lacking it.