### PR TITLE
Add Texture2D.GetDataPointerEXT

### DIFF
--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -298,11 +298,30 @@ namespace Microsoft.Xna.Framework.Graphics
 				);
 			}
 
+			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
+			ValidateGetDataFormat(Format, elementSizeInBytes);
+
+			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+			GetDataPointerEXT(
+				level,
+				rect,
+				handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes),
+				elementCount * elementSizeInBytes
+			);
+			handle.Free();
+		}
+
+		public void GetDataPointerEXT(
+			int level,
+			Rectangle? rect,
+			IntPtr data,
+			int dataLengthBytes
+		) {
 			int subX, subY, subW, subH;
 			if (rect == null)
 			{
-				subX = 0;
-				subY = 0;
+                subX = 0;
+                subY = 0;
 				subW = Width >> level;
 				subH = Height >> level;
 			}
@@ -313,11 +332,6 @@ namespace Microsoft.Xna.Framework.Graphics
 				subW = rect.Value.Width;
 				subH = rect.Value.Height;
 			}
-
-			int elementSizeInBytes = MarshalHelper.SizeOf<T>();
-			ValidateGetDataFormat(Format, elementSizeInBytes);
-
-			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 			FNA3D.FNA3D_GetTextureData2D(
 				GraphicsDevice.GLDevice,
 				texture,
@@ -326,10 +340,9 @@ namespace Microsoft.Xna.Framework.Graphics
 				subW,
 				subH,
 				level,
-				handle.AddrOfPinnedObject() + (startIndex * elementSizeInBytes),
-				elementCount * elementSizeInBytes
+				data,
+				dataLengthBytes
 			);
-			handle.Free();
 		}
 
 		#endregion

--- a/src/Graphics/Texture2D.cs
+++ b/src/Graphics/Texture2D.cs
@@ -320,8 +320,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			int subX, subY, subW, subH;
 			if (rect == null)
 			{
-                subX = 0;
-                subY = 0;
+				subX = 0;
+				subY = 0;
 				subW = Width >> level;
 				subH = Height >> level;
 			}


### PR DESCRIPTION
Without this, it's not possible to cleanly queue up texture readback operations to execute later, since GetData<T> checks the size of T against the texture format, instead of checking the size of the buffer - so you can't read a Color texture into a byte[] even if it's big enough.