### PR TITLE
GameServiceContainer.AddService Exception message is wrong in XNA

### DIFF
--- a/src/GameServiceContainer.cs
+++ b/src/GameServiceContainer.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Xna.Framework
 			{
 				throw new ArgumentException(
 					"Service provider object of type " + provider.GetType().FullName +
-					" must be assignable to service type " + type.GetType().FullName + "."
+					" must be assignable to service type " +
+					type.FullName + "." // type.GetType().FullName in XNA. It is wrong so fixed it.
 				);
 			}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Found the issue from TestCase output in #618.