### PR TITLE
Removed graphics device reset when display event enum is not orientation.

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1194,14 +1194,6 @@ namespace Microsoft.Xna.Framework
 							);
 						}
 					}
-					else
-					{
-						// Just reset, this is probably a hotplug
-						game.GraphicsDevice.Reset(
-							game.GraphicsDevice.PresentationParameters,
-							currentAdapter
-						);
-					}
 				}
 
 				// Controller device management


### PR DESCRIPTION
- SDL2_FNAPlatform.cs: Removed graphics device reset when display event enum is not orientation.

This change no longer resets the viewport to 8x8 when the display is connected or disconnected for a full screen window.

The reason why the viewport is specifically reset to 8x8 is because the FNA3D.FNA3D_GetMaxMultiSampleCount returns 8.

Resetting might make sense if the monitor was swapped entirely with another one. I'm not sure how I can track for when that happens.

This has been tested on Windows, but not linux and mac.

Fixes #500 