### PR TITLE
Set FNA.Core to use .NET 7

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<PropertyGroup>


### PR DESCRIPTION
Since we announced console support via .NET 7 NativeAOT, figured we should bump the version that the Core csproj uses to .NET 7.