### PR TITLE
Fix iOS/tvOS support in FNADllMap

### DIFF
--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xna.Framework
 			{
 				return "windows";
 			}
-			else if (OperatingSystem.IsMacOS())
+			else if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS())
 			{
 				return  "osx";
 			}
@@ -83,7 +83,6 @@ namespace Microsoft.Xna.Framework
 		public static void Init()
 		{
 			// Ignore NativeAOT platforms since they don't perform dynamic loading.
-			// FIXME: Is the iOS check needed?
 			if (!RuntimeFeature.IsDynamicCodeSupported && !OperatingSystem.IsIOS())
 			{
 				return;

--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -7,7 +7,7 @@
  */
 #endregion
 
-#if NET
+#if NET7_0_OR_GREATER
 
 #region Using Statements
 using System;
@@ -80,7 +80,10 @@ namespace Microsoft.Xna.Framework
 			{
 				mappedName = libraryName;
 			}
-			return NativeLibrary.Load(mappedName, assembly, dllImportSearchPath);
+
+			return (mappedName == "__Internal") ?
+				NativeLibrary.GetMainProgramHandle() :
+				NativeLibrary.Load(mappedName, assembly, dllImportSearchPath);
 		}
 
 		#endregion
@@ -206,4 +209,4 @@ namespace Microsoft.Xna.Framework
 	}
 }
 
-#endif // NET
+#endif // NET7_0_OR_GREATER

--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xna.Framework
 			{
 				return "windows";
 			}
-			else if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS())
+			else if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
 			{
 				return  "osx";
 			}

--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -33,13 +33,21 @@ namespace Microsoft.Xna.Framework
 
 		#region Private Static Methods
 
+		private static bool IsAppleAOTPlatform()
+		{
+			/* These platforms require a bit of special handling since
+			 * they are the only platforms that compile via Mono AOT.
+			 */
+			return OperatingSystem.IsIOS() || OperatingSystem.IsTvOS();
+		}
+
 		private static string GetPlatformName()
 		{
 			if (OperatingSystem.IsWindows())
 			{
 				return "windows";
 			}
-			else if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
+			else if (OperatingSystem.IsMacOS() || IsAppleAOTPlatform())
 			{
 				return  "osx";
 			}
@@ -83,7 +91,7 @@ namespace Microsoft.Xna.Framework
 		public static void Init()
 		{
 			// Ignore NativeAOT platforms since they don't perform dynamic loading.
-			if (!RuntimeFeature.IsDynamicCodeSupported && !OperatingSystem.IsIOS())
+			if (!RuntimeFeature.IsDynamicCodeSupported && !IsAppleAOTPlatform())
 			{
 				return;
 			}


### PR DESCRIPTION
Mono's dllmap considers "osx" to be the platform name for macOS, iOS, and tvOS. This PR brings FNADllMap in line with that convention.