### PR TITLE
IsHeadset=true

### DIFF
--- a/src/Audio/Microphone.cs
+++ b/src/Audio/Microphone.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (	value.TotalMilliseconds < 100.0 ||
-					value.TotalMilliseconds > 1000.0 ||
-					value.TotalMilliseconds % 10.0 != 0	)
+				if (	value.TotalMilliseconds < 100 ||
+					value.TotalMilliseconds > 1000 ||
+					value.TotalMilliseconds % 10 != 0	)
 				{
 					throw new ArgumentOutOfRangeException("value", "Microphone buffer duration must be between 100ms and 1sec and  10ms aligned.");
 				}

--- a/src/Audio/Microphone.cs
+++ b/src/Audio/Microphone.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (	value.TotalMilliseconds < 100 ||
-					value.TotalMilliseconds > 1000 ||
-					value.TotalMilliseconds % 10 != 0	)
+				if (	value.TotalMilliseconds < 100.0 ||
+					value.TotalMilliseconds > 1000.0 ||
+					value.TotalMilliseconds % 10.0 != 0	)
 				{
 					throw new ArgumentOutOfRangeException("value", "Microphone buffer duration must be between 100ms and 1sec and  10ms aligned.");
 				}
@@ -68,11 +68,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public bool IsHeadset
 		{
-			get
-			{
-				// FIXME: I think this is just for Windows Phone? -flibit
-				return false;
-			}
+			get { return true; }
 		}
 
 		public int SampleRate


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

IsHeadset is always true in XNA on Windows Phone and Windows.

I'm not sure how Xbox 360 is. How to know it?