### PR TITLE
Update .gitignore to include additional target frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 bin/
 obj/
 obj_core/
+obj_framework/
+obj_netstandard/
 *.pidb
 *.user
 *.userprefs


### PR DESCRIPTION
obj files are not gitignored when using the NetStandard csproj target