### PR TITLE
FIXME: ArrayIndexOutOfBounds? in EffectAnnotationCollection and EffectPassCollection. Optimize Argument Check for this[] in EffectParameterCollection and EffectTechniqueCollection.

### DIFF
--- a/src/Graphics/Effect/EffectAnnotationCollection.cs
+++ b/src/Graphics/Effect/EffectAnnotationCollection.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return elements[index];
+				return unchecked((uint) index < (uint) elements.Count) ? elements[index] : null;
 			}
 		}
 
@@ -47,12 +47,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				foreach (EffectAnnotation elem in elements)
 				{
-					if (name.Equals(elem.Name))
+					if (name == elem.Name)
 					{
 						return elem;
 					}
 				}
-				return null; // FIXME: ArrayIndexOutOfBounds? -flibit
+				return null;
 			}
 		}
 

--- a/src/Graphics/Effect/EffectParameterCollection.cs
+++ b/src/Graphics/Effect/EffectParameterCollection.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return index >= 0 && index < elements.Count ? elements[index] : null;
+				return unchecked((uint) index < (uint) elements.Count) ? elements[index] : null;
 			}
 		}
 

--- a/src/Graphics/Effect/EffectPassCollection.cs
+++ b/src/Graphics/Effect/EffectPassCollection.cs
@@ -37,14 +37,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				if (elements != null)
 				{
-					return elements[index];
+					return unchecked((uint) index < (uint) elements.Count) ? elements[index] : null;
 				}
 
-				if (index != 0)
-				{
-					throw new ArgumentOutOfRangeException("index");
-				}
-				return singleItem;
+				return index == 0 ? singleItem : null;
 			}
 		}
 
@@ -54,21 +50,17 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				if (elements == null)
 				{
-					if (singleItem.Name.Equals(name))
-					{
-						return singleItem;
-					}
-					return null;
+					return singleItem.Name == name ? singleItem : null;
 				}
 
 				foreach (EffectPass elem in elements)
 				{
-					if (name.Equals(elem.Name))
+					if (name == elem.Name)
 					{
 						return elem;
 					}
 				}
-				return null; // FIXME: ArrayIndexOutOfBounds? -flibit
+				return null;
 			}
 		}
 

--- a/src/Graphics/Effect/EffectTechniqueCollection.cs
+++ b/src/Graphics/Effect/EffectTechniqueCollection.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
-				return index >= 0 && index < elements.Count ? elements[index] : null;
+				return unchecked((uint) index < (uint) elements.Count) ? elements[index] : null;
 			}
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

The same as #603 #606