### PR TITLE
Fix SoundEffectInstance.Play setting max frequency ratio to FAUDIO_DEFAULT_FREQ_RATIO instead of FAUDIO_MAX_FREQ_RATIO

### DIFF
--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Xna.Framework.Audio
 					out handle,
 					ref (this as DynamicSoundEffectInstance).format,
 					FAudio.FAUDIO_VOICE_USEFILTER,
-					FAudio.FAUDIO_DEFAULT_FREQ_RATIO,
+					FAudio.FAUDIO_MAX_FREQ_RATIO,
 					IntPtr.Zero,
 					IntPtr.Zero,
 					IntPtr.Zero
@@ -310,7 +310,7 @@ namespace Microsoft.Xna.Framework.Audio
 					out handle,
 					parentEffect.formatPtr,
 					FAudio.FAUDIO_VOICE_USEFILTER,
-					FAudio.FAUDIO_DEFAULT_FREQ_RATIO,
+					FAudio.FAUDIO_MAX_FREQ_RATIO,
 					IntPtr.Zero,
 					IntPtr.Zero,
 					IntPtr.Zero


### PR DESCRIPTION
Resolves https://github.com/FNA-XNA/FNA/issues/519