### PR TITLE
Improve GraphicsResource leak detection

### DIFF
--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -92,12 +92,18 @@ namespace Microsoft.Xna.Framework.Graphics
 		~GraphicsResource()
 		{
 #if DEBUG
-			if (!IsDisposed) 
+			// If the graphics device associated with this resource was already disposed, we assume
+			//  that your game is in the middle of shutting down, and you don't care about leaks of stray
+			//  resources like SamplerStates or other odds and ends.
+			// We also ignore leaks of resources with no graphicsDevice yet, because they don't have
+			//  any way to have native memory associated with them yet.
+			// We also ignore leaks of resources with no associated native memory (via IsHarmlessToLeakInstance).
+			if (!IsDisposed)
 			{
-				// If you hit this breakpoint, that means you leaked a graphics resource!
+				// If you see this log message, you leaked a graphics resource without disposing it!
 				// This means your game may eventually run out of native memory for mysterious reasons.
 				// To troubleshoot this, try setting a Name and/or Tag on your resources to identify them. -kg
-				System.Diagnostics.Debugger.Break();
+				FNALoggerEXT.LogWarn(string.Format("A resource of type {0} with tag {1} and name {2} was not Disposed.", GetType().Name, Tag, Name));
 			}
 #endif
 
@@ -138,6 +144,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// </summary>
 		internal protected virtual void GraphicsDeviceResetting()
 		{
+		}
+
+		internal protected virtual bool IsHarmlessToLeakInstance
+		{
+			get
+			{
+				return false;
+			}
 		}
 
 		#endregion

--- a/src/Graphics/States/BlendState.cs
+++ b/src/Graphics/States/BlendState.cs
@@ -199,6 +199,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal FNA3D.FNA3D_BlendState state;
 
+		internal protected override bool IsHarmlessToLeakInstance
+		{
+			get
+			{
+				return true;
+			}
+		}
+
 		#endregion
 
 		#region Public Constructor

--- a/src/Graphics/States/DepthStencilState.cs
+++ b/src/Graphics/States/DepthStencilState.cs
@@ -237,6 +237,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal FNA3D.FNA3D_DepthStencilState state;
 
+		internal protected override bool IsHarmlessToLeakInstance
+		{
+			get
+			{
+				return true;
+			}
+		}
+
 		#endregion
 
 		#region Public Constructor

--- a/src/Graphics/States/RasterizerState.cs
+++ b/src/Graphics/States/RasterizerState.cs
@@ -110,6 +110,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal FNA3D.FNA3D_RasterizerState state;
 
+		internal protected override bool IsHarmlessToLeakInstance
+		{
+			get
+			{
+				return true;
+			}
+		}
+
 		#endregion
 
 		#region Public Constructor

--- a/src/Graphics/States/SamplerState.cs
+++ b/src/Graphics/States/SamplerState.cs
@@ -155,6 +155,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		internal FNA3D.FNA3D_SamplerState state;
 
+		internal protected override bool IsHarmlessToLeakInstance
+		{
+			get
+			{
+				return true;
+			}
+		}
+
 		#endregion
 
 		#region Public Constructor

--- a/src/Graphics/Vertices/VertexDeclaration.cs
+++ b/src/Graphics/Vertices/VertexDeclaration.cs
@@ -31,6 +31,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		internal VertexElement[] elements;
 		internal IntPtr elementsPin;
 
+		internal protected override bool IsHarmlessToLeakInstance
+		{
+			get
+			{
+				return true;
+			}
+		}
+
 		#endregion
 
 		#region Private Variables


### PR DESCRIPTION
* LogWarn instead of Debugger.Break. This is less disruptive but still useful
* Ignore leaks of resources that have no backing native resource (these are harmless)
* Ignore leaks of resources belonging to a graphicsDevice that was already disposed (this means the game is probably shutting down)