### PR TITLE
Add GraphicsDevice.GetRenderTargetsNoAllocEXT

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -975,12 +975,34 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+		/// <summary>
+		/// Returns a new array containing all of the render target(s) currently bound to the device.
+		/// </summary>
 		public RenderTargetBinding[] GetRenderTargets()
 		{
 			// Return a correctly sized copy our internal array.
 			RenderTargetBinding[] bindings = new RenderTargetBinding[renderTargetCount];
 			Array.Copy(renderTargetBindings, bindings, renderTargetCount);
 			return bindings;
+		}
+
+		/// <summary>
+		/// Copies the currently bound render target(s) into an output buffer (if provided), and returns the number of bound render targets.
+		/// </summary>
+		/// <param name="output">A buffer sized to contain all of the currently bound render targets, or null.</param>
+		/// <returns>The number of render targets currently bound.</returns>
+		public int GetRenderTargetsNoAllocEXT(RenderTargetBinding[] output)
+		{
+			if (output == null)
+			{
+				return renderTargetCount;
+			}
+			else if (output.Length != renderTargetCount)
+			{
+				throw new ArgumentException("Output buffer size incorrect");
+			}
+			Array.Copy(renderTargetBindings, output, renderTargetCount);
+			return renderTargetCount;
 		}
 
 		#endregion

--- a/src/Media/Xiph/VideoPlayer.cs
+++ b/src/Media/Xiph/VideoPlayer.cs
@@ -186,7 +186,9 @@ namespace Microsoft.Xna.Framework.Media
 			currentDevice.SetVertexBuffers(vertBuffer);
 
 			// Prep target bindings
-			oldTargets = currentDevice.GetRenderTargets();
+			int oldTargetCount = currentDevice.GetRenderTargetsNoAllocEXT(null);
+			Array.Resize(ref oldTargets, oldTargetCount);
+			currentDevice.GetRenderTargetsNoAllocEXT(oldTargets);
 
 			unsafe
 			{


### PR DESCRIPTION
This allows querying the currently bound render target(s) without an allocation. In my testing this works well, and it let me delete a couple hundred lines of code I was using to maintain a shadow stack.

I also updated VideoPlayer, but I don't have a way to test that part.