### PR TITLE
Microphone default pause

### DIFF
--- a/src/Audio/Microphone.cs
+++ b/src/Audio/Microphone.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Framework.Audio
 					value.Milliseconds > 1000 ||
 					value.Milliseconds % 10 != 0	)
 				{
-					throw new ArgumentOutOfRangeException();
+					throw new ArgumentOutOfRangeException("value");
 				}
 				bufferDuration = value;
 			}

--- a/src/FNAPlatform/SDL3_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL3_FNAPlatform.cs
@@ -1721,6 +1721,7 @@ namespace Microsoft.Xna.Framework
 					audioDeviceID = SDL.SDL_OpenAudioDevice(devices[i], ref want);
 					name = SDL.SDL_GetAudioDeviceName(audioDeviceID);
 				}
+				SDL.SDL_AudioDevicePaused(audioDeviceID);
 				result[i + 1] = new Microphone(audioDeviceID, name);
 
 				IntPtr stream;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

>Unlike in SDL2, audio devices start in an _unpaused_ state, since an app
has to bind a stream before any audio will flow. Pausing a paused device is
a legal no-op.