### PR TITLE
Use weak GCHandles instead of WeakReference instances for GraphicsResource

### DIFF
--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -10,6 +10,7 @@
 #region Using Statements
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 #endregion
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -39,12 +40,12 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (graphicsDevice != null && selfReference != null)
 				{
 					graphicsDevice.RemoveResourceReference(selfReference);
-					selfReference = null;
+					selfReference.Free();
 				}
 
 				graphicsDevice = value;
 
-				selfReference = new WeakReference(this);
+				selfReference = GCHandle.Alloc(this, GCHandleType.Weak);
 				graphicsDevice.AddResourceReference(selfReference);
 			}
 		}
@@ -79,7 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Private Variables
 
-		private WeakReference selfReference;
+		private GCHandle selfReference;
 
 		private GraphicsDevice graphicsDevice;
 
@@ -203,7 +204,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (graphicsDevice != null && selfReference != null)
 				{
 					graphicsDevice.RemoveResourceReference(selfReference);
-					selfReference = null;
+					selfReference.Free();
 				}
 
 				IsDisposed = true;


### PR DESCRIPTION
WeakReference is an extra heap allocation per resource that basically exists to give us a finalizer - but we already have one, so we can just use GCHandle directly.

Since the default List.Remove would box the handles to compare them I had to do the Remove manually, but that allows doing an unordered remove anyway for a slight speed boost (that doesn't matter because nobody disposes resources that often)