### PR TITLE
Emergency dispose graphics resources from finalizer

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -184,6 +184,7 @@
 		<Compile Include="src\Graphics\GraphicsDeviceStatus.cs" />
 		<Compile Include="src\Graphics\GraphicsProfile.cs" />
 		<Compile Include="src\Graphics\GraphicsResource.cs" />
+		<Compile Include="src\Graphics\GraphicsResourceDisposalHandle.cs" />
 		<Compile Include="src\Graphics\IGraphicsDeviceService.cs" />
 		<Compile Include="src\Graphics\IRenderTarget.cs" />
 		<Compile Include="src\Graphics\Model.cs" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -254,6 +254,7 @@
     <Compile Include="src\Graphics\GraphicsDeviceStatus.cs" />
     <Compile Include="src\Graphics\GraphicsProfile.cs" />
     <Compile Include="src\Graphics\GraphicsResource.cs" />
+    <Compile Include="src\Graphics\GraphicsResourceDisposalHandle.cs" />
     <Compile Include="src\Graphics\IGraphicsDeviceService.cs" />
     <Compile Include="src\Graphics\IRenderTarget.cs" />
     <Compile Include="src\Graphics\Model.cs" />

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -307,6 +307,22 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeEffect,
+					resourceHandle = glEffect
+				}
+			};
+		}
+
+		#endregion
+
 		#region Protected Methods
 
 		protected override void Dispose(bool disposing)

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -9,6 +9,7 @@
 
 #region Using Statements
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 #endregion
@@ -486,6 +487,8 @@ namespace Microsoft.Xna.Framework.Graphics
 						Disposing(this, EventArgs.Empty);
 					}
 
+					FlushEmergencyDisposalQueue();
+
 					/* Dispose of all remaining graphics resources before
 					 * disposing of the GraphicsDevice.
 					 */
@@ -547,6 +550,30 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Emergency Disposal / Finalization
+
+		ConcurrentQueue<GraphicsResourceDisposalHandle> emergencyDisposalQueue = new ConcurrentQueue<GraphicsResourceDisposalHandle>();
+
+		internal void RegisterForEmergencyDisposal(GraphicsResourceDisposalHandle[] handles)
+		{
+			for (int i = 0; i < handles.Length; i += 1)
+			{
+				emergencyDisposalQueue.Enqueue(handles[i]);
+			}
+		}
+
+		private void FlushEmergencyDisposalQueue()
+		{
+			GraphicsResourceDisposalHandle handle;
+
+			while (emergencyDisposalQueue.TryDequeue(out handle))
+			{
+				handle.Dispose(this);
+			}
+		}
+
+		#endregion
+
 		#region Public Present Method
 
 		public void Present()
@@ -557,6 +584,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				IntPtr.Zero,
 				PresentationParameters.DeviceWindowHandle
 			);
+
+			FlushEmergencyDisposalQueue();
 		}
 
 		public void Present(
@@ -608,6 +637,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					overrideWindowHandle
 				);
 			}
+
+			FlushEmergencyDisposalQueue();
 		}
 
 		#endregion

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -285,6 +285,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		 */
 		private readonly List<WeakReference> resources = new List<WeakReference>();
 		private readonly object resourcesLock = new object();
+		ConcurrentQueue<GraphicsResourceDisposalHandle> emergencyDisposalQueue = new ConcurrentQueue<GraphicsResourceDisposalHandle>();
 
 		#endregion
 
@@ -551,8 +552,6 @@ namespace Microsoft.Xna.Framework.Graphics
 		#endregion
 
 		#region Emergency Disposal / Finalization
-
-		ConcurrentQueue<GraphicsResourceDisposalHandle> emergencyDisposalQueue = new ConcurrentQueue<GraphicsResourceDisposalHandle>();
 
 		internal void RegisterForEmergencyDisposal(GraphicsResourceDisposalHandle[] handles)
 		{
@@ -1542,7 +1541,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 			}
 
