### PR TITLE
Remove netstandard2.0 target from FNA.Core.csproj

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net7.0</TargetFrameworks>
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<PropertyGroup>


### PR DESCRIPTION
There's no reason to include netstandard as a target in FNA.Core - we only officially support .NET 7 anyway. If a client has their project use an earlier target, like .NET 6, the library resolves to netstandard and this causes the DLL resolver to fail, so this target is directly causing dllimport bugs. 