### PR TITLE
Call OnResourceCreated and OnResourceDestroyed for OcclusionQuery and VertexBuffer and DynamicVertexBuffer

### DIFF
--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -52,6 +52,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public OcclusionQuery(GraphicsDevice graphicsDevice)
 		{
+			if (graphicsDevice == null)
+			{
+				throw new ArgumentNullException("graphicsDevice", "The GraphicsDevice must not be null when creating new resources.");
+			}
 			GraphicsDevice = graphicsDevice;
 			query = FNA3D.FNA3D_CreateQuery(GraphicsDevice.GLDevice);
 			graphicsDevice.OnResourceCreated(this);

--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			GraphicsDevice = graphicsDevice;
 			query = FNA3D.FNA3D_CreateQuery(GraphicsDevice.GLDevice);
+			Name = string.Empty;
 			graphicsDevice.OnResourceCreated(this);
 		}
 

--- a/src/Graphics/OcclusionQuery.cs
+++ b/src/Graphics/OcclusionQuery.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			GraphicsDevice = graphicsDevice;
 			query = FNA3D.FNA3D_CreateQuery(GraphicsDevice.GLDevice);
+			graphicsDevice.OnResourceCreated(this);
 		}
 
 		#endregion
@@ -69,6 +70,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					FNA3D.FNA3D_AddDisposeQuery(GraphicsDevice.GLDevice, toDispose);
 				}
+				GraphicsDevice.OnResourceDestroyed(Name, Tag);
 			}
 			base.Dispose(disposing);
 		}

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				bufferUsage,
 				VertexCount * VertexDeclaration.VertexStride
 			);
+			Name = string.Empty;
 			graphicsDevice.OnResourceCreated(this);
 		}
 

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		) {
 			if (graphicsDevice == null)
 			{
-				throw new ArgumentNullException("graphicsDevice");
+				throw new ArgumentNullException("graphicsDevice", "The GraphicsDevice must not be null when creating new resources.");
 			}
 
 			GraphicsDevice = graphicsDevice;

--- a/src/Graphics/Vertices/VertexBuffer.cs
+++ b/src/Graphics/Vertices/VertexBuffer.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				bufferUsage,
 				VertexCount * VertexDeclaration.VertexStride
 			);
+			graphicsDevice.OnResourceCreated(this);
 		}
 
 		#endregion
@@ -126,6 +127,7 @@ namespace Microsoft.Xna.Framework.Graphics
 						toDispose
 					);
 				}
+				GraphicsDevice.OnResourceDestroyed(Name, Tag);
 			}
 			base.Dispose(disposing);
 		}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            SDL3.SDL.SDL_SetHint("FNA3D_FORCE_DRIVER", "D3D11");
            new FNAGame().Run();
        }
    }

    class FNAGame : Game
    {
        GraphicsDeviceManager gdm;
        internal FNAGame()
        {
            gdm = new GraphicsDeviceManager(this)
            {
                GraphicsProfile = GraphicsProfile.HiDef
            };
        }

        protected override void Initialize()
        {
            base.Initialize();

            GraphicsDevice gd = gdm.GraphicsDevice;
            gd.ResourceCreated += GraphicsDevice_ResourceCreated;
            gd.ResourceDestroyed += GraphicsDevice_ResourceDestroyed;

            new OcclusionQuery(gd).Dispose();
            new OcclusionQuery(gd)
            {
                Name = "HelloOcclusionQuery",
                Tag = new GameComponent(null)
            }.Dispose();

            VertexElement vertexElement = default;
            VertexDeclaration vertexDeclaration = new VertexDeclaration(vertexElement);
            new VertexBuffer(gd, vertexDeclaration, 1, BufferUsage.None).Dispose();
            new DynamicVertexBuffer(gd, vertexDeclaration, 1, BufferUsage.None).Dispose();
            vertexDeclaration.Dispose();

            new BlendState().Dispose();

            Exit();
        }

        private static void GraphicsDevice_ResourceCreated(object sender, ResourceCreatedEventArgs e)
        {
            Console.Error.WriteLine("GraphicsDevice_ResourceCreated sender=" + GetObjType(sender) + ":" + GetObjString(sender));
            Console.Error.WriteLine("GraphicsDevice_ResourceCreated Resource=" + GetObjType(e.Resource) + ":" + GetObjString(e.Resource));
            Console.Error.WriteLine("GraphicsDevice_ResourceCreated Name=" + GetObjType(((GraphicsResource)e.Resource).Name) + ":" + GetObjString(((GraphicsResource)e.Resource).Name));
        }

        private static void GraphicsDevice_ResourceDestroyed(object sender, ResourceDestroyedEventArgs e)
        {
            Console.Error.WriteLine("GraphicsDevice_ResourceDestroyed sender=" + GetObjType(sender) + ":" + GetObjString(sender));
            Console.Error.WriteLine("GraphicsDevice_ResourceDestroyed Name=" + GetObjType(e.Name) + ":" + GetObjString(e.Name));
            Console.Error.WriteLine("GraphicsDevice_ResourceDestroyed Tag=" + GetObjType(e.Tag) + ":" + GetObjString(e.Tag));
        }

        private static string GetObjType(object obj)
        {
            return obj == null ? "null" : obj.GetType().Name;
        }

        private static string GetObjString(object obj)
        {
            return obj == null ? "null" : obj.ToString();
        }
    }
}
```
XNA output:
```
GraphicsDevice_ResourceCreated sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceCreated Resource=OcclusionQuery:Microsoft.Xna.Framework.Graphics.OcclusionQuery
GraphicsDevice_ResourceCreated Name=String:
GraphicsDevice_ResourceDestroyed sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceDestroyed Name=String:
GraphicsDevice_ResourceDestroyed Tag=null:null
GraphicsDevice_ResourceCreated sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceCreated Resource=OcclusionQuery:Microsoft.Xna.Framework.Graphics.OcclusionQuery
GraphicsDevice_ResourceCreated Name=String:
GraphicsDevice_ResourceDestroyed sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceDestroyed Name=String:HelloOcclusionQuery
GraphicsDevice_ResourceDestroyed Tag=GameComponent:Microsoft.Xna.Framework.GameComponent
GraphicsDevice_ResourceCreated sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceCreated Resource=VertexBuffer:Microsoft.Xna.Framework.Graphics.VertexBuffer
GraphicsDevice_ResourceCreated Name=String:
GraphicsDevice_ResourceDestroyed sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceDestroyed Name=String:
GraphicsDevice_ResourceDestroyed Tag=null:null
GraphicsDevice_ResourceCreated sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceCreated Resource=DynamicVertexBuffer:Microsoft.Xna.Framework.Graphics.DynamicVertexBuffer
GraphicsDevice_ResourceCreated Name=String:
GraphicsDevice_ResourceDestroyed sender=GraphicsDevice:Microsoft.Xna.Framework.Graphics.GraphicsDevice
GraphicsDevice_ResourceDestroyed Name=String:
GraphicsDevice_ResourceDestroyed Tag=null:null
```
FNA no any output.