### PR TITLE
Change Exception message as the same to XNA in GraphicsDeviceManager ctor

### DIFF
--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Xna.Framework
 
 			if (game.Services.INTERNAL_GetService(typeof(IGraphicsDeviceManager)) != null)
 			{
-				throw new ArgumentException("Graphics Device Manager Already Present");
+				throw new ArgumentException("A graphics device manager is already registered.  The graphics device manager cannot be changed once it is set.");
 			}
 
 			game.Services.INTERNAL_AddService(typeof(IGraphicsDeviceManager), this);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            Game game = new Game();
            new GraphicsDeviceManager(game);
            new GraphicsDeviceManager(game);
        }
    }
}
```
XNA output:
```
Unhandled Exception: System.ArgumentException: A graphics device manager is already registered.  The graphics device manager cannot be changed once it is set.
   at Microsoft.Xna.Framework.GraphicsDeviceManager..ctor(Game game)
   at EX.EX.Main() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 12
```