### PR TITLE
Fix 10a1472

### DIFF
--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Xna.Framework.Audio
 			private set;
 		}
 
-		private string name;
 		public string Name
 		{
 			get { return name; }
@@ -150,6 +149,12 @@ namespace Microsoft.Xna.Framework.Audio
 		internal uint sampleRate;
 		internal uint loopStart;
 		internal uint loopLength;
+
+		#endregion
+
+		#region Private Variables
+
+		private string name;
 
 		#endregion
 

--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Xna.Framework.Audio
 			private set;
 		}
 
+		private string name;
 		public string Name
 		{
 			get { return name; }
@@ -152,12 +153,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 		#endregion
 
-		#region Private Variables
-
-		private string name;
-
-		#endregion
-
 		#region Public Constructors
 
 		public SoundEffect(
@@ -165,7 +160,7 @@ namespace Microsoft.Xna.Framework.Audio
 			int sampleRate,
 			AudioChannels channels
 		) : this(
-			null,
+			string.Empty,
 			buffer,
 			0,
 			buffer.Length,
@@ -190,7 +185,7 @@ namespace Microsoft.Xna.Framework.Audio
 			int loopStart,
 			int loopLength
 		) : this(
-			null,
+			string.Empty,
 			buffer,
 			offset,
 			count,


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

https://github.com/FNA-XNA/FNA/commit/10a14723f92fb65bae9cb4924b2a5507e97a25a9

The default Name for SoundEffect is string.Empty in XNA.