### PR TITLE
fix: call Disposing when dependency for AudioEngine WaveBank SoundBank

### DIFF
--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -279,6 +279,8 @@ namespace Microsoft.Xna.Framework.Audio
 		internal void OnCueDestroyed()
 		{
 			handle = IntPtr.Zero;
+			selfReference = null;
+
 			Dispose();
 		}
 
@@ -295,8 +297,6 @@ namespace Microsoft.Xna.Framework.Audio
 					IsDisposed = true;
 
 					FAudio.FACTCue_Destroy(handle);
-					handle = IntPtr.Zero;
-					selfReference = null;
 
 					if (disposing && Disposing != null)
 					{

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -278,9 +278,8 @@ namespace Microsoft.Xna.Framework.Audio
 
 		internal void OnCueDestroyed()
 		{
-			IsDisposed = true;
 			handle = IntPtr.Zero;
-			selfReference = null;
+			Dispose();
 		}
 
 		#endregion
@@ -293,12 +292,11 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				if (!IsDisposed)
 				{
-					// If this is Disposed, stop leaking memory!
-					if (!bank.engine.IsDisposed)
-					{
-						FAudio.FACTCue_Destroy(handle);
-					}
-					OnCueDestroyed();
+					IsDisposed = true;
+
+					FAudio.FACTCue_Destroy(handle);
+					handle = IntPtr.Zero;
+					selfReference = null;
 
 					if (disposing && Disposing != null)
 					{

--- a/src/Audio/SoundBank.cs
+++ b/src/Audio/SoundBank.cs
@@ -142,12 +142,9 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				if (!IsDisposed)
 				{
-					// If this is disposed, stop leaking memory!
-					if (!engine.IsDisposed)
-					{
-						FAudio.FACTSoundBank_Destroy(handle);
-					}
-					OnSoundBankDestroyed();
+					IsDisposed = true;
+
+					FAudio.FACTSoundBank_Destroy(handle);
 
 					if (disposing && Disposing != null)
 					{
@@ -273,7 +270,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 		internal void OnSoundBankDestroyed()
 		{
-			IsDisposed = true;
 			handle = IntPtr.Zero;
 			selfReference = null;
 			if (dspSettings.pMatrixCoefficients != IntPtr.Zero)
@@ -281,6 +277,8 @@ namespace Microsoft.Xna.Framework.Audio
 				FNAPlatform.Free(dspSettings.pMatrixCoefficients);
 				dspSettings.pMatrixCoefficients = IntPtr.Zero;
 			}
+
+			Dispose();
 		}
 
 		#endregion

--- a/src/Audio/WaveBank.cs
+++ b/src/Audio/WaveBank.cs
@@ -186,12 +186,9 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				if (!IsDisposed)
 				{
-					// If this is disposed, stop leaking memory!
-					if (!engine.IsDisposed)
-					{
-						FAudio.FACTWaveBank_Destroy(handle);
-					}
-					OnWaveBankDestroyed();
+					IsDisposed = true;
+
+					FAudio.FACTWaveBank_Destroy(handle);
 
 					if (disposing && Disposing != null)
 					{
@@ -207,7 +204,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 		internal void OnWaveBankDestroyed()
 		{
-			IsDisposed = true;
 			if (bankData != IntPtr.Zero)
 			{
 				if (bankDataLen != IntPtr.Zero)
@@ -223,6 +219,8 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			handle = IntPtr.Zero;
 			selfReference = null;
+
+			Dispose();
 		}
 
 		#endregion


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            AudioEngine audioEngine = new AudioEngine(@"Music.xgs");
            audioEngine.Disposing += AudioEngine_Disposing;

            WaveBank waveBank = new WaveBank(audioEngine, @"Wave Bank.xwb", 0, 512);
            waveBank.Disposing += WaveBank_Disposing;

            SoundBank soundBank = new SoundBank(audioEngine, @"Sound Bank.xsb");
            soundBank.Disposing += SoundBank_Disposing;

            audioEngine.Update();

            Cue cue = soundBank.GetCue("Music_100");
            cue.Disposing += Cue_Disposing;

            Console.Error.WriteLine("start");
            waveBank.Dispose();
            Console.Error.WriteLine("end");
        }

        private static void AudioEngine_Disposing(object sender, EventArgs e)
        {
            Console.Error.WriteLine("AudioEngine_Disposing");
        }

        private static void SoundBank_Disposing(object sender, EventArgs e)
        {
            Console.Error.WriteLine("SoundBank_Disposing");
        }

        private static void WaveBank_Disposing(object sender, EventArgs e)
        {
            Console.Error.WriteLine("WaveBank_Disposing");
        }

        private static void Cue_Disposing(object sender, EventArgs e)
        {
            Console.Error.WriteLine("Cue_Disposing");
        }
    }
}
```
XNA output:
```
start
Cue_Disposing
WaveBank_Disposing
end
```
FNA output:
```
start
WaveBank_Disposing
end
```