### PR TITLE
Fix Dispose for Redirect API from XNA to FNA

### DIFF
--- a/src/Graphics/States/BlendState.cs
+++ b/src/Graphics/States/BlendState.cs
@@ -246,5 +246,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Protected Methods
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/States/DepthStencilState.cs
+++ b/src/Graphics/States/DepthStencilState.cs
@@ -284,5 +284,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Protected Methods
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/States/RasterizerState.cs
+++ b/src/Graphics/States/RasterizerState.cs
@@ -145,5 +145,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region Protected Methods
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/States/SamplerState.cs
+++ b/src/Graphics/States/SamplerState.cs
@@ -197,5 +197,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
+
+		#region
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+		}
+
+		#endregion
 	}
 }

--- a/src/Graphics/Vertices/VertexDeclaration.cs
+++ b/src/Graphics/Vertices/VertexDeclaration.cs
@@ -71,20 +71,24 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region Destructor
-
-		~VertexDeclaration()
-		{
-			handle.Free();
-		}
-
-		#endregion
-
 		#region Public Methods
 
 		public VertexElement[] GetVertexElements()
 		{
 			return (VertexElement[]) elements.Clone();
+		}
+
+		#endregion
+
+		#region Protected Methods
+
+		protected override void Dispose(bool disposing)
+		{
+			if (handle.IsAllocated)
+			{
+				handle.Free();
+			}
+			base.Dispose(disposing);
 		}
 
 		#endregion


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

I think it may be useful for some tool that redirect XNA API to FNA in C# IL. I'm not sure which tool do the redirect.

Remove deconstructor in VertexDeclaration. and move it to Dispose(bool)