### PR TITLE
optimize: Duplicate DrawString

### DIFF
--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -712,7 +712,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			SpriteFont.IReadOnlyCharList view = new SpriteFont.StringBuilderView(text);
+			SpriteFont.StringBuilderView view = new SpriteFont.StringBuilderView(text);
 			DrawString(spriteFont, ref view, position, color, rotation, origin, scale, effects, layerDepth);
 		}
 
@@ -774,7 +774,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			SpriteFont.IReadOnlyCharList view = new SpriteFont.StringView(text);
+			SpriteFont.StringView view = new SpriteFont.StringView(text);
 			DrawString(spriteFont, ref view, position, color, rotation, origin, scale, effects, layerDepth);
 		}
 
@@ -782,9 +782,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Private Methods
 
-		private void DrawString(
+		private void DrawString<T>(
 			SpriteFont spriteFont,
-			ref SpriteFont.IReadOnlyCharList text,
+			ref T text,
 			Vector2 position,
 			Color color,
 			float rotation,
@@ -792,7 +792,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			Vector2 scale,
 			SpriteEffects effects,
 			float layerDepth
-		)
+		) where T : SpriteFont.IReadOnlyCharList
 		{
 			CheckBegin("DrawString");
 			if (text.Length == 0)

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -708,16 +708,93 @@ namespace Microsoft.Xna.Framework.Graphics
 			SpriteEffects effects,
 			float layerDepth
 		) {
-			/* FIXME: This method is a duplicate of DrawString(string)!
-			 * The only difference is how we iterate through the StringBuilder.
-			 * We don't use ToString() since it generates garbage.
-			 * -flibit
-			 */
-			CheckBegin("DrawString");
 			if (text == null)
 			{
 				throw new ArgumentNullException("text");
 			}
+			SpriteFont.IReadOnlyCharList view = new SpriteFont.StringBuilderView(text);
+			DrawString(spriteFont, ref view, position, color, rotation, origin, scale, effects, layerDepth);
+		}
+
+		public void DrawString(
+			SpriteFont spriteFont,
+			string text,
+			Vector2 position,
+			Color color
+		) {
+			DrawString(
+				spriteFont,
+				text,
+				position,
+				color,
+				0.0f,
+				Vector2.Zero,
+				Vector2.One,
+				SpriteEffects.None,
+				0.0f
+			);
+		}
+
+		public void DrawString(
+			SpriteFont spriteFont,
+			string text,
+			Vector2 position,
+			Color color,
+			float rotation,
+			Vector2 origin,
+			float scale,
+			SpriteEffects effects,
+			float layerDepth
+		) {
+			DrawString(
+				spriteFont,
+				text,
+				position,
+				color,
+				rotation,
+				origin,
+				new Vector2(scale),
+				effects,
+				layerDepth
+			);
+		}
+
+		public void DrawString(
+			SpriteFont spriteFont,
+			string text,
+			Vector2 position,
+			Color color,
+			float rotation,
+			Vector2 origin,
+			Vector2 scale,
+			SpriteEffects effects,
+			float layerDepth
+		) {
+			if (text == null)
+			{
+				throw new ArgumentNullException("text");
+			}
+			SpriteFont.IReadOnlyCharList view = new SpriteFont.StringView(text);
+			DrawString(spriteFont, ref view, position, color, rotation, origin, scale, effects, layerDepth);
+		}
+
+		#endregion
+
+		#region Private Methods
+
+		private void DrawString(
+			SpriteFont spriteFont,
+			ref SpriteFont.IReadOnlyCharList text,
+			Vector2 position,
+			Color color,
+			float rotation,
+			Vector2 origin,
+			Vector2 scale,
+			SpriteEffects effects,
+			float layerDepth
+		)
+		{
+			CheckBegin("DrawString");
 			if (text.Length == 0)
 			{
 				return;
@@ -745,7 +822,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			float axisDirMirrorY = 0.0f;
 			if (effects != SpriteEffects.None)
 			{
-				Vector2 size = spriteFont.MeasureString(text);
+				Vector2 size = spriteFont.MeasureString(ref text);
 				baseOffset.X -= size.X * axisIsMirroredX[(int) effects];
 				baseOffset.Y -= size.Y * axisIsMirroredY[(int) effects];
 				axisDirMirrorX = axisIsMirroredX[(int) effects];
@@ -852,207 +929,6 @@ namespace Microsoft.Xna.Framework.Graphics
 				curOffset.X += cKern.Y + cKern.Z;
 			}
 		}
-
-		public void DrawString(
-			SpriteFont spriteFont,
-			string text,
-			Vector2 position,
-			Color color
-		) {
-			DrawString(
-				spriteFont,
-				text,
-				position,
-				color,
-				0.0f,
-				Vector2.Zero,
-				Vector2.One,
-				SpriteEffects.None,
-				0.0f
-			);
-		}
-
-		public void DrawString(
-			SpriteFont spriteFont,
-			string text,
-			Vector2 position,
-			Color color,
-			float rotation,
-			Vector2 origin,
-			float scale,
-			SpriteEffects effects,
-			float layerDepth
-		) {
-			DrawString(
-				spriteFont,
-				text,
-				position,
-				color,
-				rotation,
-				origin,
-				new Vector2(scale),
-				effects,
-				layerDepth
-			);
-		}
-
-		public void DrawString(
-			SpriteFont spriteFont,
-			string text,
-			Vector2 position,
-			Color color,
-			float rotation,
-			Vector2 origin,
-			Vector2 scale,
-			SpriteEffects effects,
-			float layerDepth
-		) {
-			/* FIXME: This method is a duplicate of DrawString(StringBuilder)!
-			 * The only difference is how we iterate through the string.
-			 * -flibit
-			 */
-			CheckBegin("DrawString");
-			if (text == null)
-			{
-				throw new ArgumentNullException("text");
-			}
-			if (text.Length == 0)
-			{
-				return;
-			}
-			effects &= (SpriteEffects) 0x03;
-
-			/* We pull all these internal variables in at once so
-			 * anyone who wants to use this file to make their own
-			 * SpriteBatch can easily replace these with reflection.
-			 * -flibit
-			 */
-			Texture2D textureValue = spriteFont.textureValue;
-			List<Rectangle> glyphData = spriteFont.glyphData;
-			List<Rectangle> croppingData = spriteFont.croppingData;
-			List<Vector3> kerning = spriteFont.kerning;
-			Dictionary<char, int> characterIndexMap = spriteFont.characterIndexMap;
-
-			// FIXME: This needs an accuracy check! -flibit
-
-			// Calculate offsets/axes, using the string size for flipped text
-			Vector2 baseOffset = origin;
-			float axisDirX = axisDirectionX[(int) effects];
-			float axisDirY = axisDirectionY[(int) effects];
-			float axisDirMirrorX = 0.0f;
-			float axisDirMirrorY = 0.0f;
-			if (effects != SpriteEffects.None)
-			{
-				Vector2 size = spriteFont.MeasureString(text);
-				baseOffset.X -= size.X * axisIsMirroredX[(int) effects];
-				baseOffset.Y -= size.Y * axisIsMirroredY[(int) effects];
-				axisDirMirrorX = axisIsMirroredX[(int) effects];
-				axisDirMirrorY = axisIsMirroredY[(int) effects];
-			}
-
-			Vector2 curOffset = Vector2.Zero;
-			bool firstInLine = true;
-			foreach (char c in text)
-			{
-				// Special characters
-				if (c == '\r')
-				{
-					continue;
-				}
-				if (c == '\n')
-				{
-					curOffset.X = 0.0f;
-					curOffset.Y += spriteFont.LineSpacing;
-					firstInLine = true;
-					continue;
-				}
-
-				/* Get the List index from the character map, defaulting to the
-				 * DefaultCharacter if it's set.
-				 */
-				int index;
-				if (!characterIndexMap.TryGetValue(c, out index))
-				{
-					if (!spriteFont.DefaultCharacter.HasValue)
-					{
-						throw new ArgumentException(
-							"Text contains characters that cannot be" +
-							" resolved by this SpriteFont.",
-							"text"
-						);
-					}
-					index = characterIndexMap[spriteFont.DefaultCharacter.Value];
-				}
-
-				/* For the first character in a line, always push the width
-				 * rightward, even if the kerning pushes the character to the
-				 * left.
-				 */
-				Vector3 cKern = kerning[index];
-				if (firstInLine)
-				{
-					curOffset.X += Math.Abs(cKern.X);
-					firstInLine = false;
-				}
-				else
-				{
-					curOffset.X += spriteFont.Spacing + cKern.X;
-				}
-
-				// Calculate the character origin
-				Rectangle cCrop = croppingData[index];
-				Rectangle cGlyph = glyphData[index];
-				float offsetX = baseOffset.X + (
-					curOffset.X + cCrop.X
-				) * axisDirX;
-				float offsetY = baseOffset.Y + (
-					curOffset.Y + cCrop.Y
-				) * axisDirY;
-				if (effects != SpriteEffects.None)
-				{
-					offsetX += cGlyph.Width * axisDirMirrorX;
-					offsetY += cGlyph.Height * axisDirMirrorY;
-				}
-
-				// Draw!
-				float sourceW = Math.Sign(cGlyph.Width) * Math.Max(
-					Math.Abs(cGlyph.Width),
-					MathHelper.MachineEpsilonFloat
-				) / (float) textureValue.Width;
-				float sourceH = Math.Sign(cGlyph.Height) * Math.Max(
-					Math.Abs(cGlyph.Height),
-					MathHelper.MachineEpsilonFloat
-				) / (float) textureValue.Height;
-				PushSprite(
-					textureValue,
-					cGlyph.X / (float) textureValue.Width,
-					cGlyph.Y / (float) textureValue.Height,
-					sourceW,
-					sourceH,
-					position.X,
-					position.Y,
-					cGlyph.Width * scale.X,
-					cGlyph.Height * scale.Y,
-					color,
-					offsetX / sourceW / (float) textureValue.Width,
-					offsetY / sourceH / (float) textureValue.Height,
-					(float) Math.Sin(rotation),
-					(float) Math.Cos(rotation),
-					layerDepth,
-					(int) effects
-				);
-
-				/* Add the character width and right-side
-				 * bearing to the line width.
-				 */
-				curOffset.X += cKern.Y + cKern.Z;
-			}
-		}
-
-		#endregion
-
-		#region Private Methods
-
 		private unsafe void PushSprite(
 			Texture2D texture,
 			float sourceX,

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -712,8 +712,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			SpriteFont.StringBuilderView view = new SpriteFont.StringBuilderView(text);
-			DrawString(spriteFont, ref view, position, color, rotation, origin, scale, effects, layerDepth);
+			DrawString(spriteFont, new SpriteFont.StringBuilderView(text), position, color, rotation, origin, scale, effects, layerDepth);
 		}
 
 		public void DrawString(
@@ -774,8 +773,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			SpriteFont.StringView view = new SpriteFont.StringView(text);
-			DrawString(spriteFont, ref view, position, color, rotation, origin, scale, effects, layerDepth);
+			DrawString(spriteFont, new SpriteFont.StringView(text), position, color, rotation, origin, scale, effects, layerDepth);
 		}
 
 		#endregion
@@ -784,7 +782,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		private void DrawString<T>(
 			SpriteFont spriteFont,
-			ref T text,
+			T text,
 			Vector2 position,
 			Color color,
 			float rotation,
@@ -792,7 +790,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			Vector2 scale,
 			SpriteEffects effects,
 			float layerDepth
-		) where T : SpriteFont.IReadOnlyCharList
+		) where T : struct, SpriteFont.IReadOnlyCharList
 		{
 			CheckBegin("DrawString");
 			if (text.Length == 0)
@@ -822,7 +820,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			float axisDirMirrorY = 0.0f;
 			if (effects != SpriteEffects.None)
 			{
-				Vector2 size = spriteFont.MeasureString(ref text);
+				Vector2 size = spriteFont.MeasureString(text);
 				baseOffset.X -= size.X * axisIsMirroredX[(int) effects];
 				baseOffset.Y -= size.Y * axisIsMirroredY[(int) effects];
 				axisDirMirrorX = axisIsMirroredX[(int) effects];

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -708,16 +708,90 @@ namespace Microsoft.Xna.Framework.Graphics
 			SpriteEffects effects,
 			float layerDepth
 		) {
-			/* FIXME: This method is a duplicate of DrawString(string)!
-			 * The only difference is how we iterate through the StringBuilder.
-			 * We don't use ToString() since it generates garbage.
-			 * -flibit
-			 */
-			CheckBegin("DrawString");
 			if (text == null)
 			{
 				throw new ArgumentNullException("text");
 			}
+			DrawString(spriteFont, new SpriteFont.StringBuilderView(text), position, color, rotation, origin, scale, effects, layerDepth);
+		}
+
+		public void DrawString(
+			SpriteFont spriteFont,
+			string text,
+			Vector2 position,
+			Color color
+		) {
+			DrawString(
+				spriteFont,
+				text,
+				position,
+				color,
+				0.0f,
+				Vector2.Zero,
+				Vector2.One,
+				SpriteEffects.None,
+				0.0f
+			);
+		}
+
+		public void DrawString(
+			SpriteFont spriteFont,
+			string text,
+			Vector2 position,
+			Color color,
+			float rotation,
+			Vector2 origin,
+			float scale,
+			SpriteEffects effects,
+			float layerDepth
+		) {
+			DrawString(
+				spriteFont,
+				text,
+				position,
+				color,
+				rotation,
+				origin,
+				new Vector2(scale),
+				effects,
+				layerDepth
+			);
+		}
+
+		public void DrawString(
+			SpriteFont spriteFont,
+			string text,
+			Vector2 position,
+			Color color,
+			float rotation,
+			Vector2 origin,
+			Vector2 scale,
+			SpriteEffects effects,
+			float layerDepth
+		) {
+			if (ReferenceEquals(text, null))
+			{
+				throw new ArgumentNullException("text");
+			}
+			DrawString(spriteFont, new SpriteFont.StringView(text), position, color, rotation, origin, scale, effects, layerDepth);
+		}
+
+		#endregion
+
+		#region Private Methods
+
+		private void DrawString<T>(
+			SpriteFont spriteFont,
+			T text,
+			Vector2 position,
+			Color color,
+			float rotation,
+			Vector2 origin,
+			Vector2 scale,
+			SpriteEffects effects,
+			float layerDepth
+		) where T : struct, SpriteFont.IReadOnlyCharList {
+			CheckBegin("DrawString");
 			if (text.Length == 0)
 			{
 				return;
@@ -852,206 +926,6 @@ namespace Microsoft.Xna.Framework.Graphics
 				curOffset.X += cKern.Y + cKern.Z;
 			}
 		}
-
-		public void DrawString(
-			SpriteFont spriteFont,
-			string text,
-			Vector2 position,
-			Color color
-		) {
-			DrawString(
-				spriteFont,
-				text,
-				position,
-				color,
-				0.0f,
-				Vector2.Zero,
-				Vector2.One,
-				SpriteEffects.None,
-				0.0f
-			);
-		}
-
-		public void DrawString(
-			SpriteFont spriteFont,
-			string text,
-			Vector2 position,
-			Color color,
-			float rotation,
-			Vector2 origin,
-			float scale,
-			SpriteEffects effects,
-			float layerDepth
-		) {
-			DrawString(
-				spriteFont,
-				text,
-				position,
-				color,
-				rotation,
-				origin,
-				new Vector2(scale),
-				effects,
-				layerDepth
-			);
-		}
-
-		public void DrawString(
-			SpriteFont spriteFont,
-			string text,
-			Vector2 position,
-			Color color,
-			float rotation,
-			Vector2 origin,
-			Vector2 scale,
-			SpriteEffects effects,
-			float layerDepth
-		) {
-			/* FIXME: This method is a duplicate of DrawString(StringBuilder)!
-			 * The only difference is how we iterate through the string.
-			 * -flibit
-			 */
-			CheckBegin("DrawString");
-			if (ReferenceEquals(text, null))
-			{
-				throw new ArgumentNullException("text");
-			}
-			if (text.Length == 0)
-			{
-				return;
-			}
-			effects &= (SpriteEffects) 0x03;
-
-			/* We pull all these internal variables in at once so
-			 * anyone who wants to use this file to make their own
-			 * SpriteBatch can easily replace these with reflection.
-			 * -flibit
-			 */
-			Texture2D textureValue = spriteFont.textureValue;
-			List<Rectangle> glyphData = spriteFont.glyphData;
-			List<Rectangle> croppingData = spriteFont.croppingData;
-			List<Vector3> kerning = spriteFont.kerning;
-			Dictionary<char, int> characterIndexMap = spriteFont.characterIndexMap;
-
-			// FIXME: This needs an accuracy check! -flibit
-
-			// Calculate offsets/axes, using the string size for flipped text
-			Vector2 baseOffset = origin;
-			float axisDirX = axisDirectionX[(int) effects];
-			float axisDirY = axisDirectionY[(int) effects];
-			float axisDirMirrorX = 0.0f;
-			float axisDirMirrorY = 0.0f;
-			if (effects != SpriteEffects.None)
-			{
-				Vector2 size = spriteFont.MeasureString(text);
-				baseOffset.X -= size.X * axisIsMirroredX[(int) effects];
-				baseOffset.Y -= size.Y * axisIsMirroredY[(int) effects];
-				axisDirMirrorX = axisIsMirroredX[(int) effects];
-				axisDirMirrorY = axisIsMirroredY[(int) effects];
-			}
-
-			Vector2 curOffset = Vector2.Zero;
-			bool firstInLine = true;
-			foreach (char c in text)
-			{
-				// Special characters
-				if (c == '\r')
-				{
-					continue;
-				}
-				if (c == '\n')
-				{
-					curOffset.X = 0.0f;
-					curOffset.Y += spriteFont.LineSpacing;
-					firstInLine = true;
-					continue;
-				}
-
-				/* Get the List index from the character map, defaulting to the
-				 * DefaultCharacter if it's set.
-				 */
-				int index;
-				if (!characterIndexMap.TryGetValue(c, out index))
-				{
-					if (!spriteFont.DefaultCharacter.HasValue)
-					{
-						throw new ArgumentException(
-							"Text contains characters that cannot be" +
-							" resolved by this SpriteFont.",
-							"text"
-						);
-					}
-					index = characterIndexMap[spriteFont.DefaultCharacter.Value];
-				}
-
-				/* For the first character in a line, always push the width
-				 * rightward, even if the kerning pushes the character to the
-				 * left.
-				 */
-				Vector3 cKern = kerning[index];
-				if (firstInLine)
-				{
-					curOffset.X += Math.Abs(cKern.X);
-					firstInLine = false;
-				}
-				else
-				{
-					curOffset.X += spriteFont.Spacing + cKern.X;
-				}
-
-				// Calculate the character origin
-				Rectangle cCrop = croppingData[index];
-				Rectangle cGlyph = glyphData[index];
-				float offsetX = baseOffset.X + (
-					curOffset.X + cCrop.X
-				) * axisDirX;
-				float offsetY = baseOffset.Y + (
-					curOffset.Y + cCrop.Y
-				) * axisDirY;
-				if (effects != SpriteEffects.None)
-				{
-					offsetX += cGlyph.Width * axisDirMirrorX;
-					offsetY += cGlyph.Height * axisDirMirrorY;
-				}
-
-				// Draw!
-				float sourceW = Math.Sign(cGlyph.Width) * Math.Max(
-					Math.Abs(cGlyph.Width),
-					MathHelper.MachineEpsilonFloat
-				) / (float) textureValue.Width;
-				float sourceH = Math.Sign(cGlyph.Height) * Math.Max(
-					Math.Abs(cGlyph.Height),
-					MathHelper.MachineEpsilonFloat
-				) / (float) textureValue.Height;
-				PushSprite(
-					textureValue,
-					cGlyph.X / (float) textureValue.Width,
-					cGlyph.Y / (float) textureValue.Height,
-					sourceW,
-					sourceH,
-					position.X,
-					position.Y,
-					cGlyph.Width * scale.X,
-					cGlyph.Height * scale.Y,
-					color,
-					offsetX / sourceW / (float) textureValue.Width,
-					offsetY / sourceH / (float) textureValue.Height,
-					(float) Math.Sin(rotation),
-					(float) Math.Cos(rotation),
-					layerDepth,
-					(int) effects
-				);
-
-				/* Add the character width and right-side
-				 * bearing to the line width.
-				 */
-				curOffset.X += cKern.Y + cKern.Z;
-			}
-		}
-
-		#endregion
-
-		#region Private Methods
 
 		private unsafe void PushSprite(
 			Texture2D texture,

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -123,7 +123,9 @@ namespace Microsoft.Xna.Framework.Graphics
 		#endregion
 
 		#region Internal MeasureString Method
-		internal Vector2 MeasureString(ref IReadOnlyCharList text) {
+
+		internal Vector2 MeasureString(ref IReadOnlyCharList text)
+		{
 			// FIXME: change argument to `(in IReadOnlyCharList text)`. that only allow above C# 7.2
 			if (text.Length == 0)
 			{
@@ -209,6 +211,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			return result;
 		}
+
 		#endregion
 
 		#region Public MeasureString Methods

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -122,112 +122,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region Public MeasureString Methods
-
-		public Vector2 MeasureString(string text)
-		{
-			/* FIXME: This method is a duplicate of MeasureString(StringBuilder)!
-			 * The only difference is how we iterate through the string.
-			 * -flibit
-			 */
-			if (text == null)
-			{
-				throw new ArgumentNullException("text");
-			}
-			if (text.Length == 0)
-			{
-				return Vector2.Zero;
-			}
-
-			// FIXME: This needs an accuracy check! -flibit
-
-			Vector2 result = Vector2.Zero;
-			float curLineWidth = 0.0f;
-			float finalLineHeight = LineSpacing;
-			bool firstInLine = true;
-
-			foreach (char c in text)
-			{
-				// Special characters
-				if (c == '\r')
-				{
-					continue;
-				}
-				if (c == '\n')
-				{
-					result.X = Math.Max(result.X, curLineWidth);
-					result.Y += LineSpacing;
-					curLineWidth = 0.0f;
-					finalLineHeight = LineSpacing;
-					firstInLine = true;
-					continue;
-				}
-
-				/* Get the List index from the character map, defaulting to the
-				 * DefaultCharacter if it's set.
-				 */
-				int index;
-				if (!characterIndexMap.TryGetValue(c, out index))
-				{
-					if (!DefaultCharacter.HasValue)
-					{
-						throw new ArgumentException(
-							"Text contains characters that cannot be" +
-							" resolved by this SpriteFont.",
-							"text"
-						);
-					}
-					index = characterIndexMap[DefaultCharacter.Value];
-				}
-
-				/* For the first character in a line, always push the width
-				 * rightward, even if the kerning pushes the character to the
-				 * left.
-				 */
-				Vector3 cKern = kerning[index];
-				if (firstInLine)
-				{
-					curLineWidth += Math.Abs(cKern.X);
-					firstInLine = false;
-				}
-				else
-				{
-					curLineWidth += Spacing + cKern.X;
-				}
-
-				/* Add the character width and right-side bearing to the line
-				 * width.
-				 */
-				curLineWidth += cKern.Y + cKern.Z;
-
-				/* If a character is taller than the default line height,
-				 * increase the height to that of the line's tallest character.
-				 */
-				int cCropHeight = croppingData[index].Height;
-				if (cCropHeight > finalLineHeight)
-				{
-					finalLineHeight = cCropHeight;
-				}
-			}
-
-			// Calculate the final width/height of the text box
-			result.X = Math.Max(result.X, curLineWidth);
-			result.Y += finalLineHeight;
-
-			return result;
-		}
-
-		public Vector2 MeasureString(StringBuilder text)
-		{
-			/* FIXME: This method is a duplicate of MeasureString(string)!
-			 * The only difference is how we iterate through the StringBuilder.
-			 * We don't use ToString() since it generates garbage.
-			 * -flibit
-			 */
-			if (text == null)
-			{
-				throw new ArgumentNullException("text");
-			}
+		#region Internal MeasureString Method
+		internal Vector2 MeasureString(ref IReadOnlyCharList text) {
+			// FIXME: change argument to `(in IReadOnlyCharList text)`. that only allow above C# 7.2
 			if (text.Length == 0)
 			{
 				return Vector2.Zero;
@@ -312,7 +209,82 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			return result;
 		}
+		#endregion
 
+		#region Public MeasureString Methods
+
+		public Vector2 MeasureString(string text)
+		{
+			if (text == null)
+			{
+				throw new ArgumentNullException("text");
+			}
+			IReadOnlyCharList view = new StringView(text);
+			return MeasureString(ref view);
+		}
+
+		public Vector2 MeasureString(StringBuilder text)
+		{
+			if (text == null)
+			{
+				throw new ArgumentNullException("text");
+			}
+			IReadOnlyCharList view = new StringBuilderView(text);
+			return MeasureString(ref view);
+		}
+
+		#endregion
+
+		#region Internal IReadOnlyCharList Structs
+		internal interface IReadOnlyCharList
+		{
+			int Length { get; }
+			char this[int index] { get; }
+		}
+		internal struct StringView : IReadOnlyCharList
+		{
+			private readonly string view;
+			internal StringView(string view)
+			{
+				this.view = view;
+			}
+			public int Length
+			{
+				get
+				{
+					return view.Length;
+				}
+			}
+			public char this[int index]
+			{
+				get
+				{
+					return view[index];
+				}
+			}
+		}
+		internal struct StringBuilderView : IReadOnlyCharList
+		{
+			private readonly StringBuilder view;
+			internal StringBuilderView(StringBuilder view)
+			{
+				this.view = view;
+			}
+			public int Length
+			{
+				get
+				{
+					return view.Length;
+				}
+			}
+			public char this[int index]
+			{
+				get
+				{
+					return view[index];
+				}
+			}
+		}
 		#endregion
 	}
 }

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Internal MeasureString Method
 
-		internal Vector2 MeasureString<T>(ref T text) where T : IReadOnlyCharList
+		internal Vector2 MeasureString<T>(T text) where T : struct, IReadOnlyCharList
 		{
 			if (text.Length == 0)
 			{
@@ -221,8 +221,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			StringView view = new StringView(text);
-			return MeasureString(ref view);
+			return MeasureString(new StringView(text));
 		}
 
 		public Vector2 MeasureString(StringBuilder text)
@@ -231,8 +230,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			StringBuilderView view = new StringBuilderView(text);
-			return MeasureString(ref view);
+			return MeasureString(new StringBuilderView(text));
 		}
 
 		#endregion

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -124,9 +124,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Internal MeasureString Method
 
-		internal Vector2 MeasureString(ref IReadOnlyCharList text)
+		internal Vector2 MeasureString<T>(ref T text) where T : IReadOnlyCharList
 		{
-			// FIXME: change argument to `(in IReadOnlyCharList text)`. that only allow above C# 7.2
 			if (text.Length == 0)
 			{
 				return Vector2.Zero;
@@ -222,7 +221,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			IReadOnlyCharList view = new StringView(text);
+			StringView view = new StringView(text);
 			return MeasureString(ref view);
 		}
 
@@ -232,7 +231,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("text");
 			}
-			IReadOnlyCharList view = new StringBuilderView(text);
+			StringBuilderView view = new StringBuilderView(text);
 			return MeasureString(ref view);
 		}
 

--- a/src/Graphics/SpriteFont.cs
+++ b/src/Graphics/SpriteFont.cs
@@ -126,108 +126,28 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public Vector2 MeasureString(string text)
 		{
-			/* FIXME: This method is a duplicate of MeasureString(StringBuilder)!
-			 * The only difference is how we iterate through the string.
-			 * -flibit
-			 */
 			if (ReferenceEquals(text, null))
 			{
 				throw new ArgumentNullException("text");
 			}
-			if (text.Length == 0)
-			{
-				return Vector2.Zero;
-			}
-
-			// FIXME: This needs an accuracy check! -flibit
-
-			Vector2 result = Vector2.Zero;
-			float curLineWidth = 0.0f;
-			float finalLineHeight = LineSpacing;
-			bool firstInLine = true;
-
-			foreach (char c in text)
-			{
-				// Special characters
-				if (c == '\r')
-				{
-					continue;
-				}
-				if (c == '\n')
-				{
-					result.X = Math.Max(result.X, curLineWidth);
-					result.Y += LineSpacing;
-					curLineWidth = 0.0f;
-					finalLineHeight = LineSpacing;
-					firstInLine = true;
-					continue;
-				}
-
-				/* Get the List index from the character map, defaulting to the
-				 * DefaultCharacter if it's set.
-				 */
-				int index;
-				if (!characterIndexMap.TryGetValue(c, out index))
-				{
-					if (!DefaultCharacter.HasValue)
-					{
-						throw new ArgumentException(
-							"Text contains characters that cannot be" +
-							" resolved by this SpriteFont.",
-							"text"
-						);
-					}
-					index = characterIndexMap[DefaultCharacter.Value];
-				}
-
-				/* For the first character in a line, always push the width
-				 * rightward, even if the kerning pushes the character to the
-				 * left.
-				 */
-				Vector3 cKern = kerning[index];
-				if (firstInLine)
-				{
-					curLineWidth += Math.Abs(cKern.X);
-					firstInLine = false;
-				}
-				else
-				{
-					curLineWidth += Spacing + cKern.X;
-				}
-
-				/* Add the character width and right-side bearing to the line
-				 * width.
-				 */
-				curLineWidth += cKern.Y + cKern.Z;
-
-				/* If a character is taller than the default line height,
-				 * increase the height to that of the line's tallest character.
-				 */
-				int cCropHeight = croppingData[index].Height;
-				if (cCropHeight > finalLineHeight)
-				{
-					finalLineHeight = cCropHeight;
-				}
-			}
-
-			// Calculate the final width/height of the text box
-			result.X = Math.Max(result.X, curLineWidth);
-			result.Y += finalLineHeight;
-
-			return result;
+			return MeasureString(new StringView(text));
 		}
 
 		public Vector2 MeasureString(StringBuilder text)
 		{
-			/* FIXME: This method is a duplicate of MeasureString(string)!
-			 * The only difference is how we iterate through the StringBuilder.
-			 * We don't use ToString() since it generates garbage.
-			 * -flibit
-			 */
 			if (text == null)
 			{
 				throw new ArgumentNullException("text");
 			}
+			return MeasureString(new StringBuilderView(text));
+		}
+
+		#endregion
+
+		#region Internal MeasureString Method
+
+		internal Vector2 MeasureString<T>(T text) where T : struct, IReadOnlyCharList
+		{
 			if (text.Length == 0)
 			{
 				return Vector2.Zero;
@@ -311,6 +231,50 @@ namespace Microsoft.Xna.Framework.Graphics
 			result.Y += finalLineHeight;
 
 			return result;
+		}
+
+		#endregion
+
+		#region Internal IReadOnlyCharList Structs
+
+		internal interface IReadOnlyCharList
+		{
+			int Length { get; }
+			char this[int index] { get; }
+		}
+
+		internal struct StringView : IReadOnlyCharList
+		{
+			private readonly string view;
+			internal StringView(string view)
+			{
+				this.view = view;
+			}
+			public int Length
+			{
+				get { return view.Length; }
+			}
+			public char this[int index]
+			{
+				get { return view[index]; }
+			}
+		}
+
+		internal struct StringBuilderView : IReadOnlyCharList
+		{
+			private readonly StringBuilder view;
+			internal StringBuilderView(StringBuilder view)
+			{
+				this.view = view;
+			}
+			public int Length
+			{
+				get { return view.Length; }
+			}
+			public char this[int index]
+			{
+				get { return view[index]; }
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Try to unify string class and StringBuilder class.

Core code:
```C#
		internal interface IReadOnlyCharList
		{
			int Length { get; }
			char this[int index] { get; }
		}
		internal struct StringView : IReadOnlyCharList
		{
			private readonly string view;
			internal StringView(string view)
			{
				this.view = view;
			}
			public int Length
			{
				get
				{
					return view.Length;
				}
			}
			public char this[int index]
			{
				get
				{
					return view[index];
				}
			}
		}
		internal struct StringBuilderView : IReadOnlyCharList
		{
			private readonly StringBuilder view;
			internal StringBuilderView(StringBuilder view)
			{
				this.view = view;
			}
			public int Length
			{
				get
				{
					return view.Length;
				}
			}
			public char this[int index]
			{
				get
				{
					return view[index];
				}
			}
		}
```