### PR TITLE
Add argument check for public SoundEffect ctor.

### DIFF
--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -229,75 +229,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 		internal SoundEffect() { }
 
-		internal unsafe SoundEffect FromBuffer(
-			string name,
-			IntPtr formatPtr,
-			byte[] data,
-			int offset,
-			int count,
-			int loopStart,
-			int loopLength
-		) {
-			FAudio.FAudio_AddRef(Device().Handle);
-
-			FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) formatPtr;
-			this.name = name;
-			channels = wfx->nChannels;
-			sampleRate = wfx->nSamplesPerSec;
-			this.loopStart = (uint) loopStart;
-			this.loopLength = (uint) loopLength;
-
-			/* Buffer format */
-			this.formatPtr = formatPtr;
-
-			/* Easy stuff */
-			handle = new FAudio.FAudioBuffer();
-			handle.Flags = FAudio.FAUDIO_END_OF_STREAM;
-			handle.pContext = IntPtr.Zero;
-
-			/* Buffer data */
-			handle.AudioBytes = (uint) count;
-			handle.pAudioData = FNAPlatform.Malloc(count);
-			Marshal.Copy(
-				data,
-				offset,
-				handle.pAudioData,
-				count
-			);
-
-			/* Play regions */
-			handle.PlayBegin = 0;
-			if (wfx->wFormatTag == 1)
-			{
-				handle.PlayLength = (uint) (
-					count /
-					wfx->nChannels /
-					(wfx->wBitsPerSample / 8)
-				);
-			}
-			else if (wfx->wFormatTag == 2)
-			{
-				handle.PlayLength = (uint) (
-					count /
-					wfx->nBlockAlign *
-					(((wfx->nBlockAlign / wfx->nChannels) - 6) * 2)
-				);
-			}
-			else if (wfx->wFormatTag == 0x166)
-			{
-				FAudio.FAudioXMA2WaveFormatEx* xma2 = (FAudio.FAudioXMA2WaveFormatEx*) formatPtr;
-				// dwSamplesEncoded / nChannels / (wBitsPerSample / 8) doesn't always (if ever?) match up.
-				handle.PlayLength = xma2->dwPlayLength;
-			}
-
-			/* Set by Instances! */
-			handle.LoopBegin = 0;
-			handle.LoopLength = 0;
-			handle.LoopCount = 0;
-
-			return this;
-		}
-
 		#endregion
 
 		#region Destructor
@@ -547,6 +478,79 @@ namespace Microsoft.Xna.Framework.Audio
 				samplerLoopStart,
 				samplerLoopEnd - samplerLoopStart
 			);
+		}
+
+		#endregion
+
+		#region Internal Methods
+
+		internal unsafe SoundEffect FromBuffer(
+			string name,
+			IntPtr formatPtr,
+			byte[] data,
+			int offset,
+			int count,
+			int loopStart,
+			int loopLength
+		) {
+			FAudio.FAudio_AddRef(Device().Handle);
+
+			FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) formatPtr;
+			this.name = name;
+			channels = wfx->nChannels;
+			sampleRate = wfx->nSamplesPerSec;
+			this.loopStart = (uint) loopStart;
+			this.loopLength = (uint) loopLength;
+
+			/* Buffer format */
+			this.formatPtr = formatPtr;
+
+			/* Easy stuff */
+			handle = new FAudio.FAudioBuffer();
+			handle.Flags = FAudio.FAUDIO_END_OF_STREAM;
+			handle.pContext = IntPtr.Zero;
+
+			/* Buffer data */
+			handle.AudioBytes = (uint) count;
+			handle.pAudioData = FNAPlatform.Malloc(count);
+			Marshal.Copy(
+				data,
+				offset,
+				handle.pAudioData,
+				count
+			);
+
+			/* Play regions */
+			handle.PlayBegin = 0;
+			if (wfx->wFormatTag == 1)
+			{
+				handle.PlayLength = (uint) (
+					count /
+					wfx->nChannels /
+					(wfx->wBitsPerSample / 8)
+				);
+			}
+			else if (wfx->wFormatTag == 2)
+			{
+				handle.PlayLength = (uint) (
+					count /
+					wfx->nBlockAlign *
+					(((wfx->nBlockAlign / wfx->nChannels) - 6) * 2)
+				);
+			}
+			else if (wfx->wFormatTag == 0x166)
+			{
+				FAudio.FAudioXMA2WaveFormatEx* xma2 = (FAudio.FAudioXMA2WaveFormatEx*) formatPtr;
+				// dwSamplesEncoded / nChannels / (wBitsPerSample / 8) doesn't always (if ever?) match up.
+				handle.PlayLength = xma2->dwPlayLength;
+			}
+
+			/* Set by Instances! */
+			handle.LoopBegin = 0;
+			handle.LoopLength = 0;
+			handle.LoopCount = 0;
+
+			return this;
 		}
 
 		#endregion

