### PR TITLE
Check Argument for ctor in ContentSerializerCollectionItemNameAttribute and ContentSerializerRuntimeTypeAttribute

### DIFF
--- a/src/Content/ContentSerializerCollectionItemNameAttribute.cs
+++ b/src/Content/ContentSerializerCollectionItemNameAttribute.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Xna.Framework.Content
 		/// <param name="collectionItemName">The XML element name to use for each item in the collection.</param>
 		public ContentSerializerCollectionItemNameAttribute(string collectionItemName)
 		{
+			if (string.IsNullOrEmpty(collectionItemName))
+			{
+				throw new ArgumentNullException("collectionItemName");
+			}
 			CollectionItemName = collectionItemName;
 		}
 

--- a/src/Content/ContentSerializerRuntimeTypeAttribute.cs
+++ b/src/Content/ContentSerializerRuntimeTypeAttribute.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Xna.Framework.Content
 		/// <param name="runtimeType">The name of the type to use at runtime.</param>
 		public ContentSerializerRuntimeTypeAttribute(string runtimeType)
 		{
+			if (string.IsNullOrEmpty(runtimeType))
+			{
+				throw new ArgumentNullException("runtimeType");
+			}
 			RuntimeType = runtimeType;
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Content;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            ex(() => new ContentSerializerCollectionItemNameAttribute(""));
            ex(() => new ContentSerializerRuntimeTypeAttribute(""));
        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
System.ArgumentNullException: Value cannot be null.
Parameter name: collectionItemName
   at Microsoft.Xna.Framework.Content.ContentSerializerCollectionItemNameAttribute..ctor(String collectionItemName)
   at EX.EX.<>c.<Main>b__0_0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 11
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 19

System.ArgumentNullException: Value cannot be null.
Parameter name: runtimeType
   at Microsoft.Xna.Framework.Content.ContentSerializerRuntimeTypeAttribute..ctor(String runtimeType)
   at EX.EX.<>c.<Main>b__0_1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 12
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 19

```
FNA no any output.