### PR TITLE
Return an SDL_DisplayID for GraphicsAdapter.MonitorHandle.

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -133,6 +133,7 @@ namespace Microsoft.Xna.Framework
 				PollEvents =			SDL3_FNAPlatform.PollEvents;
 				GetGraphicsAdapters =		SDL3_FNAPlatform.GetGraphicsAdapters;
 				GetCurrentDisplayMode =		SDL3_FNAPlatform.GetCurrentDisplayMode;
+				GetMonitorHandle =		SDL3_FNAPlatform.GetMonitorHandle;
 				GetKeyFromScancode =		SDL3_FNAPlatform.GetKeyFromScancode;
 				IsTextInputActive =		SDL3_FNAPlatform.IsTextInputActive;
 				StartTextInput =		SDL3_FNAPlatform.StartTextInput;
@@ -188,6 +189,7 @@ namespace Microsoft.Xna.Framework
 				PollEvents =			SDL2_FNAPlatform.PollEvents;
 				GetGraphicsAdapters =		SDL2_FNAPlatform.GetGraphicsAdapters;
 				GetCurrentDisplayMode =		SDL2_FNAPlatform.GetCurrentDisplayMode;
+				GetMonitorHandle =		SDL2_FNAPlatform.GetMonitorHandle;
 				GetKeyFromScancode =		SDL2_FNAPlatform.GetKeyFromScancode;
 				IsTextInputActive =		SDL2_FNAPlatform.IsTextInputActive;
 				StartTextInput =		SDL2_FNAPlatform.StartTextInput;
@@ -346,6 +348,9 @@ namespace Microsoft.Xna.Framework
 
 		public delegate DisplayMode GetCurrentDisplayModeFunc(int adapterIndex);
 		public static readonly GetCurrentDisplayModeFunc GetCurrentDisplayMode;
+
+		public delegate IntPtr GetMonitorHandleFunc(int adapterIndex);
+		public static readonly GetMonitorHandleFunc GetMonitorHandle;
 
 		public delegate Keys GetKeyFromScancodeFunc(Keys scancode);
 		public static readonly GetKeyFromScancodeFunc GetKeyFromScancode;

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1385,6 +1385,11 @@ namespace Microsoft.Xna.Framework
 			);
 		}
 
+		public static IntPtr GetMonitorHandle(int adapterIndex)
+		{
+			return new IntPtr(adapterIndex);
+		}
+
 		#endregion
 
 		#region Mouse Methods

--- a/src/FNAPlatform/SDL3_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL3_FNAPlatform.cs
@@ -1328,6 +1328,11 @@ namespace Microsoft.Xna.Framework
 			);
 		}
 
+		public static IntPtr GetMonitorHandle(int adapterIndex)
+		{
+			return new IntPtr(unchecked((int)displayIds[adapterIndex]));
+		}
+
 		#endregion
 
 		#region Mouse Methods

--- a/src/Graphics/GraphicsAdapter.cs
+++ b/src/Graphics/GraphicsAdapter.cs
@@ -86,7 +86,9 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				throw new NotImplementedException();
+				return FNAPlatform.GetMonitorHandle(
+					Adapters.IndexOf(this)
+				);
 			}
 		}
 


### PR DESCRIPTION
Yargis - Space Melee, a Windows XNA game, uses GraphicsAdapter.get_MonitorHandle(). In Proton, with Wine Mono's FNA-based replacement for XNA, it crashes with a NotImplementedException.

The game presumably wants an HMONITOR (though, oddly enough, this seems to satisfy it), but returning an SDL_DisplayID will make a Wine Mono hack that returns HMONITOR easier, and perhaps someone will find it useful for converting their existing code.