### PR TITLE
revert #593 that bug while CapsLock. Ctrl+V without LeftAlt

### DIFF
--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -986,6 +986,7 @@ namespace Microsoft.Xna.Framework
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
 						else if ((Keyboard.keys.IsKeyDown(Keys.LeftControl) || Keyboard.keys.IsKeyDown(Keys.RightControl))
+							&& Keyboard.keys.IsKeyUp(Keys.LeftAlt)
 							&& key == Keys.V)
 						{
 							textInputControlDown[6] = true;

--- a/src/FNAPlatform/SDL3_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL3_FNAPlatform.cs
@@ -911,7 +911,8 @@ namespace Microsoft.Xna.Framework
 							textInputControlDown[textIndex] = true;
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
-						else if ((evt.key.mod == SDL.SDL_Keymod.SDL_KMOD_LCTRL || evt.key.mod == SDL.SDL_Keymod.SDL_KMOD_RCTRL)
+						else if ((Keyboard.keys.IsKeyDown(Keys.LeftControl) || Keyboard.keys.IsKeyDown(Keys.RightControl))
+							&& Keyboard.keys.IsKeyUp(Keys.LeftAlt)
 							&& key == Keys.V)
 						{
 							textInputControlDown[6] = true;
@@ -926,7 +927,7 @@ namespace Microsoft.Xna.Framework
 						{
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[textIndex]);
 						}
-						else if ((evt.key.mod == SDL.SDL_Keymod.SDL_KMOD_LCTRL || evt.key.mod == SDL.SDL_Keymod.SDL_KMOD_RCTRL)
+						else if ((Keyboard.keys.IsKeyDown(Keys.LeftControl) || Keyboard.keys.IsKeyDown(Keys.RightControl))
 							&& key == Keys.V)
 						{
 							TextInputEXT.OnTextInput(FNAPlatform.TextInputCharacters[6]);


### PR DESCRIPTION
KeyMod include CapsLock, ScrollLock, NumLock. Ctrl+V not trigger while they locking.

I test that AltGr mean Keys.LeftCtrl and Keys.LeftAlt in XNA. So when test LeftAlt whether down.