### PR TITLE
Fixes for NativeAOT warnings

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -332,6 +332,7 @@
 		<Compile Include="src\Utilities\FileHelpers.cs" />
 		<Compile Include="src\Utilities\FNADllMap.cs" />
 		<Compile Include="src\Utilities\FNAInternalExtensions.cs" />
+		<Compile Include="src\Utilities\MarshalHelper.cs" />
 		<Compile Include="src\Utilities\XamarinHelper.cs" />
 		<Compile Include="src\Vector2.cs" />
 		<Compile Include="src\Vector3.cs" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -402,6 +402,7 @@
     <Compile Include="src\Utilities\FileHelpers.cs" />
     <Compile Include="src\Utilities\FNADllMap.cs" />
     <Compile Include="src\Utilities\FNAInternalExtensions.cs" />
+    <Compile Include="src\Utilities\MarshalHelper.cs" />
     <Compile Include="src\Utilities\XamarinHelper.cs" />
     <Compile Include="src\Vector2.cs" />
     <Compile Include="src\Vector3.cs" />

--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ SRC = \
 	src/Utilities/AssemblyHelper.cs \
 	src/Utilities/FileHelpers.cs \
 	src/Utilities/FNAInternalExtensions.cs \
+	src/Utilities/MarshalHelper.cs \
 	src/Utilities/XamarinHelper.cs \
 	src/Vector2.cs \
 	src/Vector3.cs \

--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -211,19 +211,19 @@ namespace Microsoft.Xna.Framework.Audio
 			if (extraData == null)
 			{
 				formatPtr = Marshal.AllocHGlobal(
-					Marshal.SizeOf(typeof(FAudio.FAudioWaveFormatEx))
+					MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>()
 				);
 			}
 			else
 			{
 				formatPtr = Marshal.AllocHGlobal(
-					Marshal.SizeOf(typeof(FAudio.FAudioWaveFormatEx)) +
+					MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>() +
 					extraData.Length
 				);
 				Marshal.Copy(
 					extraData,
 					0,
-					formatPtr + Marshal.SizeOf(typeof(FAudio.FAudioWaveFormatEx)),
+					formatPtr + MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>(),
 					extraData.Length
 				);
 			}
@@ -632,12 +632,12 @@ namespace Microsoft.Xna.Framework.Audio
 
 					IntPtr chainPtr;
 					chainPtr = Marshal.AllocHGlobal(
-						Marshal.SizeOf(typeof(FAudio.FAudioEffectChain))
+						MarshalHelper.SizeOf<FAudio.FAudioEffectChain>()
 					);
 					FAudio.FAudioEffectChain* reverbChain = (FAudio.FAudioEffectChain*) chainPtr;
 					reverbChain->EffectCount = 1;
 					reverbChain->pEffectDescriptors = Marshal.AllocHGlobal(
-						Marshal.SizeOf(typeof(FAudio.FAudioEffectDescriptor))
+						MarshalHelper.SizeOf<FAudio.FAudioEffectDescriptor>()
 					);
 
 					FAudio.FAudioEffectDescriptor* reverbDesc =
@@ -665,7 +665,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 					// Defaults based on FAUDIOFX_I3DL2_PRESET_GENERIC
 					IntPtr rvbParamsPtr = Marshal.AllocHGlobal(
-						Marshal.SizeOf(typeof(FAudio.FAudioFXReverbParameters))
+						MarshalHelper.SizeOf<FAudio.FAudioFXReverbParameters>()
 					);
 					FAudio.FAudioFXReverbParameters* rvbParams = (FAudio.FAudioFXReverbParameters*) rvbParamsPtr;
 					rvbParams->WetDryMix = 100.0f;
@@ -694,7 +694,7 @@ namespace Microsoft.Xna.Framework.Audio
 						ReverbVoice,
 						0,
 						rvbParamsPtr,
-						(uint) Marshal.SizeOf(typeof(FAudio.FAudioFXReverbParameters)),
+						(uint)MarshalHelper.SizeOf<FAudio.FAudioFXReverbParameters>(),
 						0
 					);
 					Marshal.FreeHGlobal(rvbParamsPtr);
