### PR TITLE
Separate Video/VideoPlayer from Theora implementation and allow new codecs to be registered

### DIFF
--- a/FNA.Core.csproj
+++ b/FNA.Core.csproj
@@ -328,7 +328,7 @@
 		<Compile Include="src\Media\VideoSoundtrackType.cs" />
 		<Compile Include="src\Media\VisualizationData.cs" />
 		<Compile Include="src\Media\Xiph\BaseYUVPlayer.cs" />
-		<Compile Include="src\Media\Xiph\IVideoPlayerImpl.cs" />
+		<Compile Include="src\Media\Xiph\IVideoPlayerCodec.cs" />
 		<Compile Include="src\Media\Xiph\Video.cs" />
 		<Compile Include="src\Media\Xiph\VideoPlayer.cs" />
 		<Compile Include="src\Media\Xiph\VideoPlayerTheora.cs" />

--- a/FNA.NetFramework.csproj
+++ b/FNA.NetFramework.csproj
@@ -329,7 +329,7 @@
 		<Compile Include="src\Media\VideoSoundtrackType.cs" />
 		<Compile Include="src\Media\VisualizationData.cs" />
 		<Compile Include="src\Media\Xiph\BaseYUVPlayer.cs" />
-		<Compile Include="src\Media\Xiph\IVideoPlayerImpl.cs" />
+		<Compile Include="src\Media\Xiph\IVideoPlayerCodec.cs" />
 		<Compile Include="src\Media\Xiph\Video.cs" />
 		<Compile Include="src\Media\Xiph\VideoPlayer.cs" />
 		<Compile Include="src\Media\Xiph\VideoPlayerTheora.cs" />

--- a/FNA.NetStandard.csproj
+++ b/FNA.NetStandard.csproj
@@ -327,7 +327,7 @@
 		<Compile Include="src\Media\VideoSoundtrackType.cs" />
 		<Compile Include="src\Media\VisualizationData.cs" />
 		<Compile Include="src\Media\Xiph\BaseYUVPlayer.cs" />
-		<Compile Include="src\Media\Xiph\IVideoPlayerImpl.cs" />
+		<Compile Include="src\Media\Xiph\IVideoPlayerCodec.cs" />
 		<Compile Include="src\Media\Xiph\Video.cs" />
 		<Compile Include="src\Media\Xiph\VideoPlayer.cs" />
 		<Compile Include="src\Media\Xiph\VideoPlayerTheora.cs" />

--- a/FNA.csproj
+++ b/FNA.csproj
@@ -399,7 +399,7 @@
     <Compile Include="src\Media\VideoSoundtrackType.cs" />
     <Compile Include="src\Media\VisualizationData.cs" />
     <Compile Include="src\Media\Xiph\BaseYUVPlayer.cs" />
-    <Compile Include="src\Media\Xiph\IVideoPlayerImpl.cs" />
+    <Compile Include="src\Media\Xiph\IVideoPlayerCodec.cs" />
     <Compile Include="src\Media\Xiph\Video.cs" />
     <Compile Include="src\Media\Xiph\VideoPlayer.cs" />
     <Compile Include="src\Media\Xiph\VideoPlayerTheora.cs" />

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ SRC = \
 	src/Media/SongCollection.cs \
 	src/Media/VideoSoundtrackType.cs \
 	src/Media/VisualizationData.cs \
-	src/Media/Xiph/IVideoPlayerImpl.cs \
+	src/Media/Xiph/IVideoPlayerCodec.cs \
 	src/Media/Xiph/BaseYUVPlayer.cs \
 	src/Media/Xiph/Video.cs \
 	src/Media/Xiph/VideoPlayer.cs \

--- a/src/Media/Xiph/IVideoPlayerCodec.cs
+++ b/src/Media/Xiph/IVideoPlayerCodec.cs
@@ -14,7 +14,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Media
 {
-	public interface IVideoPlayerImpl : IDisposable
+	internal interface IVideoPlayerCodec : IDisposable
 	{
 		#region Public Member Data: XNA VideoPlayer Implementation
 

--- a/src/Media/Xiph/Video.cs
+++ b/src/Media/Xiph/Video.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Xna.Framework.Media
 
 		internal int audioTrack = -1;
 		internal int videoTrack = -1;
-		internal IVideoPlayerImpl parent;
+		internal IVideoPlayerCodec parent;
 
 		public void SetAudioTrackEXT(int track)
 		{

--- a/src/Media/Xiph/VideoPlayer.cs
+++ b/src/Media/Xiph/VideoPlayer.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Xna.Framework.Media
 
 		#region Private Member Data: Implementation
 
-		private IVideoPlayerImpl impl;
+		private IVideoPlayerCodec impl;
 
 		internal static Dictionary<string, string> codecExtensions =
 			new Dictionary<string, string>
@@ -130,8 +130,8 @@ namespace Microsoft.Xna.Framework.Media
 				{ "Theora", VideoPlayerTheora.ReadInfo }
 			};
 
-		internal static Dictionary<string, Func<IVideoPlayerImpl>> codecPlayers =
-			new Dictionary<string, Func<IVideoPlayerImpl>>
+		internal static Dictionary<string, Func<IVideoPlayerCodec>> codecPlayers =
+			new Dictionary<string, Func<IVideoPlayerCodec>>
 			{
 				{ "Theora", () => new VideoPlayerTheora() },
 			};
@@ -250,16 +250,9 @@ namespace Microsoft.Xna.Framework.Media
 			}
 		}
 
-		public static void AddCodecEXT(string codecName, List<String> extensions, Func<string, VideoInfo> reader,
-			Func<IVideoPlayerImpl> implementation)
-		{
-			foreach (String extension in extensions)
-			{
-				codecExtensions.Add(extension.ToLower(), codecName);
-			}
-			codecInfoReaders.Add(codecName, reader);
-			codecPlayers.Add(codecName, implementation);
-		}
+		#endregion
+
+		#region Structs for Internal Use
 
 		public struct VideoInfo
 		{

--- a/src/Media/Xiph/VideoPlayerTheora.cs
+++ b/src/Media/Xiph/VideoPlayerTheora.cs
@@ -18,7 +18,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Media
 {
-	public sealed class VideoPlayerTheora : IVideoPlayerImpl, IDisposable
+	public sealed class VideoPlayerTheora : IVideoPlayerCodec, IDisposable
 	{
 		#region Hardware-accelerated YUV -> RGBA
 
@@ -936,7 +936,6 @@ namespace Microsoft.Xna.Framework.Media
 		}
 
 		#endregion
-
 
 		#region Video support methods
 


### PR DESCRIPTION
This is one of two PRs to lay the groundwork for AV1 support.  It also permits future codecs to be easily added.