### PR TITLE
MouseState equality operator bugfix.

### DIFF
--- a/src/Input/MouseState.cs
+++ b/src/Input/MouseState.cs
@@ -144,7 +144,9 @@ namespace Microsoft.Xna.Framework.Input
 					left.LeftButton == right.LeftButton &&
 					left.MiddleButton == right.MiddleButton &&
 					left.RightButton == right.RightButton &&
-					left.ScrollWheelValue == right.ScrollWheelValue	);
+					left.ScrollWheelValue == right.ScrollWheelValue &&
+					left.XButton1 == right.XButton1 &&
+					left.XButton2 == right.XButton2 );
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes a bug where the MouseState's equality operator does not check for XButton1 and XButton2, resulting in incorrect state checks.

FIXES: #559