--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -165,23 +165,17 @@ namespace Microsoft.Xna.Framework.Audio
 			int sampleRate,
 			AudioChannels channels
 		) : this(
-			string.Empty,
 			buffer,
 			0,
-			buffer.Length,
-			null,
-			1,
-			(ushort) channels,
-			(uint) sampleRate,
-			(uint) (sampleRate * ((ushort) channels * 2)),
-			(ushort) ((ushort) channels * 2),
-			16,
+			buffer == null ? 0 : buffer.Length,
+			sampleRate,
+			channels,
 			0,
 			0
 		) {
 		}
 
-		public SoundEffect(
+		public unsafe SoundEffect(
 			byte[] buffer,
 			int offset,
 			int count,
@@ -189,79 +183,72 @@ namespace Microsoft.Xna.Framework.Audio
 			AudioChannels channels,
 			int loopStart,
 			int loopLength
-		) : this(
-			string.Empty,
-			buffer,
-			offset,
-			count,
-			null,
-			1,
-			(ushort) channels,
-			(uint) sampleRate,
-			(uint) (sampleRate * ((ushort) channels * 2)),
-			(ushort) ((ushort) channels * 2),
-			16,
-			loopStart,
-			loopLength
 		) {
+			if (sampleRate < FAudio.FAUDIO_MIN_SAMPLE_RATE || sampleRate > FAudio.FAUDIO_MAX_SAMPLE_RATE) // XNA: sampleRate < 8000 || sampleRate > 48000
+			{
+				throw new ArgumentOutOfRangeException("sampleRate");
+			}
+			if (channels != AudioChannels.Mono && channels != AudioChannels.Stereo)
+			{
+				throw new ArgumentOutOfRangeException("channels");
+			}
+			int blockAlign = (int) channels * 2 /* SDL_AUDIO_BYTESIZE(SDL_AUDIO_S16) */;
+			if (buffer == null || buffer.Length == 0 || buffer.Length % blockAlign != 0)
+			{
+				throw new ArgumentException("Ensure that the buffer length is non-zero and meets the block alignment requirements for the audio format.");
+			}
+			if (unchecked((uint) offset >= (uint) buffer.Length) || offset % blockAlign != 0)
+			{
+				throw new ArgumentException("Offset must be within the buffer boundaries and meet the block alignment requirements for the audio format.");
+			}
+			if (count <= 0 || unchecked((uint) (offset + count) > (uint) buffer.Length) || count % blockAlign != 0)
+			{
+				throw new ArgumentException("Ensure that count is valid and meets the block alignment requirements for the audio format. Offset and count must define a valid region within the buffer boundaries.");
+			}
+			if (loopStart < 0 || loopLength < 0 || unchecked((uint) (loopStart + loopLength) > (uint) (count / blockAlign)))
+			{
+				throw new ArgumentException("Ensure that the loop region is defined in samples and within the buffer boundaries.");
+			}
+			IntPtr formatPtr = FNAPlatform.Malloc(sizeof(FAudio.FAudioWaveFormatEx));
+			FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) formatPtr;
+
+			wfx->wFormatTag = 1;
+			wfx->nChannels = (ushort) channels;
+			wfx->nSamplesPerSec = (uint) sampleRate;
+			wfx->nAvgBytesPerSec = (uint) (blockAlign * sampleRate);
+			wfx->nBlockAlign = (ushort) blockAlign;
+			wfx->wBitsPerSample = 16;
+			wfx->cbSize = 0;
+
+			FromBuffer(string.Empty, formatPtr, buffer, offset, count, loopStart, loopLength);
 		}
 
 		#endregion
 
 		#region Internal Constructor
 
