### PR TITLE
Added FNA_IOS_HOME_INDICATOR for controlling the home indicator

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -149,6 +149,25 @@ namespace Microsoft.Xna.Framework
 				);
 			}
 
+			// Set home indicator behavior in iOS
+			switch (Environment.GetEnvironmentVariable("FNA_IOS_HOME_INDICATOR"))
+			{
+
+				case "0":
+					SDL.SDL_SetHint(SDL.SDL_HINT_IOS_HIDE_HOME_INDICATOR, "0");
+					break;
+				case "1":
+					SDL.SDL_SetHint(SDL.SDL_HINT_IOS_HIDE_HOME_INDICATOR, "1");
+					break;
+				case "2":
+					SDL.SDL_SetHint(SDL.SDL_HINT_IOS_HIDE_HOME_INDICATOR, "2");
+					break;
+				default:
+					SDL.SDL_SetHint(SDL.SDL_HINT_IOS_HIDE_HOME_INDICATOR, "1");
+					break;
+
+			}
+
 			// Built-in SDL2 command line arguments
 			string arg;
 			if (args.TryGetValue("glprofile", out arg))


### PR DESCRIPTION
Added an environment variable to control how the home indicator in iOS behaves using SDL_SetHint.

![IMG_1067](https://github.com/FNA-XNA/FNA/assets/57515252/cd850821-7e36-4869-ab09-6d3d03158ad6)
![IMG_1068](https://github.com/FNA-XNA/FNA/assets/57515252/eaa33302-aa00-4873-ae55-3e0520e992e6)
