### PR TITLE
Fix recursion in CurveKey Equals

### DIFF
--- a/src/CurveKey.cs
+++ b/src/CurveKey.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Xna.Framework
 
 		public bool Equals(CurveKey other)
 		{
-			return !(other is null) &&
+			return ReferenceEquals(other, null) &&
 				other.Position == Position &&
 				other.Value == Value &&
 				other.TangentIn == TangentIn &&
@@ -191,9 +191,9 @@ namespace Microsoft.Xna.Framework
 		/// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
 		public static bool operator ==(CurveKey a, CurveKey b)
 		{
-			if (a is null)
+			if (ReferenceEquals（a, null))
 			{
-				return b is null;
+				return ReferenceEquals（b, null);
 			}
 			return a.Equals(b);
 		}

--- a/src/CurveKey.cs
+++ b/src/CurveKey.cs
@@ -191,9 +191,9 @@ namespace Microsoft.Xna.Framework
 		/// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
 		public static bool operator ==(CurveKey a, CurveKey b)
 		{
-			if (ReferenceEquals（a, null))
+			if (ReferenceEquals(a, null))
 			{
-				return ReferenceEquals（b, null);
+				return ReferenceEquals(b, null);
 			}
 			return a.Equals(b);
 		}

--- a/src/CurveKey.cs
+++ b/src/CurveKey.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Xna.Framework
 
 		public bool Equals(CurveKey other)
 		{
-			return ReferenceEquals(other, null) &&
+			return !ReferenceEquals(other, null) &&
 				other.Position == Position &&
 				other.Value == Value &&
 				other.TangentIn == TangentIn &&

--- a/src/CurveKey.cs
+++ b/src/CurveKey.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Xna.Framework
 
 		public bool Equals(CurveKey other)
 		{
-			return other != null &&
+			return !(other is null) &&
 				other.Position == Position &&
 				other.Value == Value &&
 				other.TangentIn == TangentIn &&
@@ -191,9 +191,9 @@ namespace Microsoft.Xna.Framework
 		/// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
 		public static bool operator ==(CurveKey a, CurveKey b)
 		{
-			if (a == null)
+			if (a is null)
 			{
-				return b == null;
+				return b is null;
 			}
 			return a.Equals(b);
 		}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Fix #621 

call obj == null in operator == cause recursion