### PR TITLE
Don't throw ArrayIndexOutOfBounds in EffectTechniqueCollection

### DIFF
--- a/src/Graphics/Effect/EffectTechniqueCollection.cs
+++ b/src/Graphics/Effect/EffectTechniqueCollection.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return elements[index];
+				return index >= 0 && index < elements.Count ? elements[index] : null;
 			}
 		}
 
@@ -40,12 +40,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				foreach (EffectTechnique elem in elements)
 				{
-					if (name.Equals(elem.Name))
+					if (name == elem.Name)
 					{
 						return elem;
 					}
 				}
-				return null; // FIXME: ArrayIndexOutOfBounds? -flibit
+				return null;
 			}
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

