### PR TITLE
Improve .NET Native AOT failure message when missing types in rd.xml

### DIFF
--- a/src/Content/ContentTypeReaderManager.cs
+++ b/src/Content/ContentTypeReaderManager.cs
@@ -220,6 +220,20 @@ namespace Microsoft.Xna.Framework.Content
 										ex
 									);
 								}
+								catch (NullReferenceException ex)
+								{
+									/* If you are getting here, you are
+									 * probably using .NET AOT and have
+									 * an incomplete rd.xml, to aid with
+									 * this, show a helpful exception
+									 */
+									throw new InvalidOperationException(
+										"Failed to get default constructor for ContentTypeReader. " +
+										"If you're using .NET Native AOT, ensure your rd.xml contains the following type: " +
+										originalReaderTypeString,
+										ex
+									);
+								}
 
 								needsInitialize[i] = true;
 


### PR DESCRIPTION
I was playing around with AOT in .NET 8 and when missing a type in `rd.xml`, it'd show the following exception which confused me:
```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Xna.Framework.Content.ContentTypeReaderManager.LoadAssetReaders(ContentReader) + 0x8e5
   at Microsoft.Xna.Framework.Content.ContentReader.InitializeTypeReaders() + 0x4e
   at Microsoft.Xna.Framework.Content.ContentReader.ReadAsset[T]() + 0x1f
   at Microsoft.Xna.Framework.Content.ContentManager.ReadAsset[T](String, Action`1) + 0x194
   at Microsoft.Xna.Framework.Content.ContentManager.Load[T](String assetName) + 0xc6
```

so to aid developers like myself in the future, I've changed the exception to be the following:
```
Unhandled Exception: System.InvalidOperationException: Failed to get constructor for ContentTypeReader. If you're using .NET Native AOT, ensure your rd.xml contains the following type: Microsoft.Xna.Framework.Content.StringReader
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Xna.Framework.Content.ContentTypeReaderManager.LoadAssetReaders(ContentReader) + 0x8e5
   --- End of inner exception stack trace ---
   at Microsoft.Xna.Framework.Content.ContentTypeReaderManager.LoadAssetReaders(ContentReader) + 0xb7a
```