### PR TITLE
Prevent corruption (via double free) of resource GC handles at game exit

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -516,6 +516,12 @@ namespace Microsoft.Xna.Framework.Graphics
 					 */
 					lock (resourcesLock)
 					{
+						/* NOTE: It is very important to make a copy of the resource handles and then clear
+						 *  the array. This enables RemoveResourceReference to identify whether the handle
+						 *  has already been disposed or not, to prevent us from freeing a given handle twice.
+						 * Freeing a GCHandle twice is very bad, and GCHandle.IsAllocated is not accurate once
+						 *  you make a copy of the handle.
+						 */
 						GCHandle[] resourceArray = resources.ToArray();
 						resources.Clear();
 						foreach (GCHandle resource in resourceArray)
@@ -563,6 +569,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+		/// <param name="resourceReference">The GCHandle for your resource</param>
+		/// <returns>true if you should Free your GCHandle</returns>
 		internal bool RemoveResourceReference(GCHandle resourceReference)
 		{
 			lock (resourcesLock)
@@ -580,6 +588,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				}
 			}
 
+			// The GCHandle was already freed, most likely by GraphicsDevice.Dispose
 			return false;
 		}
 

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (graphicsDevice != null && selfReference.IsAllocated)
 				{
 					if (graphicsDevice.RemoveResourceReference(selfReference))
+					{
 						selfReference.Free();
+					}
 				}
 
 				graphicsDevice = value;
@@ -192,7 +194,9 @@ namespace Microsoft.Xna.Framework.Graphics
 				if (graphicsDevice != null && selfReference.IsAllocated)
 				{
 					if (graphicsDevice.RemoveResourceReference(selfReference))
+					{
 						selfReference.Free();
+					}
 				}
 
 				IsDisposed = true;


### PR DESCRIPTION
Found this running my game using a debug build of the .NET runtime. At exit, I was seeing this:

```
Assert failure(PID 40104 [0x00009ca8], Thread: 57288 [0xdfc8]): !CREATE_CHECK_STRING(!"Detected use of a corrupted OBJECTREF. Possible GC hole.")

CORECLR! `Object::ValidateInner'::`1'::catch$6 + 0xFC (0x00007ffe`13d3689c)
CORECLR! CallSettingFrame_LookupContinuationIndex + 0x20 (0x00007ffe`13bd9160)
CORECLR! _FrameHandler4::CxxCallCatchBlock + 0x1DE (0x00007ffe`13bc4b2e)
NTDLL! RtlCaptureContext2 + 0x4A6 (0x00007fff`7f3c6006)
CORECLR! Object::ValidateInner + 0x7D (0x00007ffe`13463b3d)
CORECLR! Object::Validate + 0xD3 (0x00007ffe`13463a63)
CORECLR! OBJECTREF::OBJECTREF + 0xFF (0x00007ffe`1345b94f)
CORECLR! ObjectFromHandle + 0x79 (0x00007ffe`12ff53e9)
CORECLR! MarshalNative::GCHandleInternalGet + 0x70 (0x00007ffe`1372b320)
SYSTEM.PRIVATE.CORELIB! <no symbol> + 0x0 (0x00007ffe`11b52476)
    File: Z:\runtime\src\coreclr\vm\object.cpp:626
    Image: Z:\runtime\artifacts\tests\coreclr\windows.x64.Debug\Tests\Core_Root\corerun.exe
```

That error indicated that one of our GCHandles pointed to an invalid object pointer, `0x7`. It was happening during Game.Dispose:
<img width="906" height="591" alt="image" src="https://github.com/user-attachments/assets/b0b8e4ee-14c6-436c-85cc-2534379a587e" />

I'm not certain what the exact series of events was that led to the double free but these changes prevent it from happening, or at least make that debug assert go away.