### PR TITLE
Use SDL_GetKeyboardState instead of event polling

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Xna.Framework
 			PollEvents =			SDL2_FNAPlatform.PollEvents;
 			GetGraphicsAdapters =		SDL2_FNAPlatform.GetGraphicsAdapters;
 			GetCurrentDisplayMode =		SDL2_FNAPlatform.GetCurrentDisplayMode;
+			GetKeyboardState =		SDL2_FNAPlatform.GetKeyboardState;
 			GetKeyFromScancode =		SDL2_FNAPlatform.GetKeyFromScancode;
 			IsTextInputActive =		SDL2_FNAPlatform.IsTextInputActive;
 			StartTextInput =		SDL2.SDL.SDL_StartTextInput;
@@ -260,6 +261,9 @@ namespace Microsoft.Xna.Framework
 
 		public delegate DisplayMode GetCurrentDisplayModeFunc(int adapterIndex);
 		public static readonly GetCurrentDisplayModeFunc GetCurrentDisplayMode;
+
+		public delegate void GetKeyboardStateFunc(List<Keys> activeKeys);
+		public static readonly GetKeyboardStateFunc GetKeyboardState;
 
 		public delegate Keys GetKeyFromScancodeFunc(Keys scancode);
 		public static readonly GetKeyFromScancodeFunc GetKeyFromScancode;

--- a/src/Input/Keyboard.cs
+++ b/src/Input/Keyboard.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Xna.Framework.Input
 		/// <returns>Current keyboard state.</returns>
 		public static KeyboardState GetState()
 		{
-			return new KeyboardState(keys);
+			activeKeys.Clear();
+			FNAPlatform.GetKeyboardState(activeKeys);
+			return new KeyboardState(activeKeys);
 		}
 
 		/// <summary>
@@ -37,7 +39,7 @@ namespace Microsoft.Xna.Framework.Input
 		/// <returns>Current keyboard state.</returns>
 		public static KeyboardState GetState(PlayerIndex playerIndex)
 		{
-			return new KeyboardState(keys);
+			return GetState();
 		}
 
 		#endregion
@@ -51,9 +53,9 @@ namespace Microsoft.Xna.Framework.Input
 
 		#endregion
 
-		#region Internal Static Variables
+		#region Private Static Variables
 
-		internal static List<Keys> keys = new List<Keys>();
+		private static List<Keys> activeKeys = new List<Keys>();
 
 		#endregion
 	}


### PR DESCRIPTION
~~We got a report from the Celeste modding/speedrunning community that FNA was causing input latency on keyboard relative to XNA. FNA currently processes keyboard input by processing all keyboard events in PollEvents and setting the keys in an internal array. But according to the report, XNA actually gets a new state every time Keyboard.GetState is called, not just once per frame. This patch brings the behavior in line with XNA, and it should address latency by allowing input polling to occur closer to when input is actually processed by the game.~~

We got a report from the Celeste modding/speedrunning community that FNA was causing input latency on keyboard relative to XNA when an IME was installed. This patch gets the keyboard state directly all at once instead of iterating over keydown events. This might address some scenarios where the keydown event is intercepted by something. It should also be very slightly more efficient to not have to call `keys.Contains` on all keypresses.