### PR TITLE
SongReader puts the asset name in Song.Name.

### DIFF
--- a/src/Content/ContentReaders/SongReader.cs
+++ b/src/Content/ContentReaders/SongReader.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Xna.Framework.Content
 
 			int durationMs = input.ReadInt32();
 
-			return new Song(path, durationMs);
+			return new Song(path, input.AssetName, durationMs);
 		}
 
 		#endregion

--- a/src/Media/Song.cs
+++ b/src/Media/Song.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Xna.Framework.Media
 			IsDisposed = false;
 		}
 
-		internal Song(string fileName, int durationMS) : this(fileName)
+		internal Song(string fileName, string assetName, int durationMS) : this(fileName, assetName)
 		{
 			Duration = TimeSpan.FromMilliseconds(durationMS);
 		}


### PR DESCRIPTION
Verified this behavior by manual testing. (Can send test program code if it's of interest)

XNA seems to give me the asset name even if the .wma file is named differently, and even if the .wma file's metadata contains a title.

Required by Camera Obscura, which uses this property to compare Song instances.