### PR TITLE
Fix Dispose for DynamicSoundEffectInstance

### DIFF
--- a/src/Audio/DynamicSoundEffectInstance.cs
+++ b/src/Audio/DynamicSoundEffectInstance.cs
@@ -123,16 +123,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 		#endregion
 
-		#region Destructor
-
-		~DynamicSoundEffectInstance()
-		{
-			// FIXME: ReRegisterForFinalize? -flibit
-			Dispose();
-		}
-
-		#endregion
-
 		#region Public Methods
 
 		public TimeSpan GetSampleDuration(int sizeInBytes)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

>The finalizer implicitly calls [Finalize](https://learn.microsoft.com/en-us/dotnet/api/system.object.finalize) on the base class of the object.

I don't understand why ReRegisterForFinalize. Which instance leak?