### PR TITLE
Add TextInputEXT.IsScreenKeyboardShown

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Xna.Framework
 			GetWindowBorderless =		SDL2_FNAPlatform.GetWindowBorderless;
 			SetWindowBorderless =		SDL2_FNAPlatform.SetWindowBorderless;
 			SetWindowTitle =		SDL2_FNAPlatform.SetWindowTitle;
+			IsScreenKeyboardShown =		SDL2_FNAPlatform.IsScreenKeyboardShown;
 			RegisterGame =			SDL2_FNAPlatform.RegisterGame;
 			UnregisterGame =		SDL2_FNAPlatform.UnregisterGame;
 			PollEvents =			SDL2_FNAPlatform.PollEvents;
@@ -222,6 +223,9 @@ namespace Microsoft.Xna.Framework
 
 		public delegate void SetWindowTitleFunc(IntPtr window, string title);
 		public static readonly SetWindowTitleFunc SetWindowTitle;
+
+		public delegate bool IsScreenKeyboardShownFunc(IntPtr window);
+		public static readonly IsScreenKeyboardShownFunc IsScreenKeyboardShown;
 
 		public delegate GraphicsAdapter RegisterGameFunc(Game game);
 		public static readonly RegisterGameFunc RegisterGame;

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -642,6 +642,11 @@ namespace Microsoft.Xna.Framework
 			);
 		}
 
+		public static bool IsScreenKeyboardShown(IntPtr window)
+		{
+			return SDL.SDL_IsScreenKeyboardShown(window) == SDL.SDL_bool.SDL_TRUE;
+		}
+
 		private static void INTERNAL_SetIcon(IntPtr window, string title)
 		{
 			string fileIn = String.Empty;

--- a/src/Input/TextInputEXT.cs
+++ b/src/Input/TextInputEXT.cs
@@ -37,9 +37,22 @@ namespace Microsoft.Xna.Framework.Input
 
 		#region Public Static Methods
 
+		/// <summary>
+		/// Returns if text input state is active
+		///
+		/// Note: For on-screen keyboard, this may remain true on
+		/// some platforms if an external event closed the keyboard.
+		/// In this case, check IsScreenKeyboardShow instead.
+		/// </summary>
+		/// <returns>True if text input state is active</returns>
 		public static bool IsTextInputActive()
 		{
 			return FNAPlatform.IsTextInputActive();
+		}
+
+		public static bool IsScreenKeyboardShown(IntPtr window)
+		{
+			return FNAPlatform.IsScreenKeyboardShown(window);
 		}
 
 		public static void StartTextInput()


### PR DESCRIPTION
SDL's IsTextInputActive() can still return true if on-screen keyboard is closed as this function just checks the SDL event state.

On some platforms (e.g. Xbox), the on-screen keyboard can be closed by an external event which results in the event state being enabled despite the keyboard being no longer visible.

To workaround this, I've added a binding to SDL's IsScreenKeyboardShown to allow for checking this.

Note: On Xbox UWP, there is a bug in SDL which I've submitted PR for [here](https://github.com/libsdl-org/SDL/issues/6433).