### PR TITLE
Detect AOT more accurately

### DIFF
--- a/src/Utilities/FNADllMap.cs
+++ b/src/Utilities/FNADllMap.cs
@@ -91,7 +91,9 @@ namespace Microsoft.Xna.Framework
 		[ModuleInitializer]
 		public static void Init()
 		{
-			if (!RuntimeFeature.IsDynamicCodeCompiled)
+  			var stackTrace = new StackTrace(false);
+			var isAot = stackTrace.GetFrame(0)?.GetMethod() is null;
+			if (isAot)
 			{
 				/* NativeAOT platforms don't perform dynamic loading,
 				 * so setting a DllImportResolver is unnecessary.


### PR DESCRIPTION
For projects with `<PublishAot>true</PublishAot>`, `RuntimeFeature.IsDynamicCodeCompiled` return `false` in debug build. 
See https://github.com/dotnet/runtime/issues/94380#issuecomment-1794352389