### PR TITLE
Make AddTypeCreator func and some ContentTypeReader related classes public for AOT

### DIFF
--- a/src/Content/ContentReaders/DictionaryReader.cs
+++ b/src/Content/ContentReaders/DictionaryReader.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class DictionaryReader<TKey, TValue> : ContentTypeReader<Dictionary<TKey, TValue>>
+	public class DictionaryReader<TKey, TValue> : ContentTypeReader<Dictionary<TKey, TValue>>
 	{
 		#region Public Properties
 

--- a/src/Content/ContentReaders/EnumReader.cs
+++ b/src/Content/ContentReaders/EnumReader.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class EnumReader<T> : ContentTypeReader<T>
+	public class EnumReader<T> : ContentTypeReader<T>
 	{
 		#region Private ContentTypeReader Instance
 

--- a/src/Content/ContentReaders/ListReader.cs
+++ b/src/Content/ContentReaders/ListReader.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class ListReader<T> : ContentTypeReader<List<T>>
+	public class ListReader<T> : ContentTypeReader<List<T>>
 	{
 		#region Public Properties
 

--- a/src/Content/ContentTypeReaderManager.cs
+++ b/src/Content/ContentTypeReaderManager.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Xna.Framework.Content
 		/// <param name='createFunction'>
 		/// Create function.
 		/// </param>
-		internal static void AddTypeCreator(
+		public static void AddTypeCreator(
 			string typeString,
 			Func<ContentTypeReader> createFunction
 		) {


### PR DESCRIPTION
**Motivation:**
On AOT platforms, we need to manually add these type creator functions for all of our content type readers so that they can be found (without reflection) when loading the binary-serialized XML content. I'm hoping it's not controversial to make these public so we don't have to maintain custom branch when updating FNA. Thanks!