### PR TITLE
Fix GameComponets Update before game run

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -266,8 +266,8 @@ namespace Microsoft.Xna.Framework
 
 			FrameworkDispatcher.Update();
 
-			// Ready to run the loop!
-			RunApplication = true;
+			Components.ComponentAdded += OnComponentAdded;
+			Components.ComponentRemoved += OnComponentRemoved;
 		}
 
 		#endregion
@@ -394,6 +394,9 @@ namespace Microsoft.Xna.Framework
 				DoInitialize();
 				hasInitialized = true;
 			}
+
+			// Ready to run the loop!
+			RunApplication = true;
 
 			BeginRun();
 			BeforeLoop();
@@ -770,8 +773,6 @@ namespace Microsoft.Xna.Framework
 			{
 				CategorizeComponent(Components[i]);
 			}
-			Components.ComponentAdded += OnComponentAdded;
-			Components.ComponentRemoved += OnComponentRemoved;
 		}
 
 		private void CategorizeComponent(IGameComponent component)
@@ -922,7 +923,10 @@ namespace Microsoft.Xna.Framework
 			/* Since we only subscribe to ComponentAdded after the graphics
 			 * devices are set up, it is safe to just blindly call Initialize.
 			 */
-			e.GameComponent.Initialize();
+			if (RunApplication)
+			{
+				e.GameComponent.Initialize();
+			}
 			CategorizeComponent(e.GameComponent);
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test case:
```C#
using System;
using Microsoft.Xna.Framework;

namespace ConsoleApp5
{
    internal static class Show
    {
        [STAThread]
        private static void Main()
        {
            FNAGame game = new FNAGame();
            game.Components.Add(new IndexGameComponent(game, 1));
            game.Update();
            game.Run();
            game.Components.Add(new IndexGameComponent(game, -1));
            Console.Error.WriteLine("After Add Component -1");
            game.Update();

        }
    }
    class FNAGame : Game
    {
        internal FNAGame()
        {
            new GraphicsDeviceManager(this);
        }
        public void Update()
        {
            base.Update(new GameTime());
        }
        bool b = true;
        protected override void Update(GameTime gameTime)
        {
            Console.Error.WriteLine("FNAGame.Update(GameTime gameTime) before");
            base.Update(gameTime);
            Console.Error.WriteLine("FNAGame.Update(GameTime gameTime) after");
            if (b)
            {
                b = false;
                base.Exit();
            }
        }
        protected override void Initialize()
        {
            Console.Error.WriteLine("Initialize before");
            Components.Add(new IndexGameComponent(this, 2));
            base.Initialize();
            Console.Error.WriteLine("Initialize after");
            Components.Add(new IndexGameComponent(this, 3));
        }
        protected override void LoadContent()
        {
            Console.Error.WriteLine("LoadContent before");
            Components.Add(new IndexGameComponent(this, 4));
            base.LoadContent();
            Console.Error.WriteLine("LoadContent after");
            Components.Add(new IndexGameComponent(this, 5));
        }
        protected override void BeginRun()
        {
            Console.Error.WriteLine("BeginRun before");
            Components.Add(new IndexGameComponent(this, 6));
            base.BeginRun();
            Console.Error.WriteLine("BeginRun after");
            Components.Add(new IndexGameComponent(this, 7));
        }
        protected override void OnActivated(object sender, EventArgs args)
        {
            Console.Error.WriteLine("OnActivated before");
            base.OnActivated(sender, args);
            Console.Error.WriteLine("OnActivated after");
        }
        protected override void EndRun()
        {
            Console.Error.WriteLine("EndRun before");
            base.EndRun();
            Console.Error.WriteLine("EndRun after");
        }
    }
    class IndexGameComponent : GameComponent
    {
        private readonly int index;
        public IndexGameComponent(Game game, int index) : base(game)
        {
            this.index = index;
        }
        public override void Initialize()
        {
            Console.WriteLine("IndexGameComponent.Initialize " + index);
        }
        public override void Update(GameTime gameTime)
        {
            Console.WriteLine("IndexGameComponent.Update " + index);
        }
    }
}
```
XNA output:
```
IndexGameComponent.Update 1
Initialize before
IndexGameComponent.Initialize 1
IndexGameComponent.Initialize 2
LoadContent before
LoadContent after
Initialize after
BeginRun before
IndexGameComponent.Initialize 6
BeginRun after
IndexGameComponent.Initialize 7
FNAGame.Update(GameTime gameTime) before
IndexGameComponent.Update 1
IndexGameComponent.Update 2
IndexGameComponent.Update 4
IndexGameComponent.Update 5
IndexGameComponent.Update 3
IndexGameComponent.Update 6
IndexGameComponent.Update 7
FNAGame.Update(GameTime gameTime) after
OnActivated before
OnActivated after
EndRun before
EndRun after
After Add Component -1
IndexGameComponent.Update 1
IndexGameComponent.Update 2
IndexGameComponent.Update 4
IndexGameComponent.Update 5
IndexGameComponent.Update 3
IndexGameComponent.Update 6
IndexGameComponent.Update 7
IndexGameComponent.Update -1
```
FNA output:
```
Initialize before
IndexGameComponent.Initialize 1
IndexGameComponent.Initialize 2
LoadContent before
LoadContent after
Initialize after
BeginRun before
IndexGameComponent.Initialize 6
BeginRun after
IndexGameComponent.Initialize 7
OnActivated before
OnActivated after
FNAGame.Update(GameTime gameTime) before
IndexGameComponent.Update 1
IndexGameComponent.Update 2
IndexGameComponent.Update 4
IndexGameComponent.Update 5
IndexGameComponent.Update 3
IndexGameComponent.Update 6
IndexGameComponent.Update 7
FNAGame.Update(GameTime gameTime) after
EndRun before
EndRun after
IndexGameComponent.Initialize -1
After Add Component -1
IndexGameComponent.Update 1
IndexGameComponent.Update 2
IndexGameComponent.Update 4
IndexGameComponent.Update 5
IndexGameComponent.Update 3
IndexGameComponent.Update 6
IndexGameComponent.Update 7
IndexGameComponent.Update -1
```

What happen?

XNA don't initialize GameComponent after EndRun. But FNA do it.

Componets.Add Before Game.Run, XNA call GameComponent.Update when Game.Update. But FNA no call it.

XNA not call GameComponent.Initialize when `Componets.Add` between `LoadContent before` and `BeginRun before`.