### PR TITLE
Reduce EffectParameter-related heap allocations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,10 @@
 indent_style = tab
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_space_after_cast = true
+csharp_space_between_method_declaration_name_and_open_parenthesis = false

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1018,6 +1018,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			IntPtr rawAnnotations,
 			uint numAnnotations
 		) {
+			if (numAnnotations == 0)
+				return EffectAnnotationCollection.Empty;
+
 			MOJOSHADER_effectAnnotation* annoPtr = (MOJOSHADER_effectAnnotation*) rawAnnotations;
 			List<EffectAnnotation> annotations = new List<EffectAnnotation>((int) numAnnotations);
 			for (int i = 0; i < numAnnotations; i += 1)

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -990,7 +990,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				return null;
 			}
 
-			var type = *(MOJOSHADER_symbolTypeInfo*)_type;
+			var type = *(MOJOSHADER_symbolTypeInfo*) _type;
 			EffectParameterCollection structMembers = null;
 			if (type.member_count > 0)
 			{

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -986,7 +986,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			IntPtr _type
 		) {
 			if (_type == IntPtr.Zero)
+			{
 				return null;
+			}
 
 			var type = *(MOJOSHADER_symbolTypeInfo*)_type;
 			EffectParameterCollection structMembers = null;

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -925,40 +925,6 @@ namespace Microsoft.Xna.Framework.Graphics
 					continue;
 				}
 
-				EffectParameterCollection structMembers = null;
-				if (param.value.type.member_count > 0)
-				{
-					List<EffectParameter> memList = new List<EffectParameter>();
-					unsafe
-					{
-						MOJOSHADER_symbolStructMember* mem = (MOJOSHADER_symbolStructMember*) param.value.type.members;
-						IntPtr curOffset = IntPtr.Zero;
-						for (int j = 0; j < param.value.type.member_count; j += 1)
-						{
-							uint memSize = mem[j].info.rows * mem[j].info.columns;
-							if (mem[j].info.elements > 0)
-							{
-								memSize *= mem[j].info.elements;
-							}
-							memList.Add(new EffectParameter(
-								Marshal.PtrToStringAnsi(mem[j].name),
-								null,
-								(int) mem[j].info.rows,
-								(int) mem[j].info.columns,
-								(int) mem[j].info.elements,
-								XNAClass[(int) mem[j].info.parameter_class],
-								XNAType[(int) mem[j].info.parameter_type],
-								null, // FIXME: Nested structs! -flibit
-								null,
-								param.value.values + curOffset.ToInt32(),
-								memSize * 4
-							));
-							curOffset += (int) memSize * 4;
-						}
-					}
-					structMembers = new EffectParameterCollection(memList);
-				}
-
 				parameters.Add(new EffectParameter(
 					Marshal.PtrToStringAnsi(param.value.name),
 					Marshal.PtrToStringAnsi(param.value.semantic),
@@ -967,7 +933,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					(int) param.value.type.elements,
 					XNAClass[(int) param.value.type.parameter_class],
 					XNAType[(int) param.value.type.parameter_type],
-					structMembers,
+					new IntPtr(&paramPtr[i].value.type),
 					INTERNAL_readAnnotations(
 						param.annotations,
 						param.annotation_count
@@ -1013,6 +979,51 @@ namespace Microsoft.Xna.Framework.Graphics
 				));
 			}
 			Techniques = new EffectTechniqueCollection(techniques);
