### PR TITLE
Remove more instances of "multiply to divide".

### DIFF
--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -1775,23 +1775,22 @@ namespace Microsoft.Xna.Framework
 		/// <returns>The result of dividing a matrix by a scalar.</returns>
 		public static Matrix Divide(Matrix matrix1, float divider)
 		{
-			float num = 1f / divider;
-			matrix1.M11 = matrix1.M11 * num;
-			matrix1.M12 = matrix1.M12 * num;
-			matrix1.M13 = matrix1.M13 * num;
-			matrix1.M14 = matrix1.M14 * num;
-			matrix1.M21 = matrix1.M21 * num;
-			matrix1.M22 = matrix1.M22 * num;
-			matrix1.M23 = matrix1.M23 * num;
-			matrix1.M24 = matrix1.M24 * num;
-			matrix1.M31 = matrix1.M31 * num;
-			matrix1.M32 = matrix1.M32 * num;
-			matrix1.M33 = matrix1.M33 * num;
-			matrix1.M34 = matrix1.M34 * num;
-			matrix1.M41 = matrix1.M41 * num;
-			matrix1.M42 = matrix1.M42 * num;
-			matrix1.M43 = matrix1.M43 * num;
-			matrix1.M44 = matrix1.M44 * num;
+			matrix1.M11 = matrix1.M11 / divider;
+			matrix1.M12 = matrix1.M12 / divider;
+			matrix1.M13 = matrix1.M13 / divider;
+			matrix1.M14 = matrix1.M14 / divider;
+			matrix1.M21 = matrix1.M21 / divider;
+			matrix1.M22 = matrix1.M22 / divider;
+			matrix1.M23 = matrix1.M23 / divider;
+			matrix1.M24 = matrix1.M24 / divider;
+			matrix1.M31 = matrix1.M31 / divider;
+			matrix1.M32 = matrix1.M32 / divider;
+			matrix1.M33 = matrix1.M33 / divider;
+			matrix1.M34 = matrix1.M34 / divider;
+			matrix1.M41 = matrix1.M41 / divider;
+			matrix1.M42 = matrix1.M42 / divider;
+			matrix1.M43 = matrix1.M43 / divider;
+			matrix1.M44 = matrix1.M44 / divider;
 			return matrix1;
 		}
 
@@ -1803,23 +1802,22 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">The result of dividing a matrix by a scalar as an output parameter.</param>
 		public static void Divide(ref Matrix matrix1, float divider, out Matrix result)
 		{
-			float num = 1f / divider;
-			result.M11 = matrix1.M11 * num;
-			result.M12 = matrix1.M12 * num;
-			result.M13 = matrix1.M13 * num;
-			result.M14 = matrix1.M14 * num;
-			result.M21 = matrix1.M21 * num;
-			result.M22 = matrix1.M22 * num;
-			result.M23 = matrix1.M23 * num;
-			result.M24 = matrix1.M24 * num;
-			result.M31 = matrix1.M31 * num;
-			result.M32 = matrix1.M32 * num;
-			result.M33 = matrix1.M33 * num;
-			result.M34 = matrix1.M34 * num;
-			result.M41 = matrix1.M41 * num;
-			result.M42 = matrix1.M42 * num;
-			result.M43 = matrix1.M43 * num;
-			result.M44 = matrix1.M44 * num;
+			result.M11 = matrix1.M11 / divider;
+			result.M12 = matrix1.M12 / divider;
+			result.M13 = matrix1.M13 / divider;
+			result.M14 = matrix1.M14 / divider;
+			result.M21 = matrix1.M21 / divider;
+			result.M22 = matrix1.M22 / divider;
+			result.M23 = matrix1.M23 / divider;
+			result.M24 = matrix1.M24 / divider;
+			result.M31 = matrix1.M31 / divider;
+			result.M32 = matrix1.M32 / divider;
+			result.M33 = matrix1.M33 / divider;
+			result.M34 = matrix1.M34 / divider;
+			result.M41 = matrix1.M41 / divider;
+			result.M42 = matrix1.M42 / divider;
+			result.M43 = matrix1.M43 / divider;
+			result.M44 = matrix1.M44 / divider;
 		}
 
 		/// <summary>

--- a/src/Vector3.cs
+++ b/src/Vector3.cs
@@ -624,10 +624,9 @@ namespace Microsoft.Xna.Framework
 		/// <returns>The result of dividing a vector by a scalar.</returns>
 		public static Vector3 Divide(Vector3 value1, float value2)
 		{
-			float factor = 1 / value2;
-			value1.X *= factor;
-			value1.Y *= factor;
-			value1.Z *= factor;
+			value1.X /= value2;
+			value1.Y /= value2;
+			value1.Z /= value2;
 			return value1;
 		}
 
@@ -639,10 +638,9 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">The result of dividing a vector by a scalar as an output parameter.</param>
 		public static void Divide(ref Vector3 value1, float value2, out Vector3 result)
 		{
-			float factor = 1 / value2;
-			result.X = value1.X * factor;
-			result.Y = value1.Y * factor;
-			result.Z = value1.Z * factor;
+			result.X = value1.X / value2;
+			result.Y = value1.Y / value2;
+			result.Z = value1.Z / value2;
 		}
 
 		/// <summary>


### PR DESCRIPTION
I missed these in https://github.com/FNA-XNA/FNA/pull/536. I've also tested these methods in XNA/.NET Framework/Windows.

The remaining instances of this have us calculating the divisor. Those are mostly Normalize functions. XNA seems to be able to handle that too, but I think that FNA would fail to calculate the length due to the square of each component being too small to represent, so fixing that would be more involved.