### PR TITLE
Move Effect state changes to the GraphicsDevice

### DIFF
--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -73,8 +73,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		private IntPtr stateChangesPtr;
-
 		private IntPtr effectData;
 
 		#endregion
@@ -236,19 +234,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			// The default technique is the first technique.
 			CurrentTechnique = Techniques[0];
-
-			// Use native memory for changes, .NET loves moving this around
-			unsafe
-			{
-				stateChangesPtr = FNAPlatform.Malloc(
-					sizeof(MOJOSHADER_effectStateChanges)
-				);
-				MOJOSHADER_effectStateChanges *stateChanges =
-					(MOJOSHADER_effectStateChanges*) stateChangesPtr;
-				stateChanges->render_state_change_count = 0;
-				stateChanges->sampler_state_change_count = 0;
-				stateChanges->vertex_sampler_state_change_count = 0;
-			}
 		}
 
 		#endregion
@@ -287,19 +272,6 @@ namespace Microsoft.Xna.Framework.Graphics
 					CurrentTechnique = Techniques[i];
 				}
 			}
-
-			// Use native memory for changes, .NET loves moving this around
-			unsafe
-			{
-				stateChangesPtr = FNAPlatform.Malloc(
-					sizeof(MOJOSHADER_effectStateChanges)
-				);
-				MOJOSHADER_effectStateChanges *stateChanges =
-					(MOJOSHADER_effectStateChanges*) stateChangesPtr;
-				stateChanges->render_state_change_count = 0;
-				stateChanges->sampler_state_change_count = 0;
-				stateChanges->vertex_sampler_state_change_count = 0;
-			}
 		}
 
 		#endregion
@@ -326,11 +298,6 @@ namespace Microsoft.Xna.Framework.Graphics
 						glEffect
 					);
 				}
-				if (stateChangesPtr != IntPtr.Zero)
-				{
-					FNAPlatform.Free(stateChangesPtr);
-					stateChangesPtr = IntPtr.Zero;
-				}
 			}
 			base.Dispose(disposing);
 		}
@@ -349,10 +316,10 @@ namespace Microsoft.Xna.Framework.Graphics
 				GraphicsDevice.GLDevice,
 				glEffect,
 				pass,
-				stateChangesPtr
+				GraphicsDevice.effectStateChangesPtr
 			);
 			MOJOSHADER_effectStateChanges *stateChanges =
-				(MOJOSHADER_effectStateChanges*) stateChangesPtr;
+				(MOJOSHADER_effectStateChanges*) GraphicsDevice.effectStateChangesPtr;
 			if (stateChanges->render_state_change_count > 0)
 			{
 				PipelineCache pipelineCache = GraphicsDevice.PipelineCache;

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -275,6 +275,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Internal State Changes Pointer
+
+		internal IntPtr effectStateChangesPtr;
+
+		#endregion
+
 		#region Private Disposal Variables
 
 		/* Use WeakReference for the global resources list as we do not
@@ -461,6 +467,19 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			// Allocate the pipeline cache to be used by Effects
 			PipelineCache = new PipelineCache(this);
+
+			// Set up the effect state changes pointer.
+			unsafe
+			{
+				effectStateChangesPtr = FNAPlatform.Malloc(
+					sizeof(Effect.MOJOSHADER_effectStateChanges)
+				);
+                Effect.MOJOSHADER_effectStateChanges* stateChanges =
+					(Effect.MOJOSHADER_effectStateChanges*) effectStateChangesPtr;
+				stateChanges->render_state_change_count = 0;
+				stateChanges->sampler_state_change_count = 0;
+				stateChanges->vertex_sampler_state_change_count = 0;
+			}
 		}
 
 		~GraphicsDevice()
@@ -516,6 +535,8 @@ namespace Microsoft.Xna.Framework.Graphics
 							userIndexBuffer
 						);
 					}
+
+					FNAPlatform.Free(effectStateChangesPtr);
 
 					// Dispose of the GL Device/Context
 					FNA3D.FNA3D_DestroyDevice(GLDevice);


### PR DESCRIPTION
There's no need for each Effect to maintain its own state changes pointer because there can only ever be one Effect active at a time, so we can just move the pointer to the GraphicsDevice.