### PR TITLE
don't run GetCaseName with Path.Combine on rooted path

### DIFF
--- a/src/TitleContainer.cs
+++ b/src/TitleContainer.cs
@@ -38,7 +38,10 @@ namespace Microsoft.Xna.Framework
 			{
 				safeName = GetCaseName(safeName);
 			}
-			safeName = GetCaseName(Path.Combine(TitleLocation.Path, safeName));
+			else
+			{
+				safeName = GetCaseName(Path.Combine(TitleLocation.Path, safeName));
+			}
 #endif
 			if (Path.IsPathRooted(safeName))
 			{
@@ -60,7 +63,10 @@ namespace Microsoft.Xna.Framework
 			{
 				safeName = GetCaseName(safeName);
 			}
-			safeName = GetCaseName(Path.Combine(TitleLocation.Path, safeName));
+			else
+			{
+				safeName = GetCaseName(Path.Combine(TitleLocation.Path, safeName));
+			}
 #endif
 			string realName;
 			if (Path.IsPathRooted(safeName))


### PR DESCRIPTION
This looks like a copy-pasto from the lines just below that use the same structure `if(Path.IsPathRooted...){...}...;`, but there it's fine because those are `return statements`. Here the result for a rooted path would be addition of `TitleLocation.Path` before the already rooted path.

From my observation with some debug prints, I don't think rooted paths are encountered much (if ever). This is likely the reason why this issue hasn't shown up.