### PR TITLE
Simplify object initialization

### DIFF
--- a/src/Content/ContentManager.cs
+++ b/src/Content/ContentManager.cs
@@ -363,9 +363,7 @@ namespace Microsoft.Xna.Framework.Content
 				{
 					byte[] data = new byte[stream.Length];
 					stream.Read(data, 0, (int) stream.Length);
-					Effect effect = new Effect(GetGraphicsDevice(), data);
-					effect.Name = assetName;
-					result = effect;
+					result = new Effect(GetGraphicsDevice(), data) { Name = assetName };
 				}
 				else if (typeof(T) == typeof(Song))
 				{

--- a/src/Content/ContentSerializerAttribute.cs
+++ b/src/Content/ContentSerializerAttribute.cs
@@ -104,14 +104,14 @@ namespace Microsoft.Xna.Framework.Content
 
 		public ContentSerializerAttribute Clone()
 		{
-			ContentSerializerAttribute clone = new ContentSerializerAttribute();
-			clone.AllowNull = AllowNull;
-			clone.collectionItemName = collectionItemName;
-			clone.ElementName = ElementName;
-			clone.FlattenContent = FlattenContent;
-			clone.Optional = Optional;
-			clone.SharedResource = SharedResource;
-			return clone;
+			return new ContentSerializerAttribute() {
+				AllowNull = AllowNull,
+				collectionItemName = collectionItemName,
+				ElementName = ElementName,
+				FlattenContent = FlattenContent,
+				Optional = Optional,
+				SharedResource = SharedResource
+			};
 		}
 
 		#endregion

--- a/src/Curve.cs
+++ b/src/Curve.cs
@@ -94,10 +94,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>A copy of this curve.</returns>
 		public Curve Clone()
 		{
-			Curve curve = new Curve(Keys.Clone());
-			curve.PreLoop = PreLoop;
-			curve.PostLoop = PostLoop;
-			return curve;
+			return new Curve(Keys.Clone()) { PreLoop = PreLoop, PostLoop = PostLoop };
 		}
 
 		/// <summary>

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -859,13 +859,11 @@ namespace Microsoft.Xna.Framework
 
 		public static void SetTextInputRectangle(IntPtr window, Rectangle rectangle)
 		{
-			SDL.SDL_Rect rect = new SDL.SDL_Rect
-			{
-				x = rectangle.X,
-				y = rectangle.Y,
-				w = rectangle.Width,
-				h = rectangle.Height
-			};
+			SDL.SDL_Rect rect;
+			rect.x = rectangle.X;
+			rect.y = rectangle.Y;
+			rect.w = rectangle.Width;
+			rect.h = rectangle.Height;
 			SDL.SDL_SetTextInputRect(ref rect);
 		}
 
@@ -2137,7 +2135,8 @@ namespace Microsoft.Xna.Framework
 			INTERNAL_instanceList.Add(thisInstance, which);
 
 			// Start with a fresh state.
-			INTERNAL_states[which] = new GamePadState { IsConnected = true };
+			INTERNAL_states[which] = new GamePadState();
+			INTERNAL_states[which].IsConnected = true;
 
 			// Initialize the haptics for the joystick, if applicable.
 			bool hasRumble = SDL.SDL_GameControllerRumble(

--- a/src/FNAPlatform/SDL3_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL3_FNAPlatform.cs
@@ -769,13 +769,11 @@ namespace Microsoft.Xna.Framework
 
 		public static void SetTextInputRectangle(IntPtr window, Rectangle rectangle)
 		{
-			SDL.SDL_Rect rect = new SDL.SDL_Rect
-			{
-				x = rectangle.X,
-				y = rectangle.Y,
-				w = rectangle.Width,
-				h = rectangle.Height
-			};
+			SDL.SDL_Rect rect;
+			rect.x = rectangle.X;
+			rect.y = rectangle.Y;
+			rect.w = rectangle.Width;
+			rect.h = rectangle.Height;
 			// FIXME SDL3: Do we need a cursor here?
 			SDL.SDL_SetTextInputArea(WrapWindow(window), ref rect, 0);
 		}
@@ -1700,12 +1698,10 @@ namespace Microsoft.Xna.Framework
 			Microphone[] result = new Microphone[numDev + 1];
 
 			// Default input format
-			SDL.SDL_AudioSpec want = new SDL.SDL_AudioSpec
-			{
-				freq = Microphone.SAMPLERATE,
-				format = SDL.SDL_AudioFormat.SDL_AUDIO_S16,
-				channels = 1
-			};
+			SDL.SDL_AudioSpec want;
+			want.freq = Microphone.SAMPLERATE;
+			want.format = SDL.SDL_AudioFormat.SDL_AUDIO_S16;
+			want.channels = 1;
 
 			// First mic is always OS default
 			result[0] = new Microphone(
@@ -2113,7 +2109,8 @@ namespace Microsoft.Xna.Framework
 			INTERNAL_instanceList.Add(thisInstance, which);
 
 			// Start with a fresh state.
-			INTERNAL_states[which] = new GamePadState { IsConnected = true };
+			INTERNAL_states[which] = new GamePadState();
+			INTERNAL_states[which].IsConnected = true;
 
 			// Initialize the haptics for the joystick, if applicable.
 			bool hasRumble = SDL.SDL_RumbleGamepad(

--- a/src/Graphics/PresentationParameters.cs
+++ b/src/Graphics/PresentationParameters.cs
@@ -176,18 +176,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public PresentationParameters Clone()
 		{
-			PresentationParameters clone = new PresentationParameters();
-			clone.BackBufferFormat = BackBufferFormat;
-			clone.BackBufferHeight = BackBufferHeight;
-			clone.BackBufferWidth = BackBufferWidth;
-			clone.DeviceWindowHandle = DeviceWindowHandle;
-			clone.IsFullScreen = IsFullScreen;
-			clone.DepthStencilFormat = DepthStencilFormat;
-			clone.MultiSampleCount = MultiSampleCount;
-			clone.PresentationInterval = PresentationInterval;
-			clone.DisplayOrientation = DisplayOrientation;
-			clone.RenderTargetUsage = RenderTargetUsage;
-			return clone;
+			return new PresentationParameters() {
+				BackBufferFormat = BackBufferFormat,
+				BackBufferHeight = BackBufferHeight,
+				BackBufferWidth = BackBufferWidth,
+				DeviceWindowHandle = DeviceWindowHandle,
+				IsFullScreen = IsFullScreen,
+				DepthStencilFormat = DepthStencilFormat,
+				MultiSampleCount = MultiSampleCount,
+				PresentationInterval = PresentationInterval,
+				DisplayOrientation = DisplayOrientation,
+				RenderTargetUsage = RenderTargetUsage
+			};
 		}
 
 		#endregion


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

revert #608

Object Initializer operator is good for class, but bad for struct.

Please don't use the operator for Collection element like Array, Directory.

Do not use the operator on structs unless you know what you are doing.

especial for ref struct argument and arguemnt with virtual method, don't use the operator.

Note: Object Initializer operator is no better performance. Only simplify code.


What happen? Object Initializer operator Implicit generate a temporary local struct variable in some cases.
```C#
var s = struct() { X=1, Y=2 };
```
Above code will translate to below code in some cases.
```C#
var temp = struct();
temp.X = 1;
temp.Y = 2;
var s = temp;
```