### PR TITLE
Add ToString for AudioCategory GamePadButtons GamePadDPad GamePadThumbSticks GamePadTriggers. Fix ToString for GamePadState. Fix ToString format for all PackedVector.

### DIFF
--- a/src/Audio/AudioCategory.cs
+++ b/src/Audio/AudioCategory.cs
@@ -144,6 +144,11 @@ namespace Microsoft.Xna.Framework.Audio
 			return !(value1.Equals(value2));
 		}
 
+		public override string ToString()
+		{
+			return INTERNAL_name ?? string.Empty;
+		}
+
 		#endregion
 	}
 }

--- a/src/Graphics/PackedVector/Alpha8.cs
+++ b/src/Graphics/PackedVector/Alpha8.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>A string representation of the packed vector.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X2");
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/Bgr565.cs
+++ b/src/Graphics/PackedVector/Bgr565.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>A string representation of the packed vector.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X4");
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/Bgra4444.cs
+++ b/src/Graphics/PackedVector/Bgra4444.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>A string representation of the packed vector.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X4");
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/Bgra5551.cs
+++ b/src/Graphics/PackedVector/Bgra5551.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>A string representation of the packed vector.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X4");
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/Byte4.cs
+++ b/src/Graphics/PackedVector/Byte4.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>String that represents the object.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X8");
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/HalfVector2.cs
+++ b/src/Graphics/PackedVector/HalfVector2.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return ToVector2().ToString();
 		}
 
 		public override int GetHashCode()

--- a/src/Graphics/PackedVector/HalfVector4.cs
+++ b/src/Graphics/PackedVector/HalfVector4.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>String that represents the object.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return ToVector4().ToString();
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/NormalizedByte2.cs
+++ b/src/Graphics/PackedVector/NormalizedByte2.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X4");
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/NormalizedByte4.cs
+++ b/src/Graphics/PackedVector/NormalizedByte4.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X8");
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/NormalizedShort2.cs
+++ b/src/Graphics/PackedVector/NormalizedShort2.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X8");
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/NormalizedShort4.cs
+++ b/src/Graphics/PackedVector/NormalizedShort4.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X16");
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/Rg32.cs
+++ b/src/Graphics/PackedVector/Rg32.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>A string representation of the packed vector.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X8");
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/Rgba1010102.cs
+++ b/src/Graphics/PackedVector/Rgba1010102.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>A string representation of the packed vector.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X8");
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/Rgba64.cs
+++ b/src/Graphics/PackedVector/Rgba64.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>A string representation of the packed vector.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X16");
 		}
 
 		/// <summary>

--- a/src/Graphics/PackedVector/Short2.cs
+++ b/src/Graphics/PackedVector/Short2.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X8");
 		}
 
 		#endregion

--- a/src/Graphics/PackedVector/Short4.cs
+++ b/src/Graphics/PackedVector/Short4.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <returns>String that represents the object.</returns>
 		public override string ToString()
 		{
-			return packedValue.ToString("X");
+			return packedValue.ToString("X16");
 		}
 
 		#endregion

--- a/src/Input/GamePadButtons.cs
+++ b/src/Input/GamePadButtons.cs
@@ -7,7 +7,9 @@
  */
 #endregion
 
+#region Using Statements
 using System.Text;
