### PR TITLE
Fix HalfTypeHelper for Infinity and NaN

### DIFF
--- a/src/Graphics/PackedVector/HalfTypeHelper.cs
+++ b/src/Graphics/PackedVector/HalfTypeHelper.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			uint mantissa = (uint)(value & 1023);
 			uint exp = 0xfffffff2;
 
-			if ((value & -33792) == 0)
+			if ((value & 0x7C00) == 0)
 			{
 				if (mantissa != 0)
 				{

--- a/src/Graphics/PackedVector/HalfTypeHelper.cs
+++ b/src/Graphics/PackedVector/HalfTypeHelper.cs
@@ -16,32 +16,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
 	internal static class HalfTypeHelper
 	{
-		#region Private Struct uif
-
-		[StructLayout(LayoutKind.Explicit)]
-		private struct uif
-		{
-			[FieldOffset(0)]
-			public float f;
-			[FieldOffset(0)]
-			public int i;
-			[FieldOffset(0)]
-			public uint u;
-		}
-
-		#endregion
-
 		#region Internal Static Methods
 
-		internal static ushort Convert(float f)
+		internal static unsafe ushort Convert(float f)
 		{
-			uif uif = new uif();
-			uif.f = f;
-			return Convert(uif.i);
-		}
-
-		internal static ushort Convert(int i)
-		{
+			int i = *(int*) &f;
 			int s = (i >> 16) & 0x00008000;
 			int e = ((i >> 23) & 0x000000ff) - (127 - 15);
 			int m = i & 0x007fffff;
@@ -63,17 +42,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 				return (ushort) (s | m);
 			}
-			else if (e == 0xff - (127 - 15))
+			else if (e > 31)
 			{
-				if (m == 0)
-				{
-					return (ushort) (s | 0x7c00);
-				}
-				else
-				{
-					m >>= 13;
-					return (ushort) (s | 0x7c00 | m | ((m == 0) ? 1 : 0));
-				}
+				return (ushort) (s | 0x7FFF);
 			}
 			else
 			{
@@ -85,16 +56,16 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 					e += 1;
 				}
 
-				if (e > 30)
+				if (e > 31)
 				{
-					return (ushort) (s | 0x7c00);
+					return (ushort) (s | 0x7FFF);
 				}
 
 				return (ushort) (s | (e << 10) | (m >> 13));
 			}
 		}
 
-		internal static float Convert(ushort value)
+		internal static unsafe float Convert(ushort value)
 		{
 			uint rst;
 			uint mantissa = (uint)(value & 1023);
@@ -122,9 +93,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 				rst = (uint) (((((uint) value & 0x8000) << 16) | ((((((uint) value >> 10) & 0x1f) - 15) + 127) << 23)) | (mantissa << 13));
 			}
 
-			uif uif = new uif();
-			uif.u = rst;
-			return uif.f;
+			return *(float*) &rst;
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/HalfTypeHelper.cs
+++ b/src/Graphics/PackedVector/HalfTypeHelper.cs
@@ -27,20 +27,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 			if (e <= 0)
 			{
-				if (e < -10)
-				{
-					return (ushort) s;
-				}
+				m = (m | 0x00800000) >> (1 - e);
 
-				m = m | 0x00800000;
+				m = m + 0x00000FFF + ((m >> 13) & 1);
 
-				int t = 14 - e;
-				int a = (1 << (t - 1)) - 1;
-				int b = (m >> t) & 1;
-
-				m = (m + a + b) >> t;
-
-				return (ushort) (s | m);
+				return (ushort) (s | (m >> 13));
 			}
 			else if (e > 31)
 			{
@@ -69,7 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		{
 			uint rst;
 			uint mantissa = (uint)(value & 1023);
-			uint exp = 0xfffffff2;
+			uint exp = 0xfffffff2; // -14
 
 			if ((value & 0x7C00) == 0)
 			{


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

The same behavior as XNA.

Test case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics.PackedVector;
using System;

namespace ConsoleApp4
{
    internal class testfile
    {
        [STAThread]
        private static unsafe void Main4(string[] args)
        {
            //uint m = 1;
            //short e = 17;
            //uint sign = 0;
            //uint fi = (uint)(sign << 31 ^ e + 127 << 23 ^ m);
            //float f1 = *(float*)&fi;

            float f1 = float.PositiveInfinity;

            uint i1 = *(uint*)&f1;
            HalfSingle half = new HalfSingle(f1);

            float f2 = half.ToSingle();
            uint i2 = *(uint*)&f2;

            Console.Error.WriteLine("32bit:" + i1.ToString("X") + ",16bit:" + half.PackedValue.ToString("X") + ",re 32bit:" + i2.ToString("X"));
        }
}
```