-		internal unsafe SoundEffect(
+		internal SoundEffect() { }
+
+		internal unsafe SoundEffect FromBuffer(
 			string name,
-			byte[] buffer,
+			IntPtr formatPtr,
+			byte[] data,
 			int offset,
 			int count,
-			byte[] extraData,
-			ushort wFormatTag,
-			ushort nChannels,
-			uint nSamplesPerSec,
-			uint nAvgBytesPerSec,
-			ushort nBlockAlign,
-			ushort wBitsPerSample,
 			int loopStart,
 			int loopLength
 		) {
 			FAudio.FAudio_AddRef(Device().Handle);
 
+			FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) formatPtr;
 			this.name = name;
-			channels = nChannels;
-			sampleRate = nSamplesPerSec;
+			channels = wfx->nChannels;
+			sampleRate = wfx->nSamplesPerSec;
 			this.loopStart = (uint) loopStart;
 			this.loopLength = (uint) loopLength;
 
 			/* Buffer format */
-			if (extraData == null)
-			{
-				formatPtr = FNAPlatform.Malloc(
-					MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>()
-				);
-			}
-			else
-			{
-				formatPtr = FNAPlatform.Malloc(
-					MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>() +
-					extraData.Length
-				);
-				Marshal.Copy(
-					extraData,
-					0,
-					formatPtr + MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>(),
-					extraData.Length
-				);
-			}
-
-			FAudio.FAudioWaveFormatEx* pcm = (FAudio.FAudioWaveFormatEx*) formatPtr;
-			pcm->wFormatTag = wFormatTag;
-			pcm->nChannels = nChannels;
-			pcm->nSamplesPerSec = nSamplesPerSec;
-			pcm->nAvgBytesPerSec = nAvgBytesPerSec;
-			pcm->nBlockAlign = nBlockAlign;
-			pcm->wBitsPerSample = wBitsPerSample;
-			pcm->cbSize = (ushort) ((extraData == null) ? 0 : extraData.Length);
+			this.formatPtr = formatPtr;
 
 			/* Easy stuff */
 			handle = new FAudio.FAudioBuffer();
@@ -272,7 +259,7 @@ namespace Microsoft.Xna.Framework.Audio
 			handle.AudioBytes = (uint) count;
 			handle.pAudioData = FNAPlatform.Malloc(count);
 			Marshal.Copy(
-				buffer,
+				data,
 				offset,
 				handle.pAudioData,
 				count
@@ -280,23 +267,23 @@ namespace Microsoft.Xna.Framework.Audio
 
 			/* Play regions */
 			handle.PlayBegin = 0;
-			if (wFormatTag == 1)
+			if (wfx->wFormatTag == 1)
 			{
 				handle.PlayLength = (uint) (
 					count /
-					nChannels /
-					(wBitsPerSample / 8)
+					wfx->nChannels /
+					(wfx->wBitsPerSample / 8)
 				);
 			}
-			else if (wFormatTag == 2)
+			else if (wfx->wFormatTag == 2)
 			{
 				handle.PlayLength = (uint) (
 					count /
-					nBlockAlign *
-					(((nBlockAlign / nChannels) - 6) * 2)
+					wfx->nBlockAlign *
+					(((wfx->nBlockAlign / wfx->nChannels) - 6) * 2)
 				);
 			}
-			else if (wFormatTag == 0x166)
+			else if (wfx->wFormatTag == 0x166)
 			{
 				FAudio.FAudioXMA2WaveFormatEx* xma2 = (FAudio.FAudioXMA2WaveFormatEx*) formatPtr;
 				// dwSamplesEncoded / nChannels / (wBitsPerSample / 8) doesn't always (if ever?) match up.
@@ -307,6 +294,8 @@ namespace Microsoft.Xna.Framework.Audio
 			handle.LoopBegin = 0;
 			handle.LoopLength = 0;
 			handle.LoopCount = 0;
+
+			return this;
 		}
 
 		#endregion
@@ -443,13 +432,7 @@ namespace Microsoft.Xna.Framework.Audio
 			byte[] data;
 
 			// WaveFormatEx data
-			ushort wFormatTag;
-			ushort nChannels;
-			uint nSamplesPerSec;
-			uint nAvgBytesPerSec;
-			ushort nBlockAlign;
-			ushort wBitsPerSample;
-			// ushort cbSize;
+			byte[] formatBytes;
 
 			int samplerLoopStart = 0;
 			int samplerLoopEnd = 0;
@@ -479,20 +462,7 @@ namespace Microsoft.Xna.Framework.Audio
 					format_signature = new string(reader.ReadChars(4));
 				}
 
-				int format_chunk_size = reader.ReadInt32();
-
-				wFormatTag = reader.ReadUInt16();
-				nChannels = reader.ReadUInt16();
-				nSamplesPerSec = reader.ReadUInt32();
-				nAvgBytesPerSec = reader.ReadUInt32();
-				nBlockAlign = reader.ReadUInt16();
-				wBitsPerSample = reader.ReadUInt16();
-
-				// Reads residual bytes
-				if (format_chunk_size > 16)
-				{
-					reader.ReadBytes(format_chunk_size - 16);
-				}
+				formatBytes = reader.ReadBytes(reader.ReadInt32());
 
 				// data Signature
 				string data_signature = new string(reader.ReadChars(4));
@@ -565,18 +535,15 @@ namespace Microsoft.Xna.Framework.Audio
 				// End scan
 			}
 
