### PR TITLE
Reveal amount of textures in TextureCollection

### DIFF
--- a/src/Graphics/TextureCollection.cs
+++ b/src/Graphics/TextureCollection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return textures.Length;
+				return Math.Min(textures.Length, modifiedSamplers.Length);
 			}
 		}
 


### PR DESCRIPTION
Reveals amount of textures in the TextureCollection.
Example usage:

```c#
// Reset the graphics device textures
for(var i = 0; i < GraphicsDevice.Textures.Count; ++i) 
{
  GraphicsDevice.Textures[i] = null;
}
```