+#endregion
 
 namespace Microsoft.Xna.Framework.Input
 {

--- a/src/Input/GamePadButtons.cs
+++ b/src/Input/GamePadButtons.cs
@@ -7,6 +7,8 @@
  */
 #endregion
 
+using System.Text;
+
 namespace Microsoft.Xna.Framework.Input
 {
 	public struct GamePadButtons
@@ -203,6 +205,61 @@ namespace Microsoft.Xna.Framework.Input
 		public override int GetHashCode()
 		{
 			return (int) this.buttons;
+		}
+
+		public override string ToString()
+		{
+			StringBuilder sb = new StringBuilder("{Buttons:");
+			if ((buttons & Buttons.A) == Buttons.A)
+			{
+				sb.Append("A ");
+			}
+			if ((buttons & Buttons.B) == Buttons.B)
+			{
+				sb.Append("B ");
+			}
+			if ((buttons & Buttons.X) == Buttons.X)
+			{
+				sb.Append("X ");
+			}
+			if ((buttons & Buttons.Y) == Buttons.Y)
+			{
+				sb.Append("Y ");
+			}
+			if ((buttons & Buttons.LeftShoulder) == Buttons.LeftShoulder)
+			{
+				sb.Append("LeftShoulder ");
+			}
+			if ((buttons & Buttons.RightShoulder) == Buttons.RightShoulder)
+			{
+				sb.Append("RightShoulder ");
+			}
+			if ((buttons & Buttons.LeftStick) == Buttons.LeftStick)
+			{
+				sb.Append("LeftStick ");
+			}
+			if ((buttons & Buttons.RightStick) == Buttons.RightStick)
+			{
+				sb.Append("RightStick ");
+			}
+			if ((buttons & Buttons.Start) == Buttons.Start)
+			{
+				sb.Append("Start ");
+			}
+			if ((buttons & Buttons.Back) == Buttons.Back)
+			{
+				sb.Append("Back ");
+			}
+			if ((buttons & Buttons.BigButton) == Buttons.BigButton)
+			{
+				sb.Append("BigButton ");
+			}
+			if (sb.Length == 9)
+			{
+				sb.Append("None ");
+			}
+			sb[sb.Length - 1] = '}';
+			return sb.ToString();
 		}
 
 		#endregion

--- a/src/Input/GamePadDPad.cs
+++ b/src/Input/GamePadDPad.cs
@@ -7,7 +7,9 @@
  */
 #endregion
 
+#region Using Statements
 using System.Text;
+#endregion
 
 namespace Microsoft.Xna.Framework.Input
 {

--- a/src/Input/GamePadDPad.cs
+++ b/src/Input/GamePadDPad.cs
@@ -7,6 +7,8 @@
  */
 #endregion
 
+using System.Text;
+
 namespace Microsoft.Xna.Framework.Input
 {
 	public struct GamePadDPad
@@ -143,6 +145,33 @@ namespace Microsoft.Xna.Framework.Input
 				(Right	== ButtonState.Pressed ? 4 : 0) +
 				(Up	== ButtonState.Pressed ? 8 : 0)
 			);
+		}
+
+		public override string ToString()
+		{
+			StringBuilder sb = new StringBuilder("{DPad:");
+			if (Up == ButtonState.Pressed)
+			{
+				sb.Append("Up ");
+			}
+			if (Down == ButtonState.Pressed)
+			{
+				sb.Append("Down ");
+			}
+			if (Left == ButtonState.Pressed)
+			{
+				sb.Append("Left ");
+			}
+			if (Right == ButtonState.Pressed)
+			{
+				sb.Append("Right ");
+			}
+			if (sb.Length == 6)
+			{
+				sb.Append("None ");
+			}
+			sb[sb.Length - 1] = '}';
+			return sb.ToString();
 		}
 
 		#endregion

--- a/src/Input/GamePadState.cs
+++ b/src/Input/GamePadState.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Xna.Framework.Input
 		/// </summary>
 		public override string ToString()
 		{
-			return base.ToString();
+			return "{IsConnected:" + IsConnected + '}';
 		}
 
 		#endregion

--- a/src/Input/GamePadThumbSticks.cs
+++ b/src/Input/GamePadThumbSticks.cs
@@ -186,6 +186,11 @@ namespace Microsoft.Xna.Framework.Input
 			return left.X.GetHashCode() ^ left.Y.GetHashCode() ^ right.X.GetHashCode() ^ right.Y.GetHashCode();
 		}
 
+		public override string ToString()
+		{
+			return "{Left:" + left + " Right:" + right + '}';
+		}
+
 		#endregion
 	}
 }

--- a/src/Input/GamePadTriggers.cs
+++ b/src/Input/GamePadTriggers.cs
@@ -137,6 +137,11 @@ namespace Microsoft.Xna.Framework.Input
 			return left.GetHashCode() ^ right.GetHashCode();
 		}
 
+		public override string ToString()
+		{
+			return "{Left:" + left + " Right:" + right + '}';
+		}
+
 		#endregion
 	}
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            AudioCategory audioCategory;
            string str;

            audioCategory = new AudioCategory();
            str = audioCategory.ToString();
            Console.WriteLine("AudioCategory.Name=" + (audioCategory.Name ?? "null"));
            Console.WriteLine("AudioCategory.ToString=" + str.Length + "|" + str);

            audioCategory = new AudioEngine("test.xgs").GetCategory("Global");
            str = audioCategory.ToString();
            Console.WriteLine("AudioCategory.Name=" + (audioCategory.Name ?? "null"));
            Console.WriteLine("AudioCategory.ToString=" + str.Length + "|" + str);
        }
    }
}
```
XNA output:
```
AudioCategory.Name=null
AudioCategory.ToString=0|
AudioCategory.Name=Global
AudioCategory.ToString=6|Global
```
FNA output:
```
AudioCategory.Name=null
AudioCategory.ToString=43|Microsoft.Xna.Framework.Audio.AudioCategory
AudioCategory.Name=Global
AudioCategory.ToString=43|Microsoft.Xna.Framework.Audio.AudioCategory
```