### PR TITLE
Enable Alpha8 render targets

### DIFF
--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -98,7 +98,8 @@ namespace Microsoft.Xna.Framework.Graphics
 						format != SurfaceFormat.HalfSingle &&
 						format != SurfaceFormat.HalfVector2 &&
 						format != SurfaceFormat.HalfVector4 &&
-						format != SurfaceFormat.HdrBlendable	)
+						format != SurfaceFormat.HdrBlendable &&
+						format != SurfaceFormat.Alpha8)
 				{
 					// Not a renderable format period
 					Format = SurfaceFormat.Color;


### PR DESCRIPTION
I vaguely recall this working in XNA - I think escape goat 2 used it.
Right now it works for D3D11 and Vulkan with this change, but the behavior is different when sampling from the resulting RT. 

D3D11:
<img width="404" alt="d3d11" src="https://github.com/FNA-XNA/FNA/assets/198130/89d1ebb4-4adb-4174-989c-2c62902ee5b1">

Vulkan:
<img width="404" alt="vulkan" src="https://github.com/FNA-XNA/FNA/assets/198130/a59bb00d-6601-428d-bf89-fc4f615fce92">

Maybe an sRGB vs linear thing? Not sure.