-			for (int sampler = 0; sampler < modifiedVertexSamplers.Length; sampler += 1) 
+			for (int sampler = 0; sampler < modifiedVertexSamplers.Length; sampler += 1)
 			{
 				if (!modifiedVertexSamplers[sampler])
 				{

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 #endregion
 
 namespace Microsoft.Xna.Framework.Graphics
-{	
+{
 	public abstract class GraphicsResource : IDisposable
 	{
 		#region Public Properties
@@ -110,7 +110,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			// While we only log in debug builds, in both debug and release builds we want to free
 			// any native resources associated with this object at the earliest opportunity.
 			// This will at least prevent you from running out of memory rapidly.
-			var handles = CreateDisposalHandles();
+			GraphicsResourceDisposalHandle[] handles = CreateDisposalHandles();
 			if (handles != null)
 			{
 				graphicsDevice.RegisterForEmergencyDisposal(handles);
@@ -161,9 +161,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		// This has to return an array because some resources have multiple handles... d'oh!
-		internal virtual GraphicsResourceDisposalHandle[] CreateDisposalHandles() 
+		// This has to return an array because some resources have multiple handles...
+		internal virtual GraphicsResourceDisposalHandle[] CreateDisposalHandles()
 		{
+			// ... But only certain GraphicsResource types have pointers to dispose!
 			return null;
 		}
 

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -107,7 +107,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 #endif
 
-			// FIXME: We really should call Dispose() here! -flibit
+			// While we only log in debug builds, in both debug and release builds we want to free
+			// any native resources associated with this object at the earliest opportunity.
+			// This will at least prevent you from running out of memory rapidly.
+			var handles = CreateDisposalHandles();
+			if (handles != null)
+			{
+				graphicsDevice.RegisterForEmergencyDisposal(handles);
+			}
 		}
 
 		#endregion
@@ -152,6 +159,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				return false;
 			}
+		}
+
+		// This has to return an array because some resources have multiple handles... d'oh!
+		internal virtual GraphicsResourceDisposalHandle[] CreateDisposalHandles() 
+		{
+			return null;
 		}
 
 		#endregion

--- a/src/Graphics/GraphicsResourceDisposalHandle.cs
+++ b/src/Graphics/GraphicsResourceDisposalHandle.cs
@@ -1,3 +1,12 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2023 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/src/Graphics/GraphicsResourceDisposalHandle.cs
+++ b/src/Graphics/GraphicsResourceDisposalHandle.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	// This allows us to defer native dispose calls from the finalizer thread.
+	internal struct GraphicsResourceDisposalHandle
+	{
+		internal Action<IntPtr, IntPtr> disposeAction;
+		internal IntPtr resourceHandle;
+
+		public void Dispose(GraphicsDevice device)
+		{
+			if (device == null)
+			{
+				throw new ArgumentNullException("device");
+			}
+
+			if (disposeAction == null)
+			{
+				return;
+			}
+
+			disposeAction(device.GLDevice, resourceHandle);
+		}
+	}
+}

--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -83,5 +83,21 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeQuery,
+					resourceHandle = query
+				}
+			};
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/RenderTarget2D.cs
+++ b/src/Graphics/RenderTarget2D.cs
@@ -208,5 +208,55 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			int length = 1;
+			int index = 0;
+			
+			if (glColorBuffer != IntPtr.Zero)
+			{
+				length += 1;
+			}
+
+			if (glDepthStencilBuffer != IntPtr.Zero)
+			{
+				length += 1;
+			}
+
+			GraphicsResourceDisposalHandle[] handles = new GraphicsResourceDisposalHandle[length];
+
+			handles[index] = new GraphicsResourceDisposalHandle
+			{
+				disposeAction = FNA3D.FNA3D_AddDisposeTexture,
+				resourceHandle = texture
+			};
+
+			if (glColorBuffer != IntPtr.Zero)
+			{
+				handles[index] = new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeRenderbuffer,
+					resourceHandle = glColorBuffer
+				};
+				index += 1;
+			}
+
+			if (glDepthStencilBuffer != IntPtr.Zero)
+			{
+				handles[index] = new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeRenderbuffer,
+					resourceHandle = glDepthStencilBuffer
+				};
+				index += 1;
+			}
+			
+			return handles;
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -467,5 +467,21 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeTexture,
+					resourceHandle = texture
+				}
+			};
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/Vertices/IndexBuffer.cs
+++ b/src/Graphics/Vertices/IndexBuffer.cs
@@ -337,5 +337,21 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeIndexBuffer,
+					resourceHandle = buffer
+				}
+			};
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -342,5 +342,21 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeVertexBuffer,
+					resourceHandle = buffer
+				}
+			};
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
Alternate implementation of #441 

Note that this definitely allocates in the "sad path" where the client loses track of a resource and the finalizer is invoked. They shouldn't do that and we do warn them, so I don't think it's a huge deal.

This also moves the Effect state changes pointer to the GraphicsDevice, which simplifies cleanup.