### PR TITLE
Check Argument for ContentSerializerAttribute.CollectionItemName

### DIFF
--- a/src/Content/ContentSerializerAttribute.cs
+++ b/src/Content/ContentSerializerAttribute.cs
@@ -32,15 +32,14 @@ namespace Microsoft.Xna.Framework.Content
 			get
 			{
 				// Return the default if unset.
-				if (string.IsNullOrEmpty(collectionItemName))
-				{
-					return "Item";
-				}
-
-				return collectionItemName;
+				return collectionItemName ?? "Item";
 			}
 			set
 			{
+				if (string.IsNullOrEmpty(value))
+				{
+					throw new ArgumentNullException("value");
+				}
 				collectionItemName = value;
 			}
 		}
@@ -64,7 +63,7 @@ namespace Microsoft.Xna.Framework.Content
 		{
 			get
 			{
-				return !string.IsNullOrEmpty(collectionItemName);
+				return collectionItemName != null;
 			}
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Content;
using System;
using System.Reflection;

namespace ConsoleApp5
{
    static class Show
    {
        [ContentSerializerAttribute(CollectionItemName = "")]
        public static int a;
        [STAThread]
        static void Main()
        {
            a = 6;
            Console.WriteLine(a);
            FieldInfo fieldInfo = typeof(Show).GetField("a");
            Attribute.GetCustomAttribute(fieldInfo, typeof(ContentSerializerAttribute));
        }
    }
}
```
XNA output:
```
6

Unhandled Exception: System.Reflection.CustomAttributeFormatException: 'CollectionItemName' property specified was not found. ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.ArgumentNullException: Value cannot be null.
Parameter name: value
   at Microsoft.Xna.Framework.Content.ContentSerializerAttribute.set_CollectionItemName(String value)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeModule decoratedModule, Int32 decoratedMetadataToken, Int32 pcaCount, RuntimeType attributeFilterType, Boolean mustBeInheritable, IList derivedAttributes, Boolean isDecoratedTargetSecurityTransparent)
   --- End of inner exception stack trace ---
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeModule decoratedModule, Int32 decoratedMetadataToken, Int32 pcaCount, RuntimeType attributeFilterType, Boolean mustBeInheritable, IList derivedAttributes, Boolean isDecoratedTargetSecurityTransparent)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeFieldInfo field, RuntimeType caType)
   at System.Reflection.RuntimeFieldInfo.GetCustomAttributes(Type attributeType, Boolean inherit)
   at System.Attribute.GetCustomAttributes(MemberInfo element, Type type, Boolean inherit)
   at System.Attribute.GetCustomAttribute(MemberInfo element, Type attributeType, Boolean inherit)
   at ConsoleApp5.Show.Main() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\show.cs:line 16
```
FNA output:
```
6
```