### PR TITLE
Optimize StateHash lookups

### DIFF
--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -24,21 +24,23 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    #region Internal PSO Hash Struct
+	#region Internal PSO Hash Struct
 
-    internal sealed class StateHashComparer : IEqualityComparer<StateHash> {
+	internal sealed class StateHashComparer : IEqualityComparer<StateHash> {
 		public static readonly StateHashComparer Instance = new StateHashComparer();
 
-        public bool Equals (StateHash x, StateHash y) {
+		public bool Equals (StateHash x, StateHash y) 
+		{
 			return x.Equals(y);
-        }
+		}
 
-        public int GetHashCode (StateHash obj) {
+		public int GetHashCode (StateHash obj) 
+		{
 			return obj.GetHashCode();
-        }
-    }
+		}
+	}
 
-    [StructLayout(LayoutKind.Sequential)]
+	[StructLayout(LayoutKind.Sequential)]
 	internal struct StateHash : IEquatable<StateHash>
 	{
 		readonly ulong a;

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -24,9 +24,21 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	#region Internal PSO Hash Struct
+    #region Internal PSO Hash Struct
 
-	[StructLayout(LayoutKind.Sequential)]
+    internal sealed class StateHashComparer : IEqualityComparer<StateHash> {
+		public static readonly StateHashComparer Instance = new StateHashComparer();
+
+        public bool Equals (StateHash x, StateHash y) {
+			return x.Equals(y);
+        }
+
+        public int GetHashCode (StateHash obj) {
+			return obj.GetHashCode();
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
 	internal struct StateHash : IEquatable<StateHash>
 	{
 		readonly ulong a;
@@ -44,7 +56,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				Convert.ToString((long) b, 2).PadLeft(64, '0');
 		}
 
-		bool IEquatable<StateHash>.Equals(StateHash hash)
+		public bool Equals(StateHash hash)
 		{
 			return a == hash.a && b == hash.b;
 		}
@@ -116,7 +128,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		/* Private Cache Storage */
 
 		private Dictionary<StateHash, BlendState> blendCache =
-			new Dictionary<StateHash, BlendState>();
+			new Dictionary<StateHash, BlendState>(StateHashComparer.Instance);
 
 		/* Private Hashing Functions */
 
@@ -279,7 +291,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		/* Private Cache Storage */
 
 		private Dictionary<StateHash, DepthStencilState> depthStencilCache =
-			new Dictionary<StateHash, DepthStencilState>();
+			new Dictionary<StateHash, DepthStencilState>(StateHashComparer.Instance);
 
 		/* Private Hashing Functions */
 
@@ -458,7 +470,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		/* Private Cache Storage */
 
 		private Dictionary<StateHash, RasterizerState> rasterizerCache =
-			new Dictionary<StateHash, RasterizerState>();
+			new Dictionary<StateHash, RasterizerState>(StateHashComparer.Instance);
 
 		/* Private Hashing Functions */
 
@@ -577,7 +589,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		/* Private Cache Storage */
 
 		private Dictionary<StateHash, SamplerState> samplerCache =
-			new Dictionary<StateHash, SamplerState>();
+			new Dictionary<StateHash, SamplerState>(StateHashComparer.Instance);
 
 		/* Private Hashing Functions */
 

--- a/src/Graphics/PipelineCache.cs
+++ b/src/Graphics/PipelineCache.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Xna.Framework.Graphics
 {
 	#region Internal PSO Hash Struct
 
-	internal sealed class StateHashComparer : IEqualityComparer<StateHash> {
+	internal sealed class StateHashComparer : IEqualityComparer<StateHash>
+	{
 		public static readonly StateHashComparer Instance = new StateHashComparer();
 
 		public bool Equals (StateHash x, StateHash y) 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/588c1660-9aa7-4098-9b33-8b5300776977)
Using the default GenericEqualityComparer for these dictionaries adds overhead