### PR TITLE
Emergency dispose graphics resources without double free

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -184,6 +184,7 @@
 		<Compile Include="src\Graphics\GraphicsDeviceStatus.cs" />
 		<Compile Include="src\Graphics\GraphicsProfile.cs" />
 		<Compile Include="src\Graphics\GraphicsResource.cs" />
+		<Compile Include="src\Graphics\GraphicsResourceDisposalHandle.cs" />
 		<Compile Include="src\Graphics\IGraphicsDeviceService.cs" />
 		<Compile Include="src\Graphics\IRenderTarget.cs" />
 		<Compile Include="src\Graphics\Model.cs" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -254,6 +254,7 @@
     <Compile Include="src\Graphics\GraphicsDeviceStatus.cs" />
     <Compile Include="src\Graphics\GraphicsProfile.cs" />
     <Compile Include="src\Graphics\GraphicsResource.cs" />
+    <Compile Include="src\Graphics\GraphicsResourceDisposalHandle.cs" />
     <Compile Include="src\Graphics\IGraphicsDeviceService.cs" />
     <Compile Include="src\Graphics\IRenderTarget.cs" />
     <Compile Include="src\Graphics\Model.cs" />

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ SRC = \
 	src/Graphics/GraphicsDeviceStatus.cs \
 	src/Graphics/GraphicsProfile.cs \
 	src/Graphics/GraphicsResource.cs \
+	src/Graphics/GraphicsResourceDisposalHandle.cs \
 	src/Graphics/IGraphicsDeviceService.cs \
 	src/Graphics/IRenderTarget.cs \
 	src/Graphics/Model.cs \

--- a/src/Graphics/Effect/Effect.cs
+++ b/src/Graphics/Effect/Effect.cs
@@ -285,13 +285,29 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeEffect,
+					resourceHandle = glEffect
+				}
+			};
+		}
+
+		#endregion
+
 		#region Protected Methods
 
 		protected override void Dispose(bool disposing)
 		{
 			if (!IsDisposed)
 			{
-				if (glEffect != IntPtr.Zero)
+				if (glEffect != IntPtr.Zero && !NativeDisposeFunctionQueued)
 				{
 					FNA3D.FNA3D_AddDisposeEffect(
 						GraphicsDevice.GLDevice,

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -9,6 +9,7 @@
 
 #region Using Statements
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 #endregion
@@ -294,6 +295,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		 */
 		private readonly List<GCHandle> resources = new List<GCHandle>();
 		private readonly object resourcesLock = new object();
+		ConcurrentQueue<GraphicsResourceDisposalHandle> emergencyDisposalQueue = new ConcurrentQueue<GraphicsResourceDisposalHandle>();
 
 		#endregion
 
@@ -509,6 +511,8 @@ namespace Microsoft.Xna.Framework.Graphics
 						Disposing(this, EventArgs.Empty);
 					}
 
+					FlushEmergencyDisposalQueue();
+
 					/* Dispose of all remaining graphics resources before
 					 * disposing of the GraphicsDevice.
 					 */
@@ -582,6 +586,28 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Emergency Disposal / Finalization
+
+		internal void RegisterForEmergencyDisposal(GraphicsResourceDisposalHandle[] handles)
+		{
+			for (int i = 0; i < handles.Length; i += 1)
+			{
+				emergencyDisposalQueue.Enqueue(handles[i]);
+			}
+		}
+
+		private void FlushEmergencyDisposalQueue()
+		{
+			GraphicsResourceDisposalHandle handle;
+
+			while (emergencyDisposalQueue.TryDequeue(out handle))
+			{
+				handle.Dispose(this);
+			}
+		}
+
+		#endregion
+
 		#region Public Present Method
 
 		public void Present()
@@ -592,6 +618,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				IntPtr.Zero,
 				PresentationParameters.DeviceWindowHandle
 			);
+
+			FlushEmergencyDisposalQueue();
 		}
 
 		public void Present(
@@ -643,6 +671,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					overrideWindowHandle
 				);
 			}
+
+			FlushEmergencyDisposalQueue();
 		}
 
 		#endregion
@@ -1568,7 +1598,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 			}
 
-			for (int sampler = 0; sampler < modifiedVertexSamplers.Length; sampler += 1) 
+			for (int sampler = 0; sampler < modifiedVertexSamplers.Length; sampler += 1)
 			{
 				if (!modifiedVertexSamplers[sampler])
 				{

--- a/src/Graphics/GraphicsResourceDisposalHandle.cs
+++ b/src/Graphics/GraphicsResourceDisposalHandle.cs
@@ -1,0 +1,35 @@
+#region License
+/* FNA - XNA4 Reimplementation for Desktop Platforms
+ * Copyright 2009-2023 Ethan Lee and the MonoGame Team
+ *
+ * Released under the Microsoft Public License.
+ * See LICENSE for details.
+ */
+#endregion
+
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+	// This allows us to defer native dispose calls from the finalizer thread.
+	internal struct GraphicsResourceDisposalHandle
+	{
+		internal Action<IntPtr, IntPtr> disposeAction;
+		internal IntPtr resourceHandle;
+
+		public void Dispose(GraphicsDevice device)
+		{
+			if (device == null)
+			{
+				throw new ArgumentNullException("device");
+			}
+
+			if (disposeAction == null)
+			{
+				return;
+			}
+
+			disposeAction(device.GLDevice, resourceHandle);
+		}
+	}
+}

--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		protected override void Dispose(bool disposing)
 		{
-			if (!IsDisposed)
+			if (!IsDisposed && !NativeDisposeFunctionQueued)
 			{
 				FNA3D.FNA3D_AddDisposeQuery(GraphicsDevice.GLDevice, query);
 			}
@@ -80,6 +80,22 @@ namespace Microsoft.Xna.Framework.Graphics
 		public void End()
 		{
 			FNA3D.FNA3D_QueryEnd(GraphicsDevice.GLDevice, query);
+		}
+
+		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeQuery,
+					resourceHandle = query
+				}
+			};
 		}
 
 		#endregion

