### PR TITLE
Add Exception in DrawableGameComponent that The GraphicsDevice property cannot be used before Initialize has been called.

### DIFF
--- a/src/DrawableGameComponent.cs
+++ b/src/DrawableGameComponent.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Xna.Framework
 		{
 			get
 			{
+				if (!_initialized)
+				{
+					throw new InvalidOperationException("The GraphicsDevice property cannot be used before Initialize has been called.");
+				}
 				return this.Game.GraphicsDevice;
 			}
 		}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            Game game = new Game();
            new GraphicsDeviceManager(game);
            GraphicsDevice gd = new DrawableGameComponent(game).GraphicsDevice;
            Console.Error.WriteLine(gd == null);
        }
    }
}
```
XNA output:
```
Unhandled Exception: System.InvalidOperationException: The GraphicsDevice property cannot be used before Initialize has been called.
   at Microsoft.Xna.Framework.DrawableGameComponent.get_GraphicsDevice()
   at ConsoleApp5.Show.Main() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\show.cs:line 13
```
FNA output:
```
True
```