### PR TITLE
Intern various strings parsed out of Effect instances to reduce GC overhead

### DIFF
--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -915,8 +915,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 
 				EffectParameter toAdd = new EffectParameter(
-					Marshal.PtrToStringAnsi(param.value.name),
-					Marshal.PtrToStringAnsi(param.value.semantic),
+					MarshalHelper.PtrToInternedStringAnsi(param.value.name),
+					MarshalHelper.PtrToInternedStringAnsi(param.value.semantic),
 					(int) param.value.type.rows,
 					(int) param.value.type.columns,
 					(int) param.value.type.elements,
@@ -966,7 +966,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 
 				techniques.Add(new EffectTechnique(
-					Marshal.PtrToStringAnsi(techPtr->name),
+					MarshalHelper.PtrToInternedStringAnsi(techPtr->name),
 					(IntPtr) techPtr,
 					passes,
 					INTERNAL_readAnnotations(
@@ -1005,7 +1005,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							memSize *= mem[j].info.elements;
 						}
 						EffectParameter toAdd = new EffectParameter(
-							Marshal.PtrToStringAnsi(mem[j].name),
+							MarshalHelper.PtrToInternedStringAnsi(mem[j].name),
 							null,
 							(int) mem[j].info.rows,
 							(int) mem[j].info.columns,
@@ -1053,7 +1053,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			IntPtr techPtr, uint index
 		) {
 			return new EffectPass(
-				Marshal.PtrToStringAnsi(pass.name),
+				MarshalHelper.PtrToInternedStringAnsi(pass.name),
 				INTERNAL_readAnnotations(
 					pass.annotations,
 					pass.annotation_count
@@ -1080,8 +1080,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				MOJOSHADER_effectAnnotation anno = annoPtr[i];
 
 				EffectAnnotation toAdd = new EffectAnnotation(
-					Marshal.PtrToStringAnsi(anno.name),
-					Marshal.PtrToStringAnsi(anno.semantic),
+					MarshalHelper.PtrToInternedStringAnsi(anno.name),
+					MarshalHelper.PtrToInternedStringAnsi(anno.semantic),
 					(int) anno.type.rows,
 					(int) anno.type.columns,
 					XNAClass[(int) anno.type.parameter_class],

--- a/src/Utilities/MarshalHelper.cs
+++ b/src/Utilities/MarshalHelper.cs
@@ -8,6 +8,7 @@
 #endregion
 
 #region Using Statements
+using System;
 using System.Runtime.InteropServices;
 #endregion
 
@@ -22,6 +23,14 @@ namespace Microsoft.Xna.Framework
 #else
 			return Marshal.SizeOf(typeof(T));
 #endif
+		}
+
+		internal static string PtrToInternedStringAnsi(IntPtr ptr)
+		{
+			string result = Marshal.PtrToStringAnsi(ptr);
+			if (result != null)
+				result = string.Intern(result);
+			return result;
 		}
 	}
 }


### PR DESCRIPTION
For my game this eliminates ~9200 duplicate string instances, saving around 270KB of memory and (more importantly) speeding up by-name lookups (i.e. looking for a specific effect parameter by name) since interned strings are (AFAIK) faster to compare.