### PR TITLE
FNA: Add last possible orientation value PORTRAIT_FLIPPED

### DIFF
--- a/src/DisplayOrientation.cs
+++ b/src/DisplayOrientation.cs
@@ -34,6 +34,10 @@ namespace Microsoft.Xna.Framework
 		/// <summary>
 		/// The display is rotated as portrait, where height is greater than width.
 		/// </summary>
-		Portrait = 4
+		Portrait = 4,
+		/// <summary>
+		/// The display is rotated as portrait, where height is greater than width, but upside down.
+		/// </summary>
+		PortraitUpsideDown = 8
 	}
 }

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -873,6 +873,9 @@ namespace Microsoft.Xna.Framework
 				case SDL.SDL_DisplayOrientation.SDL_ORIENTATION_PORTRAIT:
 					return DisplayOrientation.Portrait;
 
+				case SDL.SDL_DisplayOrientation.SDL_ORIENTATION_PORTRAIT_FLIPPED:
+					return DisplayOrientation.PortraitUpsideDown;
+
 				default:
 					throw new NotSupportedException("FNA does not support this device orientation.");
 			}
@@ -890,7 +893,7 @@ namespace Microsoft.Xna.Framework
 			int min = Math.Min(width, height);
 			int max = Math.Max(width, height);
 
-			if (orientation == DisplayOrientation.Portrait)
+			if (orientation == DisplayOrientation.Portrait || orientation == DisplayOrientation.PortraitUpsideDown)
 			{
 				graphicsDevice.PresentationParameters.BackBufferWidth = min;
 				graphicsDevice.PresentationParameters.BackBufferHeight = max;


### PR DESCRIPTION
… or PortraitUpsideDown. This really crashes on tablets otherwise. Corresponding pull request is in FNA3D, though the DisplayOrientation enum there is not used at all yet. https://github.com/FNA-XNA/FNA3D/pull/190