### PR TITLE
Don't throw exception for missing Video until it's played

### DIFF
--- a/src/Content/ContentReaders/VideoReader.cs
+++ b/src/Content/ContentReaders/VideoReader.cs
@@ -41,10 +41,11 @@ namespace Microsoft.Xna.Framework.Content
 			/* The path string includes the ".wmv" extension. Let's see if this
 			 * file exists in a format we actually support...
 			 */
+			string origpath = path;
 			path = Normalize(path.Substring(0, path.Length - 4));
 			if (String.IsNullOrEmpty(path))
 			{
-				throw new ContentLoadException();
+				path = origpath;
 			}
 
 			int durationMS = input.ReadObject<int>();

--- a/src/Media/Xiph/Video.cs
+++ b/src/Media/Xiph/Video.cs
@@ -89,38 +89,41 @@ namespace Microsoft.Xna.Framework.Media
 
 			Theorafile.th_pixel_fmt fmt;
 			Theorafile.tf_fopen(fileName, out theora);
-			Theorafile.tf_videoinfo(
-				theora,
-				out yWidth,
-				out yHeight,
-				out fps,
-				out fmt
-			);
-			if (fmt == Theorafile.th_pixel_fmt.TH_PF_420)
+			if (theora != IntPtr.Zero)
 			{
-				uvWidth = yWidth / 2;
-				uvHeight = yHeight / 2;
-			}
-			else if (fmt == Theorafile.th_pixel_fmt.TH_PF_422)
-			{
-				uvWidth = yWidth / 2;
-				uvHeight = yHeight;
-			}
-			else if (fmt == Theorafile.th_pixel_fmt.TH_PF_444)
-			{
-				uvWidth = yWidth;
-				uvHeight = yHeight;
-			}
-			else
-			{
-				throw new NotSupportedException(
-					"Unrecognized YUV format!"
+				Theorafile.tf_videoinfo(
+					theora,
+					out yWidth,
+					out yHeight,
+					out fps,
+					out fmt
 				);
-			}
+				if (fmt == Theorafile.th_pixel_fmt.TH_PF_420)
+				{
+					uvWidth = yWidth / 2;
+					uvHeight = yHeight / 2;
+				}
+				else if (fmt == Theorafile.th_pixel_fmt.TH_PF_422)
+				{
+					uvWidth = yWidth / 2;
+					uvHeight = yHeight;
+				}
+				else if (fmt == Theorafile.th_pixel_fmt.TH_PF_444)
+				{
+					uvWidth = yWidth;
+					uvHeight = yHeight;
+				}
+				else
+				{
+					throw new NotSupportedException(
+						"Unrecognized YUV format!"
+					);
+				}
 
-			// FIXME: This is a part of the Duration hack!
-			Duration = TimeSpan.MaxValue;
-			needsDurationHack = true;
+				// FIXME: This is a part of the Duration hack!
+				Duration = TimeSpan.MaxValue;
+				needsDurationHack = true;
+			}
 		}
 
 		internal Video(
@@ -139,20 +142,29 @@ namespace Microsoft.Xna.Framework.Media
 			 * you, just remove the XNB file and we'll read the OGV straight up.
 			 * -flibit
 			 */
-			if (width != Width || height != Height)
+			if (theora == IntPtr.Zero)
 			{
-				throw new InvalidOperationException(
-					"XNB/OGV width/height mismatch!" +
-					" Width: " + Width.ToString() +
-					" Height: " + Height.ToString()
-				);
+				yWidth = width;
+				yHeight = height;
+				fps = framesPerSecond;
 			}
-			if (Math.Abs(FramesPerSecond - framesPerSecond) >= 1.0f)
+			else
 			{
-				throw new InvalidOperationException(
-					"XNB/OGV framesPerSecond mismatch!" +
-					" FPS: " + FramesPerSecond.ToString()
-				);
+			    if (width != Width || height != Height)
+			    {
+				    throw new InvalidOperationException(
+					    "XNB/OGV width/height mismatch!" +
+					    " Width: " + Width.ToString() +
+					    " Height: " + Height.ToString()
+				    );
+			    }
+			    if (Math.Abs(FramesPerSecond - framesPerSecond) >= 1.0f)
+			    {
+				    throw new InvalidOperationException(
+					    "XNB/OGV framesPerSecond mismatch!" +
+					    " FPS: " + FramesPerSecond.ToString()
+				    );
+			    }
 			}
 
 			// FIXME: Oh, hey! I wish we had this info in Theora!

--- a/src/Media/Xiph/VideoPlayer.cs
+++ b/src/Media/Xiph/VideoPlayer.cs
@@ -594,6 +594,15 @@ namespace Microsoft.Xna.Framework.Media
 
 		public void Play(Video video)
 		{
+			if (video == null)
+			{
+				throw new System.ArgumentNullException();
+			}
+			if (video.theora == IntPtr.Zero)
+			{
+				throw new System.ArgumentException();
+			}
+
 			checkDisposed();
 
 			// We need to assign this regardless of what happens next.


### PR DESCRIPTION
This is a PR I originally raised against the `wine-mono` fork to fix an issue with Hell Yeah! Wrath of the Dead Rabbit (205230):
https://github.com/madewokherd/FNA/pull/6

@madewokherd and I thought it would be worth checking to see if this was something wanted upstream.

The PR changes the behavior when a Video file is missing to match what Windows does. Windows will only throw an exception when you attempt to play the Video (rather than when loading the resource).

The aim of the patch is match Windows behavior, and therefore the focus is on the scenario where an XNB file is present. But as it is, this will also modify the behavior when:
- the XNB file is missing; and
- calls to `FromUriEXT`

which may not be desirable.