--- a/src/Graphics/RenderTarget2D.cs
+++ b/src/Graphics/RenderTarget2D.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		protected override void Dispose(bool disposing)
 		{
-			if (!IsDisposed)
+			if (!IsDisposed && !NativeDisposeFunctionQueued)
 			{
 				if (glColorBuffer != IntPtr.Zero)
 				{
@@ -205,6 +205,56 @@ namespace Microsoft.Xna.Framework.Graphics
 		protected internal override void GraphicsDeviceResetting()
 		{
 			base.GraphicsDeviceResetting();
+		}
+
+		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			int length = 1;
+			int index = 0;
+
+			if (glColorBuffer != IntPtr.Zero)
+			{
+				length += 1;
+			}
+
+			if (glDepthStencilBuffer != IntPtr.Zero)
+			{
+				length += 1;
+			}
+
+			GraphicsResourceDisposalHandle[] handles = new GraphicsResourceDisposalHandle[length];
+
+			handles[index] = new GraphicsResourceDisposalHandle
+			{
+				disposeAction = FNA3D.FNA3D_AddDisposeTexture,
+				resourceHandle = texture
+			};
+
+			if (glColorBuffer != IntPtr.Zero)
+			{
+				handles[index] = new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeRenderbuffer,
+					resourceHandle = glColorBuffer
+				};
+				index += 1;
+			}
+
+			if (glDepthStencilBuffer != IntPtr.Zero)
+			{
+				handles[index] = new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeRenderbuffer,
+					resourceHandle = glDepthStencilBuffer
+				};
+				index += 1;
+			}
+
+			return handles;
 		}
 
 		#endregion

--- a/src/Graphics/RenderTargetCube.cs
+++ b/src/Graphics/RenderTargetCube.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// </param>
 		protected override void Dispose(bool disposing)
 		{
-			if (!IsDisposed)
+			if (!IsDisposed && !NativeDisposeFunctionQueued)
 			{
 				if (glColorBuffer != IntPtr.Zero)
 				{

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -73,10 +73,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				GraphicsDevice.Textures.RemoveDisposedTexture(this);
 				GraphicsDevice.VertexTextures.RemoveDisposedTexture(this);
-				FNA3D.FNA3D_AddDisposeTexture(
-					GraphicsDevice.GLDevice,
-					texture
-				);
+
+				if (!NativeDisposeFunctionQueued)
+				{
+					FNA3D.FNA3D_AddDisposeTexture(
+						GraphicsDevice.GLDevice,
+						texture
+					);
+				}
 			}
 			base.Dispose(disposing);
 		}
@@ -491,6 +495,22 @@ namespace Microsoft.Xna.Framework.Graphics
 					"Unsupported DDS texture format"
 				);
 			}
+		}
+
+		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeTexture,
+					resourceHandle = texture
+				}
+			};
 		}
 
 		#endregion

--- a/src/Graphics/Vertices/IndexBuffer.cs
+++ b/src/Graphics/Vertices/IndexBuffer.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		protected override void Dispose(bool disposing)
 		{
-			if (!IsDisposed)
+			if (!IsDisposed && !NativeDisposeFunctionQueued)
 			{
 				FNA3D.FNA3D_AddDisposeIndexBuffer(
 					GraphicsDevice.GLDevice,
@@ -309,7 +309,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		#endregion
 
 		#region Private Type Size Calculator
-		
+
 		/// <summary>
 		/// Gets the relevant IndexElementSize enum value for the given type.
 		/// </summary>
@@ -334,6 +334,22 @@ namespace Microsoft.Xna.Framework.Graphics
 				"Index buffers can only be created for types" +
 				" that are sixteen or thirty two bits in length"
 			);
+		}
+
+		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeIndexBuffer,
+					resourceHandle = buffer
+				}
+			};
 		}
 
 		#endregion

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		protected override void Dispose(bool disposing)
 		{
-			if (!IsDisposed)
+			if (!IsDisposed && !NativeDisposeFunctionQueued)
 			{
 				FNA3D.FNA3D_AddDisposeVertexBuffer(
 					GraphicsDevice.GLDevice,
@@ -339,6 +339,22 @@ namespace Microsoft.Xna.Framework.Graphics
 		internal protected override void GraphicsDeviceResetting()
 		{
 			// FIXME: Do we even want to bother with DeviceResetting for GL? -flibit
+		}
+
+		#endregion
+
+		#region Emergency Disposal
+
+		internal override GraphicsResourceDisposalHandle[] CreateDisposalHandles()
+		{
+			return new GraphicsResourceDisposalHandle[]
+			{
+				new GraphicsResourceDisposalHandle
+				{
+					disposeAction = FNA3D.FNA3D_AddDisposeVertexBuffer,
+					resourceHandle = buffer
+				}
+			};
 		}
 
 		#endregion


### PR DESCRIPTION
Resolves #461

Two changes from the reverted patch:

- Move the disposal enqueue into the block where the warning is logged in the finalizer.
- Set a flag when the disposal is enqueued and check the flag in Dispose so the native dispose function doesn't get called twice if Dispose is called afterward.

It should be noted that calling Dispose from a finalizer is a very bad idea, but at least it shouldn't crash now!