### PR TITLE
Call SDL_GetEventFilter after SDL_Init.

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -92,20 +92,6 @@ namespace Microsoft.Xna.Framework
 						"1"
 					);
 				}
-
-				/* Windows has terrible event pumping and doesn't give us
-				 * WM_PAINT events correctly. So we get to do this!
-				 * -flibit
-				 */
-				IntPtr prevUserData;
-				SDL.SDL_GetEventFilter(
-					out prevEventFilter,
-					out prevUserData
-				);
-				SDL.SDL_SetEventFilter(
-					win32OnPaint,
-					prevUserData
-				);
 			}
 
 			/* Mount TitleLocation.Path */
@@ -229,6 +215,24 @@ namespace Microsoft.Xna.Framework
 			) != 0)
 			{
 				throw new Exception("SDL_Init failed: " + SDL.SDL_GetError());
+			}
+
+			if (	OSVersion.Equals("Windows") ||
+				OSVersion.Equals("WinRT")	)
+			{
+				/* Windows has terrible event pumping and doesn't give us
+				 * WM_PAINT events correctly. So we get to do this!
+				 * -flibit
+				 */
+				IntPtr prevUserData;
+				SDL.SDL_GetEventFilter(
+					out prevEventFilter,
+					out prevUserData
+				);
+				SDL.SDL_SetEventFilter(
+					win32OnPaint,
+					prevUserData
+				);
 			}
 
 			string videoDriver = SDL.SDL_GetCurrentVideoDriver();


### PR DESCRIPTION
This fixes a crash in SDL 2.28.0.