### PR TITLE
Replace FNA3D and SDL SetEnvironmentVariable calls with SDL_SetHintWithPriority

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Xna.Framework
 
 			// Environment.GetEnvironmentVariable("FNA_PLATFORM_BACKEND");
 
+			SetEnv = SDL2_FNAPlatform.SetEnv;
+
 			// Built-in command line arguments
 			LaunchParameters args = new LaunchParameters();
 			string arg;
@@ -93,7 +95,6 @@ namespace Microsoft.Xna.Framework
 
 			Malloc =			SDL2_FNAPlatform.Malloc;
 			Free =				SDL2.SDL.SDL_free;
-			SetEnv =			SDL2_FNAPlatform.SetEnv;
 			CreateWindow =			SDL2_FNAPlatform.CreateWindow;
 			DisposeWindow =			SDL2_FNAPlatform.DisposeWindow;
 			ApplyWindowChanges =		SDL2_FNAPlatform.ApplyWindowChanges;

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -50,30 +50,34 @@ namespace Microsoft.Xna.Framework
 			}
 			if (args.TryGetValue("gldevice", out arg))
 			{
-				Environment.SetEnvironmentVariable(
+				SDL2.SDL.SDL_SetHintWithPriority(
 					"FNA3D_FORCE_DRIVER",
-					arg
+					arg,
+					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
 			}
 			if (args.TryGetValue("enablelateswaptear", out arg) && arg == "1")
 			{
-				Environment.SetEnvironmentVariable(
+				SDL2.SDL.SDL_SetHintWithPriority(
 					"FNA3D_ENABLE_LATESWAPTEAR",
-					"1"
+					"1",
+					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
 			}
 			if (args.TryGetValue("mojoshaderprofile", out arg))
 			{
-				Environment.SetEnvironmentVariable(
+				SDL2.SDL.SDL_SetHintWithPriority(
 					"FNA3D_MOJOSHADER_PROFILE",
-					arg
+					arg,
+					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
 			}
 			if (args.TryGetValue("backbufferscalenearest", out arg) && arg == "1")
 			{
-				Environment.SetEnvironmentVariable(
+				SDL2.SDL.SDL_SetHintWithPriority(
 					"FNA3D_BACKBUFFER_SCALE_NEAREST",
-					"1"
+					"1",
+					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
 			}
 			if (args.TryGetValue("usescancodes", out arg) && arg == "1")

--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -50,34 +50,30 @@ namespace Microsoft.Xna.Framework
 			}
 			if (args.TryGetValue("gldevice", out arg))
 			{
-				SDL2.SDL.SDL_SetHintWithPriority(
+				SetEnv(
 					"FNA3D_FORCE_DRIVER",
-					arg,
-					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+					arg
 				);
 			}
 			if (args.TryGetValue("enablelateswaptear", out arg) && arg == "1")
 			{
-				SDL2.SDL.SDL_SetHintWithPriority(
+				SetEnv(
 					"FNA3D_ENABLE_LATESWAPTEAR",
-					"1",
-					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+					"1"
 				);
 			}
 			if (args.TryGetValue("mojoshaderprofile", out arg))
 			{
-				SDL2.SDL.SDL_SetHintWithPriority(
+				SetEnv(
 					"FNA3D_MOJOSHADER_PROFILE",
-					arg,
-					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+					arg
 				);
 			}
 			if (args.TryGetValue("backbufferscalenearest", out arg) && arg == "1")
 			{
-				SDL2.SDL.SDL_SetHintWithPriority(
+				SetEnv(
 					"FNA3D_BACKBUFFER_SCALE_NEAREST",
-					"1",
-					SDL2.SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+					"1"
 				);
 			}
 			if (args.TryGetValue("usescancodes", out arg) && arg == "1")
@@ -97,6 +93,7 @@ namespace Microsoft.Xna.Framework
 
 			Malloc =			SDL2_FNAPlatform.Malloc;
 			Free =				SDL2.SDL.SDL_free;
+			SetEnv =			SDL2_FNAPlatform.SetEnv;
 			CreateWindow =			SDL2_FNAPlatform.CreateWindow;
 			DisposeWindow =			SDL2_FNAPlatform.DisposeWindow;
 			ApplyWindowChanges =		SDL2_FNAPlatform.ApplyWindowChanges;
@@ -199,6 +196,9 @@ namespace Microsoft.Xna.Framework
 
 		public delegate void FreeFunc(IntPtr ptr);
 		public static readonly FreeFunc Free;
+
+		public delegate void SetEnvFunc(string name, string value);
+		public static readonly SetEnvFunc SetEnv;
 
 		public delegate GameWindow CreateWindowFunc();
 		public static readonly CreateWindowFunc CreateWindow;

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -395,10 +395,14 @@ namespace Microsoft.Xna.Framework
 
 		#endregion
 
+		#region Environment
+
 		public static void SetEnv(string name, string value)
 		{
 			SDL.SDL_SetHintWithPriority(name, value, SDL.SDL_HintPriority.SDL_HINT_OVERRIDE);
 		}
+
+		#endregion
 
 		#region Window Methods
 

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -395,6 +395,11 @@ namespace Microsoft.Xna.Framework
 
 		#endregion
 
+		public static void SetEnv(string name, string value)
+		{
+			SDL.SDL_SetHintWithPriority(name, value, SDL.SDL_HintPriority.SDL_HINT_OVERRIDE);
+		}
+
 		#region Window Methods
 
 		public static GameWindow CreateWindow()

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -155,42 +155,48 @@ namespace Microsoft.Xna.Framework
 			{
 				if (arg == "es3")
 				{
-					Environment.SetEnvironmentVariable(
+					SDL.SDL_SetHintWithPriority(
 						"FNA3D_OPENGL_FORCE_ES3",
-						"1"
+						"1",
+						SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 					);
 				}
 				else if (arg == "core")
 				{
-					Environment.SetEnvironmentVariable(
+					SDL.SDL_SetHintWithPriority(
 						"FNA3D_OPENGL_FORCE_CORE_PROFILE",
-						"1"
+						"1",
+						SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 					);
 				}
 				else if (arg == "compatibility")
 				{
-					Environment.SetEnvironmentVariable(
+					SDL.SDL_SetHintWithPriority(
 						"FNA3D_OPENGL_FORCE_COMPATIBILITY_PROFILE",
-						"1"
+						"1",
+						SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 					);
 				}
 			}
 			if (args.TryGetValue("angle", out arg) && arg == "1")
 			{
-				Environment.SetEnvironmentVariable(
+				SDL.SDL_SetHintWithPriority(
 					"FNA3D_OPENGL_FORCE_ES3",
-					"1"
+					"1",
+					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
-				Environment.SetEnvironmentVariable(
+				SDL.SDL_SetHintWithPriority(
 					"SDL_OPENGL_ES_DRIVER",
-					"1"
+					"1",
+					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
 			}
 			if (args.TryGetValue("forcemailboxvsync", out arg) && arg == "1")
 			{
-				Environment.SetEnvironmentVariable(
+				SDL.SDL_SetHintWithPriority(
 					"FNA3D_VULKAN_FORCE_MAILBOX_VSYNC",
-					"1"
+					"1",
+					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
 				);
 			}
 
@@ -205,7 +211,11 @@ namespace Microsoft.Xna.Framework
 			 */
 			if (args.TryGetValue("audiodriver", out arg))
 			{
-				Environment.SetEnvironmentVariable("SDL_AUDIODRIVER", arg);
+				SDL.SDL_SetHintWithPriority(
+					"SDL_AUDIODRIVER",
+					arg,
+					SDL.SDL_HintPriority.SDL_HINT_OVERRIDE
+				);
 			}
 
 			// This _should_ be the first real SDL call we make...


### PR DESCRIPTION
Fixes #435

### Alternatives
- `FNAPlatform` appears intended to be backend agnostic. The fact that `FNA3D` uses `SDL_GetHint` to read env vars is an implementation detail, so `FNA3D` should probably expose a `SetHint` or `SetEnv` method. (selected)
- ~~A wrapper method could be created which actually calls `setenv` on linux systems.~~

### Backwards Compatibility

Technically a breaking change for anyone using `GetEnvironmentVariable` to read the value of a variable set by FNA for FNA3D/SDL. Note that `FNA_` variables still use `Get/SetEnvironmentVariable` for this reason, as they run in purely managed code.
