### PR TITLE
Eases checking of output array for GraphicsDevice.GetRenderTargetsNoAllocExt

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -1052,7 +1052,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				return renderTargetCount;
 			}
-			else if (output.Length != renderTargetCount)
+			else if (output.Length < renderTargetCount)
 			{
 				throw new ArgumentException("Output buffer size incorrect");
 			}


### PR DESCRIPTION
This PR eases the checking condition for the output array in the method GraphicsDevice.GetRenderTargetsNoAllocExt
So exact sized array is no longer required. Larger arrays are allowed too.