-			return new SoundEffect(
+			IntPtr formatPtr = FNAPlatform.Malloc(formatBytes.Length);
+			Marshal.Copy(formatBytes, 0, formatPtr, formatBytes.Length);
+
+			return new SoundEffect().FromBuffer(
 				string.Empty,
+				formatPtr,
 				data,
 				0,
 				data.Length,
-				null,
-				wFormatTag,
-				nChannels,
-				nSamplesPerSec,
-				nAvgBytesPerSec,
-				nBlockAlign,
-				wBitsPerSample,
 				samplerLoopStart,
 				samplerLoopEnd - samplerLoopStart
 			);

--- a/src/Content/ContentReaders/SoundEffectReader.cs
+++ b/src/Content/ContentReaders/SoundEffectReader.cs
@@ -8,8 +8,8 @@
 #endregion
 
 #region Using Statements
-using System.IO;
-
+using System;
+using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Audio;
 #endregion
 
@@ -19,58 +19,44 @@ namespace Microsoft.Xna.Framework.Content
 	{
 		#region Protected Read Method
 
-		protected internal override SoundEffect Read(
+		protected internal override unsafe SoundEffect Read(
 			ContentReader input,
 			SoundEffect existingInstance
 		) {
+			// Format block
+			byte[] formatBytes = input.ReadBytes(input.ReadInt32());
+
 			/* Swap endian - this is one of the very few places requiring this!
 			 * Note: This only affects the fmt chunk that's glued into the file.
 			 */
-			bool se = input.platform == 'x';
-
-			// Format block length
-			uint formatLength = input.ReadUInt32();
-
-			// WaveFormatEx data
-			ushort wFormatTag = Swap(se, input.ReadUInt16());
-			ushort nChannels = Swap(se, input.ReadUInt16());
-			uint nSamplesPerSec = Swap(se, input.ReadUInt32());
-			uint nAvgBytesPerSec = Swap(se, input.ReadUInt32());
-			ushort nBlockAlign = Swap(se, input.ReadUInt16());
-			ushort wBitsPerSample = Swap(se, input.ReadUInt16());
-
-			byte[] extra = null;
-			if (formatLength > 16)
+			if (input.platform == 'x')
 			{
-				ushort cbSize = Swap(se, input.ReadUInt16());
-
-				if (wFormatTag == 0x166 && cbSize == 34)
+				fixed (byte* ptr = formatBytes)
 				{
-					// XMA2 has got some nice extra crap.
-					extra = new byte[34];
-					using (MemoryStream extraStream = new MemoryStream(extra))
-					using (BinaryWriter extraWriter = new BinaryWriter(extraStream))
+					FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) ptr;
+					wfx->wFormatTag = Swap(wfx->wFormatTag);
+					wfx->nChannels = Swap(wfx->nChannels);
+					wfx->nSamplesPerSec = Swap(wfx->nSamplesPerSec);
+					wfx->nAvgBytesPerSec = Swap(wfx->nAvgBytesPerSec);
+					wfx->nBlockAlign = Swap(wfx->nBlockAlign);
+					wfx->wBitsPerSample = Swap(wfx->wBitsPerSample);
+					if (formatBytes.Length > 16)
 					{
-						// See FAudio.FAudioXMA2WaveFormatEx for the layout.
-						extraWriter.Write(Swap(se, input.ReadUInt16()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(input.ReadByte());
-						extraWriter.Write(input.ReadByte());
-						extraWriter.Write(Swap(se, input.ReadUInt16()));
+						wfx->cbSize = Swap(wfx->cbSize);
+						if (wfx->wFormatTag == 0x166 && wfx->cbSize == 34)
+						{
+							FAudio.FAudioXMA2WaveFormatEx* xma2format = (FAudio.FAudioXMA2WaveFormatEx*) ptr;
+							xma2format->wNumStreams = Swap(xma2format->wNumStreams);
+							xma2format->dwChannelMask = Swap(xma2format->dwChannelMask);
+							xma2format->dwSamplesEncoded = Swap(xma2format->dwSamplesEncoded);
+							xma2format->dwBytesPerBlock = Swap(xma2format->dwBytesPerBlock);
+							xma2format->dwPlayBegin = Swap(xma2format->dwPlayBegin);
+							xma2format->dwPlayLength = Swap(xma2format->dwPlayLength);
+							xma2format->dwLoopBegin = Swap(xma2format->dwLoopBegin);
+							xma2format->dwLoopLength = Swap(xma2format->dwLoopLength);
+							xma2format->wBlockCount = Swap(xma2format->wBlockCount);
+						}
 					}
-					// Is there any crap that needs skipping? Eh whatever.
-					input.ReadBytes((int) (formatLength - 18 - 34));
-				}
-				else
-				{
-					// Seek past the rest of this crap (cannot seek though!)
-					input.ReadBytes((int) (formatLength - 18));
 				}
 			}
 
@@ -84,18 +70,15 @@ namespace Microsoft.Xna.Framework.Content
 			// Sound duration in milliseconds, unused
 			input.ReadUInt32();
 
-			return new SoundEffect(
+			IntPtr formatPtr = FNAPlatform.Malloc(formatBytes.Length);
+			Marshal.Copy(formatBytes, 0, formatPtr, formatBytes.Length);
+
+			return new SoundEffect().FromBuffer(
 				input.AssetName,
+				formatPtr,
 				data,
 				0,
 				data.Length,
-				extra,
-				wFormatTag,
-				nChannels,
-				nSamplesPerSec,
-				nAvgBytesPerSec,
-				nBlockAlign,
-				wBitsPerSample,
 				loopStart,
 				loopLength
 			);
@@ -105,17 +88,17 @@ namespace Microsoft.Xna.Framework.Content
 
 		#region Internal Static Swapping Methods
 
-		internal static ushort Swap(bool swap, ushort x)
+		internal static ushort Swap(ushort x)
 		{
-			return !swap ? x : (ushort) (
+			return (ushort) (
 				((x >> 8)	& 0x00FF) |
 				((x << 8)	& 0xFF00)
 			);
 		}
 
-		internal static uint Swap(bool swap, uint x)
+		internal static uint Swap(uint x)
 		{
-			return !swap ? x : (
+			return (
 				((x >> 24)	& 0x000000FF) |
 				((x >> 8)	& 0x0000FF00) |
 				((x << 8)	& 0x00FF0000) |
@@ -124,6 +107,5 @@ namespace Microsoft.Xna.Framework.Content
 		}
 
 		#endregion
-
 	}
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

For check buffer == null in ctor. don't use ctor chain. move code from ctor chain to FromBuffer.