### PR TITLE
Don't allow drag or minimize window when ShowMissingRequirementMessage

### DIFF
--- a/src/FNAPlatform/FNAPlatform.cs
+++ b/src/FNAPlatform/FNAPlatform.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Xna.Framework
 		public delegate void FreeFilePointerFunc(IntPtr file);
 		public static readonly FreeFilePointerFunc FreeFilePointer;
 
-		public delegate void ShowRuntimeErrorFunc(string title, string message);
+		public delegate void ShowRuntimeErrorFunc(GameWindow gameWindow, string message);
 		public static readonly ShowRuntimeErrorFunc ShowRuntimeError;
 
 		public delegate Microphone[] GetMicrophonesFunc();

--- a/src/FNAPlatform/SDL2_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL2_FNAPlatform.cs
@@ -1669,13 +1669,13 @@ namespace Microsoft.Xna.Framework
 
 		#region Logging/Messaging Methods
 
-		public static void ShowRuntimeError(string title, string message)
+		public static void ShowRuntimeError(GameWindow gameWindow, string message)
 		{
 			SDL.SDL_ShowSimpleMessageBox(
 				SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
-				title ?? "",
-				message ?? "",
-				IntPtr.Zero
+				gameWindow.Title,
+				message,
+				gameWindow.Handle
 			);
 		}
 

--- a/src/FNAPlatform/SDL3_FNAPlatform.cs
+++ b/src/FNAPlatform/SDL3_FNAPlatform.cs
@@ -1654,13 +1654,13 @@ namespace Microsoft.Xna.Framework
 
 		#region Logging/Messaging Methods
 
-		public static void ShowRuntimeError(string title, string message)
+		public static void ShowRuntimeError(GameWindow gameWindow, string message)
 		{
 			SDL.SDL_ShowSimpleMessageBox(
 				SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
-				title ?? "",
-				message ?? "",
-				IntPtr.Zero
+				gameWindow.Title,
+				message,
+				gameWindow.Handle
 			);
 		}
 

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -717,7 +717,7 @@ namespace Microsoft.Xna.Framework
 			if (exception is NoAudioHardwareException)
 			{
 				FNAPlatform.ShowRuntimeError(
-					Window.Title,
+					Window,
 					"Could not find a suitable audio device. " +
 					" Verify that a sound card is\ninstalled," +
 					" and check the driver properties to make" +
@@ -728,7 +728,7 @@ namespace Microsoft.Xna.Framework
 			if (exception is NoSuitableGraphicsDeviceException)
 			{
 				FNAPlatform.ShowRuntimeError(
-					Window.Title,
+					Window,
 					"Could not find a suitable graphics device." +
 					" More information:\n\n" + exception.Message
 				);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Audio;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            new FNAGame().Run();
        }
    }

    class FNAGame : Game
    {
        internal FNAGame()
        {
            new GraphicsDeviceManager(this);
        }

        int b = 0;
        protected override void Update(GameTime gameTime)
        {
            base.Update(gameTime);
            if (b++ == 120)
            {
                base.ShowMissingRequirementMessage(new NoAudioHardwareException("NoAudioHardwareExceptionMessage"));
            }
        }
    }
}
```