+		}
+
+		internal unsafe static EffectParameterCollection INTERNAL_readEffectParameterStructureMembers(
+			EffectParameter parameter,
+			IntPtr _type
+		) {
+			if (_type == IntPtr.Zero)
+				return null;
+
+			var type = *(MOJOSHADER_symbolTypeInfo*)_type;
+			EffectParameterCollection structMembers = null;
+			if (type.member_count > 0)
+			{
+				List<EffectParameter> memList = new List<EffectParameter>();
+				unsafe
+				{
+					MOJOSHADER_symbolStructMember* mem = (MOJOSHADER_symbolStructMember*) type.members;
+					IntPtr curOffset = IntPtr.Zero;
+					for (int j = 0; j < type.member_count; j += 1)
+					{
+						uint memSize = mem[j].info.rows * mem[j].info.columns;
+						if (mem[j].info.elements > 0)
+						{
+							memSize *= mem[j].info.elements;
+						}
+						memList.Add(new EffectParameter(
+							Marshal.PtrToStringAnsi(mem[j].name),
+							null,
+							(int) mem[j].info.rows,
+							(int) mem[j].info.columns,
+							(int) mem[j].info.elements,
+							XNAClass[(int) mem[j].info.parameter_class],
+							XNAType[(int) mem[j].info.parameter_type],
+							IntPtr.Zero, // FIXME: Nested structs! -flibit
+							null,
+							parameter.values + curOffset.ToInt32(),
+							memSize * 4
+						));
+						curOffset += (int) memSize * 4;
+					}
+				}
+				structMembers = new EffectParameterCollection(memList);
+			}
+
+			return structMembers;
 		}
 
 		private unsafe EffectPass INTERNAL_readPass(

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -1049,7 +1049,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			uint numAnnotations
 		) {
 			if (numAnnotations == 0)
+			{
 				return EffectAnnotationCollection.Empty;
+			}
 
 			MOJOSHADER_effectAnnotation* annoPtr = (MOJOSHADER_effectAnnotation*) rawAnnotations;
 			List<EffectAnnotation> annotations = new List<EffectAnnotation>((int) numAnnotations);

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -985,26 +985,27 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				// Set up Passes
 				MOJOSHADER_effectPass* passPtr = (MOJOSHADER_effectPass*) techPtr->passes;
-				List<EffectPass> passes = new List<EffectPass>((int) techPtr->pass_count);
-				for (int j = 0; j < passes.Capacity; j += 1)
+				EffectPassCollection passes;
+				if (techPtr->pass_count == 1)
 				{
-					MOJOSHADER_effectPass pass = passPtr[j];
-					passes.Add(new EffectPass(
-						Marshal.PtrToStringAnsi(pass.name),
-						INTERNAL_readAnnotations(
-							pass.annotations,
-							pass.annotation_count
-						),
-						this,
-						(IntPtr) techPtr,
-						(uint) j
+					passes = new EffectPassCollection(INTERNAL_readPass(
+						ref passPtr[0], (IntPtr) techPtr, 0
 					));
+				}
+				else
+				{
+					List<EffectPass> passList = new List<EffectPass>((int) techPtr->pass_count);
+					for (int j = 0; j < passList.Capacity; j += 1)
+					{
+						passList.Add(INTERNAL_readPass(ref passPtr[j], (IntPtr) techPtr, (uint) j));
+					}
+					passes = new EffectPassCollection(passList);
 				}
 
 				techniques.Add(new EffectTechnique(
 					Marshal.PtrToStringAnsi(techPtr->name),
 					(IntPtr) techPtr,
-					new EffectPassCollection(passes),
+					passes,
 					INTERNAL_readAnnotations(
 						techPtr->annotations,
 						techPtr->annotation_count
@@ -1012,6 +1013,22 @@ namespace Microsoft.Xna.Framework.Graphics
 				));
 			}
 			Techniques = new EffectTechniqueCollection(techniques);
+		}
+
+		private unsafe EffectPass INTERNAL_readPass(
+			ref MOJOSHADER_effectPass pass,
+			IntPtr techPtr, uint index
+		) {
+			return new EffectPass(
+				Marshal.PtrToStringAnsi(pass.name),
+				INTERNAL_readAnnotations(
+					pass.annotations,
+					pass.annotation_count
+				),
+				this,
+				techPtr,
+				index
+			);
 		}
 
 		private unsafe EffectAnnotationCollection INTERNAL_readAnnotations(

--- a/src/Graphics/Effect/EffectAnnotationCollection.cs
+++ b/src/Graphics/Effect/EffectAnnotationCollection.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Xna.Framework.Graphics
 {
 	public sealed class EffectAnnotationCollection : IEnumerable<EffectAnnotation>, IEnumerable
 	{
+		#region Allocation optimization
+		internal static readonly EffectAnnotationCollection Empty =
+			new EffectAnnotationCollection(new List<EffectAnnotation>());
+		#endregion
+
 		#region Public Properties
 
 		public int Count

--- a/src/Graphics/Effect/EffectAnnotationCollection.cs
+++ b/src/Graphics/Effect/EffectAnnotationCollection.cs
@@ -17,8 +17,10 @@ namespace Microsoft.Xna.Framework.Graphics
 	public sealed class EffectAnnotationCollection : IEnumerable<EffectAnnotation>, IEnumerable
 	{
 		#region Allocation optimization
+
 		internal static readonly EffectAnnotationCollection Empty =
 			new EffectAnnotationCollection(new List<EffectAnnotation>());
+
 		#endregion
 
 		#region Public Properties

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -43,12 +43,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			private set;
 		}
 
-		public int ElementCount
-		{
-			get;
-			private set;
-		}
-
 		public EffectParameterClass ParameterClass
 		{
 			get;
@@ -64,7 +58,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public EffectParameterCollection Elements
 		{
 			get {
-				if ((ElementCount > 0) && (elements == null))
+				if ((elementCount > 0) && (elements == null))
 					BuildElementList();
 				return elements;
 			}
@@ -96,6 +90,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal IntPtr mojoType;
 
+		internal int elementCount;
 		internal EffectParameterCollection elements;
 		internal EffectParameterCollection members;
 
@@ -125,7 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			Semantic = semantic ?? string.Empty;
 			RowCount = rowCount;
 			ColumnCount = columnCount;
-			ElementCount = elementCount;
+			this.elementCount = elementCount;
 			ParameterClass = parameterClass;
 			ParameterType = parameterType;
 			this.mojoType = mojoType;
@@ -156,7 +151,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			Semantic = semantic ?? string.Empty;
 			RowCount = rowCount;
 			ColumnCount = columnCount;
-			ElementCount = elementCount;
+			this.elementCount = elementCount;
 			ParameterClass = parameterClass;
 			ParameterType = parameterType;
 			members = structureMembers;
@@ -175,38 +170,39 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal void BuildElementList ()
 		{
-			if (ElementCount > 0)
+			if (elementCount > 0)
 			{
 				int curOffset = 0;
-				List<EffectParameter> elements = new List<EffectParameter>(ElementCount);
-				for (int i = 0; i < ElementCount; i += 1)
+				List<EffectParameter> elements = new List<EffectParameter>(elementCount);
+				EffectParameterCollection structureMembers = StructureMembers;
+				for (int i = 0; i < elementCount; i += 1)
 				{
 					EffectParameterCollection elementMembers = null;
-					if (StructureMembers != null)
+					if (structureMembers != null)
 					{
 						List<EffectParameter> memList = new List<EffectParameter>();
-						for (int j = 0; j < StructureMembers.Count; j += 1)
+						for (int j = 0; j < structureMembers.Count; j += 1)
 						{
 							int memElems = 0;
-							if (StructureMembers[j].Elements != null)
+							if (structureMembers[j].Elements != null)
 							{
-								memElems = StructureMembers[j].Elements.Count;
+								memElems = structureMembers[j].Elements.Count;
 							}
-							int memSize = StructureMembers[j].RowCount * 4;
+							int memSize = structureMembers[j].RowCount * 4;
 							if (memElems > 0)
 							{
 								memSize *= memElems;
 							}
 							memList.Add(new EffectParameter(
-								StructureMembers[j].Name,
-								StructureMembers[j].Semantic,
-								StructureMembers[j].RowCount,
-								StructureMembers[j].ColumnCount,
+								structureMembers[j].Name,
+								structureMembers[j].Semantic,
+								structureMembers[j].RowCount,
+								structureMembers[j].ColumnCount,
 								memElems,
-								StructureMembers[j].ParameterClass,
-								StructureMembers[j].ParameterType,
+								structureMembers[j].ParameterClass,
+								structureMembers[j].ParameterType,
 								IntPtr.Zero, // FIXME: Nested structs! -flibit
-								StructureMembers[j].Annotations,
+								structureMembers[j].Annotations,
 								new IntPtr(values.ToInt64() + curOffset),
 								(uint) memSize * 4
 							));

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public EffectParameterCollection Elements
 		{
-			get {
+			get
+			{
 				if ((elementCount > 0) && (elements == null))
 					BuildElementList();
 				return elements;
@@ -66,7 +67,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public EffectParameterCollection StructureMembers
 		{
-			get {
+			get
+			{
 				if ((mojoType != IntPtr.Zero) && (members == null))
 					BuildMemberList();
 				return members;
@@ -163,12 +165,12 @@ namespace Microsoft.Xna.Framework.Graphics
 		#endregion
 
 		#region Allocation optimizations
-		internal void BuildMemberList ()
+		internal void BuildMemberList()
 		{
 			members = Effect.INTERNAL_readEffectParameterStructureMembers(this, mojoType);
 		}
 
-		internal void BuildElementList ()
+		internal void BuildElementList()
 		{
 			if (elementCount > 0)
 			{

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			get
 			{
 				if ((elementCount > 0) && (elements == null))
+				{
 					BuildElementList();
+				}
 				return elements;
 			}
 		}
@@ -70,7 +72,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			get
 			{
 				if ((mojoType != IntPtr.Zero) && (members == null))
+				{
 					BuildMemberList();
+				}
 				return members;
 			}
 		}
@@ -164,7 +168,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region Allocation optimizations
+		#region Allocation Optimizations
+
 		internal void BuildMemberList()
 		{
 			members = Effect.INTERNAL_readEffectParameterStructureMembers(this, mojoType);

--- a/src/Graphics/Effect/EffectParameter.cs
+++ b/src/Graphics/Effect/EffectParameter.cs
@@ -238,6 +238,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				this.elements = new EffectParameterCollection(elements);
 			}
 		}
+
 		#endregion
 
 		#region Public Get Methods

--- a/src/Graphics/Effect/EffectPassCollection.cs
+++ b/src/Graphics/Effect/EffectPassCollection.cs
@@ -8,6 +8,7 @@
 #endregion
 
 #region Using Statements
+using System;
 using System.Collections;
 using System.Collections.Generic;
 #endregion
@@ -22,7 +23,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return elements.Count;
+				if (elements == null)
+					return singleItem != null ? 1 : 0;
+				else
+					return elements.Count;
 			}
 		}
 
@@ -30,7 +34,12 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return elements[index];
+				if (elements != null)
+					return elements[index];
+
+				if (index != 0)
+					throw new ArgumentOutOfRangeException("index");
+				return singleItem;
 			}
 		}
 
@@ -38,6 +47,13 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
+				if (elements == null) {
+					if (singleItem.Name.Equals(name))
+						return singleItem;
+					else
+						return null;
+				}
+
 				foreach (EffectPass elem in elements)
 				{
 					if (name.Equals(elem.Name))
@@ -54,6 +70,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		#region Private Variables
 
 		private List<EffectPass> elements;
+		private EffectPass singleItem;
 
 		#endregion
 
@@ -64,13 +81,29 @@ namespace Microsoft.Xna.Framework.Graphics
 			elements = value;
 		}
 
+		internal EffectPassCollection(EffectPass pass)
+		{
+			singleItem = pass;
+		}
+
+		#endregion
+
+		#region Allocation optimization
+		internal List<EffectPass> GetList()
+		{
+			if (elements == null) {
+				elements = new List<EffectPass>(1);
+				elements.Add(singleItem);
+			}
+			return elements;
+		}
 		#endregion
 
 		#region Public Methods
 
 		public List<EffectPass>.Enumerator GetEnumerator()
 		{
-			return elements.GetEnumerator();
+			return GetList().GetEnumerator();
 		}
 
 		#endregion
@@ -79,12 +112,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		IEnumerator System.Collections.IEnumerable.GetEnumerator()
 		{
-			return elements.GetEnumerator();
+			return GetList().GetEnumerator();
 		}
 
 		IEnumerator<EffectPass> System.Collections.Generic.IEnumerable<EffectPass>.GetEnumerator()
 		{
-			return elements.GetEnumerator();
+			return GetList().GetEnumerator();
 		}
 
 		#endregion

--- a/src/Graphics/Effect/EffectPassCollection.cs
+++ b/src/Graphics/Effect/EffectPassCollection.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				if (elements == null) {
+				if (elements == null)
+				{
 					if (singleItem.Name.Equals(name))
 						return singleItem;
 					else
@@ -91,7 +92,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		#region Allocation optimization
 		internal List<EffectPass> GetList()
 		{
-			if (elements == null) {
+			if (elements == null)
+			{
 				elements = new List<EffectPass>(1);
 				elements.Add(singleItem);
 			}

--- a/src/Graphics/Effect/EffectPassCollection.cs
+++ b/src/Graphics/Effect/EffectPassCollection.cs
@@ -24,9 +24,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			get
 			{
 				if (elements == null)
+				{
 					return singleItem != null ? 1 : 0;
-				else
-					return elements.Count;
+				}
+				return elements.Count;
 			}
 		}
 
@@ -35,10 +36,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			get
 			{
 				if (elements != null)
+				{
 					return elements[index];
+				}
 
 				if (index != 0)
+				{
 					throw new ArgumentOutOfRangeException("index");
+				}
 				return singleItem;
 			}
 		}
@@ -50,9 +55,10 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (elements == null)
 				{
 					if (singleItem.Name.Equals(name))
+					{
 						return singleItem;
-					else
-						return null;
+					}
+					return null;
 				}
 
 				foreach (EffectPass elem in elements)
@@ -89,7 +95,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region Allocation optimization
+		#region Allocation Optimization
+
 		internal List<EffectPass> GetList()
 		{
 			if (elements == null)
@@ -99,6 +106,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			return elements;
 		}
+
 		#endregion
 
 		#region Public Methods


### PR DESCRIPTION
This PR optimizes the case where an EffectAnnotationCollection is empty by using a shared 'Empty' instance instead of allocating a bunch of unique ones.

Most Effect techniques only have a single pass, so this PR adds a single-item mode to EffectPassCollection, allowing us to skip allocating the backing List unless someone calls .GetEnumerator on the collection.

In various circumstances we allocate EffectParameter instances and associated collections that aren't actually used, so this PR attempts to allocate them lazily on-demand instead.

These optimizations combined reduce the number of heap objects in my game at a fixed point from 121.2K to 100.5K, and the heap size from 66.2MB to 64.6MB. This should also help reduce GC pause times.