### PR TITLE
Optimize Dictionary.TryGetValue in GameServiceContainer.GetService

### DIFF
--- a/src/GameServiceContainer.cs
+++ b/src/GameServiceContainer.cs
@@ -61,12 +61,8 @@ namespace Microsoft.Xna.Framework
 			}
 
 			object service;
-			if (services.TryGetValue(type, out service))
-			{
-				return service;
-			}
-
-			return null;
+			services.TryGetValue(type, out service);
+			return service;
 		}
 
 		public void RemoveService(Type type)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

> If the key is not found, then the value parameter gets the appropriate default value for the type TValue; for example, 0 (zero) for integer types, false for Boolean types, and null for reference types.

Reference: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.trygetvalue?view=netframework-4.0