@@ -702,7 +702,7 @@ namespace Microsoft.Xna.Framework.Audio
 					reverbSends = new FAudio.FAudioVoiceSends();
 					reverbSends.SendCount = 2;
 					reverbSends.pSends = Marshal.AllocHGlobal(
-						2 * Marshal.SizeOf(typeof(FAudio.FAudioSendDescriptor))
+						2 * MarshalHelper.SizeOf<FAudio.FAudioSendDescriptor>()
 					);
 					FAudio.FAudioSendDescriptor* sendDesc = (FAudio.FAudioSendDescriptor*) reverbSends.pSends;
 					sendDesc[0].Flags = 0;

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -803,7 +803,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				h = rect.Value.Height;
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			Texture.ValidateGetDataFormat(
 				FNA3D.FNA3D_GetBackbufferSurfaceFormat(GLDevice),
 				elementSizeInBytes

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				w = Math.Max(Width >> level, 1);
 				h = Math.Max(Height >> level, 1);
 			}
-			int elementSize = Marshal.SizeOf(typeof(T));
+			int elementSize = MarshalHelper.SizeOf<T>();
 			int requiredBytes = (w * h * GetFormatSize(Format)) / GetBlockSizeSquared(Format);
 			int availableBytes = elementCount * elementSize;
 			if (requiredBytes > availableBytes)
@@ -314,7 +314,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				subH = rect.Value.Height;
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			ValidateGetDataFormat(Format, elementSizeInBytes);
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);

--- a/src/Graphics/Texture3D.cs
+++ b/src/Graphics/Texture3D.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				throw new ArgumentNullException("data");
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetTextureData3D(
 				GraphicsDevice.GLDevice,
@@ -256,7 +256,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				throw new ArgumentException("Neither box size nor box position can be negative");
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			ValidateGetDataFormat(Format, elementSizeInBytes);
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);

--- a/src/Graphics/TextureCube.cs
+++ b/src/Graphics/TextureCube.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				height = Math.Max(1, Size >> level);
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetTextureDataCube(
 				GraphicsDevice.GLDevice,
@@ -288,7 +288,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				subH = rect.Value.Height;
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			ValidateGetDataFormat(Format, elementSizeInBytes);
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);

--- a/src/Graphics/Vertices/DynamicIndexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicIndexBuffer.cs
@@ -85,8 +85,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				GraphicsDevice.GLDevice,
 				buffer,
 				offsetInBytes,
-				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),
-				elementCount * Marshal.SizeOf(typeof(T)),
+				handle.AddrOfPinnedObject() + (startIndex * MarshalHelper.SizeOf<T>()),
+				elementCount * MarshalHelper.SizeOf<T>(),
 				options
 			);
 			handle.Free();
@@ -105,8 +105,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				GraphicsDevice.GLDevice,
 				buffer,
 				0,
-				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),
-				elementCount * Marshal.SizeOf(typeof(T)),
+				handle.AddrOfPinnedObject() + (startIndex * MarshalHelper.SizeOf<T>()),
+				elementCount * MarshalHelper.SizeOf<T>(),
 				options
 			);
 			handle.Free();

--- a/src/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/src/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		) where T : struct {
 			ErrorCheck(data, startIndex, elementCount, vertexStride);
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetVertexBufferData(
 				GraphicsDevice.GLDevice,
@@ -102,7 +102,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			int elementCount,
 			SetDataOptions options
 		) where T : struct {
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			ErrorCheck(data, startIndex, elementCount, elementSizeInBytes);
 
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);

--- a/src/Graphics/Vertices/IndexBuffer.cs
+++ b/src/Graphics/Vertices/IndexBuffer.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_GetIndexBufferData(
 				GraphicsDevice.GLDevice,
@@ -209,7 +209,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				buffer,
 				0,
 				handle.AddrOfPinnedObject(),
-				data.Length * Marshal.SizeOf(typeof(T)),
+				data.Length * MarshalHelper.SizeOf<T>(),
 				SetDataOptions.None
 			);
 			handle.Free();
@@ -227,8 +227,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				GraphicsDevice.GLDevice,
 				buffer,
 				0,
-				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),
-				elementCount * Marshal.SizeOf(typeof(T)),
+				handle.AddrOfPinnedObject() + (startIndex * MarshalHelper.SizeOf<T>()),
+				elementCount * MarshalHelper.SizeOf<T>(),
 				SetDataOptions.None
 			);
 			handle.Free();
