### PR TITLE
Fix VertexDeclaration Name for VertexPosition

### DIFF
--- a/src/Graphics/Vertices/VertexPositionColor.cs
+++ b/src/Graphics/Vertices/VertexPositionColor.cs
@@ -49,22 +49,19 @@ namespace Microsoft.Xna.Framework.Graphics
 		static VertexPositionColor()
 		{
 			VertexDeclaration = new VertexDeclaration(
-				new VertexElement[]
-				{
-					new VertexElement(
-						0,
-						VertexElementFormat.Vector3,
-						VertexElementUsage.Position,
-						0
-					),
-					new VertexElement(
-						12,
-						VertexElementFormat.Color,
-						VertexElementUsage.Color,
-						0
-					)
-				}
-			);
+				new VertexElement(
+					0,
+					VertexElementFormat.Vector3,
+					VertexElementUsage.Position,
+					0
+				),
+				new VertexElement(
+					12,
+					VertexElementFormat.Color,
+					VertexElementUsage.Color,
+					0
+				)
+			) { Name = "VertexPositionColor.VertexDeclaration" };
 		}
 
 		#endregion

--- a/src/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -49,28 +49,25 @@ namespace Microsoft.Xna.Framework.Graphics
 		static VertexPositionColorTexture()
 		{
 			VertexDeclaration = new VertexDeclaration(
-				new VertexElement[]
-				{
-					new VertexElement(
-						0,
-						VertexElementFormat.Vector3,
-						VertexElementUsage.Position,
-						0
-					),
-					new VertexElement(
-						12,
-						VertexElementFormat.Color,
-						VertexElementUsage.Color,
-						0
-					),
-					new VertexElement(
-						16,
-						VertexElementFormat.Vector2,
-						VertexElementUsage.TextureCoordinate,
-						0
-					)
-				}
-			);
+				new VertexElement(
+					0,
+					VertexElementFormat.Vector3,
+					VertexElementUsage.Position,
+					0
+				),
+				new VertexElement(
+					12,
+					VertexElementFormat.Color,
+					VertexElementUsage.Color,
+					0
+				),
+				new VertexElement(
+					16,
+					VertexElementFormat.Vector2,
+					VertexElementUsage.TextureCoordinate,
+					0
+				)
+			) { Name = "VertexPositionColorTexture.VertexDeclaration" };
 		}
 
 		#endregion

--- a/src/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -49,28 +49,25 @@ namespace Microsoft.Xna.Framework.Graphics
 		static VertexPositionNormalTexture()
 		{
 			VertexDeclaration = new VertexDeclaration(
-				new VertexElement[]
-				{
-					new VertexElement(
-						0,
-						VertexElementFormat.Vector3,
-						VertexElementUsage.Position,
-						0
-					),
-					new VertexElement(
-						12,
-						VertexElementFormat.Vector3,
-						VertexElementUsage.Normal,
-						0
-					),
-					new VertexElement(
-						24,
-						VertexElementFormat.Vector2,
-						VertexElementUsage.TextureCoordinate,
-						0
-					)
-				}
-			);
+				new VertexElement(
+					0,
+					VertexElementFormat.Vector3,
+					VertexElementUsage.Position,
+					0
+				),
+				new VertexElement(
+					12,
+					VertexElementFormat.Vector3,
+					VertexElementUsage.Normal,
+					0
+				),
+				new VertexElement(
+					24,
+					VertexElementFormat.Vector2,
+					VertexElementUsage.TextureCoordinate,
+					0
+				)
+			) { Name = "VertexPositionNormalTexture.VertexDeclaration" };
 		}
 
 		#endregion

--- a/src/Graphics/Vertices/VertexPositionTexture.cs
+++ b/src/Graphics/Vertices/VertexPositionTexture.cs
@@ -48,22 +48,19 @@ namespace Microsoft.Xna.Framework.Graphics
 		static VertexPositionTexture()
 		{
 			VertexDeclaration = new VertexDeclaration(
-				new VertexElement[]
-				{
-					new VertexElement(
-						0,
-						VertexElementFormat.Vector3,
-						VertexElementUsage.Position,
-						0
-					),
-					new VertexElement(
-						12,
-						VertexElementFormat.Vector2,
-						VertexElementUsage.TextureCoordinate,
-						0
-					)
-				}
-			);
+				new VertexElement(
+					0,
+					VertexElementFormat.Vector3,
+					VertexElementUsage.Position,
+					0
+				),
+				new VertexElement(
+					12,
+					VertexElementFormat.Vector2,
+					VertexElementUsage.TextureCoordinate,
+					0
+				)
+			) { Name = "VertexPositionTexture.VertexDeclaration" };
 		}
 
 		#endregion


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Graphics;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            Console.WriteLine(VertexPositionColor.VertexDeclaration.Name);
            Console.WriteLine(VertexPositionColorTexture.VertexDeclaration.Name);
            Console.WriteLine(VertexPositionNormalTexture.VertexDeclaration.Name);
            Console.WriteLine(VertexPositionTexture.VertexDeclaration.Name);
        }
    }
}
```
XNA output:
```
VertexPositionColor.VertexDeclaration
VertexPositionColorTexture.VertexDeclaration
VertexPositionNormalTexture.VertexDeclaration
VertexPositionTexture.VertexDeclaration
```
FNA output:
```




```