@@ -247,8 +247,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				GraphicsDevice.GLDevice,
 				buffer,
 				offsetInBytes,
-				handle.AddrOfPinnedObject() + (startIndex * Marshal.SizeOf(typeof(T))),
-				elementCount * Marshal.SizeOf(typeof(T)),
+				handle.AddrOfPinnedObject() + (startIndex * MarshalHelper.SizeOf<T>()),
+				elementCount * MarshalHelper.SizeOf<T>(),
 				SetDataOptions.None
 			);
 			handle.Free();

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				data,
 				0,
 				data.Length,
-				Marshal.SizeOf(typeof(T))
+				MarshalHelper.SizeOf<T>()
 			);
 		}
 
@@ -150,7 +150,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				data,
 				startIndex,
 				elementCount,
-				Marshal.SizeOf(typeof(T))
+				MarshalHelper.SizeOf<T>()
 			);
 		}
 
@@ -177,7 +177,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				throw new NotSupportedException("Calling GetData on a resource that was created with BufferUsage.WriteOnly is not supported.");
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			if (vertexStride == 0)
 			{
 				vertexStride = elementSizeInBytes;
@@ -219,7 +219,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				data,
 				0,
 				data.Length,
-				Marshal.SizeOf(typeof(T))
+				MarshalHelper.SizeOf<T>()
 			);
 		}
 
@@ -233,7 +233,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				data,
 				startIndex,
 				elementCount,
-				Marshal.SizeOf(typeof(T))
+				MarshalHelper.SizeOf<T>()
 			);
 		}
 
@@ -246,7 +246,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		) where T : struct {
 			ErrorCheck(data, startIndex, elementCount, vertexStride);
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_SetVertexBufferData(
 				GraphicsDevice.GLDevice,
@@ -314,7 +314,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 			}
 
-			int elementSizeInBytes = Marshal.SizeOf(typeof(T));
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
 			if (vertexStride == 0)
 			{
 				vertexStride = elementSizeInBytes;

--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -96,15 +96,10 @@ namespace Microsoft.Xna.Framework
 
 			// Get the path to the assembly
 			Assembly assembly = Assembly.GetExecutingAssembly();
-			string assemblyPath = "";
-			if (!String.IsNullOrEmpty(assembly.Location))
-			{
-				assemblyPath = Path.GetDirectoryName(assembly.Location);
-			}
 
 			// Locate the config file
 			string xmlPath = Path.Combine(
-				assemblyPath,
+				AppContext.BaseDirectory,
 				assembly.GetName().Name + ".dll.config"
 			);
 			if (!File.Exists(xmlPath))

--- a/src/Utilities/MarshalHelper.cs
+++ b/src/Utilities/MarshalHelper.cs
@@ -1,0 +1,27 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2022 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+#region Using Statements
+using System.Runtime.InteropServices;
+#endregion
+
+namespace Microsoft.Xna.Framework
+{
+	internal static class MarshalHelper
+	{
+		internal static int SizeOf<T>()
+		{
+#if NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
+			return Marshal.SizeOf<T>();
+#else
+			return Marshal.SizeOf(typeof(T));
+#endif
+		}
+	}
+}


### PR DESCRIPTION
Minor fixes discovered by running the AOT analyzers. This doesn't fix every warning because not everything is fixable. For example, the content pipeline is heavily based on reflection. I could have annotated all of those APIs to remove the warnings from FNA and shift them into game code calling those APIs, but it's a considerable number of annotations introduced throughout the code base and I wasn't ready to propose cluttering everything up with those just yet.