### PR TITLE
Fix Exception for AudioEngine SoundBank Cue

### DIFF
--- a/src/Audio/AudioEngine.cs
+++ b/src/Audio/AudioEngine.cs
@@ -296,9 +296,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (variable == FAudio.FACTVARIABLEINDEX_INVALID)
 			{
-				throw new InvalidOperationException(
-					"Invalid variable name!"
-				);
+				throw new IndexOutOfRangeException("The specified variable index is invalid.");
 			}
 
 			float result;
@@ -324,9 +322,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (variable == FAudio.FACTVARIABLEINDEX_INVALID)
 			{
-				throw new InvalidOperationException(
-					"Invalid variable name!"
-				);
+				throw new IndexOutOfRangeException("The specified variable index is invalid.");
 			}
 
 			FAudio.FACTAudioEngine_SetGlobalVariable(

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -206,9 +206,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (variable == FAudio.FACTVARIABLEINDEX_INVALID)
 			{
-				throw new InvalidOperationException(
-					"Invalid variable name!"
-				);
+				throw new IndexOutOfRangeException("The specified variable index is invalid.");
 			}
 
 			float result;
@@ -222,6 +220,10 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public void Pause()
 		{
+			if (IsStopped)
+			{
+				throw new InvalidOperationException("The method or function that was called cannot be used in the manner requested.");
+			}
 			FAudio.FACTCue_Pause(handle, 1);
 		}
 
@@ -233,6 +235,10 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public void Resume()
 		{
+			if (IsStopped)
+			{
+				throw new InvalidOperationException("The method or function that was called cannot be used in the manner requested.");
+			}
 			FAudio.FACTCue_Pause(handle, 0);
 		}
 
@@ -250,9 +256,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (variable == FAudio.FACTVARIABLEINDEX_INVALID)
 			{
-				throw new InvalidOperationException(
-					"Invalid variable name!"
-				);
+				throw new IndexOutOfRangeException("The specified variable index is invalid.");
 			}
 
 			FAudio.FACTCue_SetVariable(

--- a/src/Audio/SoundBank.cs
+++ b/src/Audio/SoundBank.cs
@@ -174,9 +174,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (cue == FAudio.FACTINDEX_INVALID)
 			{
-				throw new InvalidOperationException(
-					"Invalid cue name!"
-				);
+				throw new ArgumentException("An error occurred trying to play the cue named \"" + name + "\". Is the cue name correct?");
 			}
 
 			IntPtr result;
@@ -206,9 +204,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (cue == FAudio.FACTINDEX_INVALID)
 			{
-				throw new InvalidOperationException(
-					"Invalid cue name!"
-				);
+				throw new InvalidOperationException("An error occurred trying to play the cue named \"" + name + "\". Is the cue name correct?");
 			}
 
 			FAudio.FACTSoundBank_Play(
@@ -245,9 +241,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			if (cue == FAudio.FACTINDEX_INVALID)
 			{
-				throw new InvalidOperationException(
-					"Invalid cue name!"
-				);
+				throw new InvalidOperationException("An error occurred trying to play the cue named \"" + name + "\". Is the cue name correct?");
 			}
 
 			emitter.emitterData.ChannelCount = dspSettings.SrcChannelCount;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            AudioEngine audioEngine = new AudioEngine(@"Music.xgs");
            SoundBank soundBank = new SoundBank(audioEngine, @"Sound Bank.xsb");
            WaveBank waveBank = new WaveBank(audioEngine, @"Wave Bank.xwb", 0, 512);
            
            audioEngine.Update();

            Cue cue = soundBank.GetCue("Music_100");
            cue.Stop(AudioStopOptions.Immediate);
            Console.WriteLine("cue:" + cue.IsStopping + " | " + cue.IsStopped);
            cue.Pause();
            cue.Resume();
            while (!cue.IsStopped) ;
            Console.WriteLine("cue:" + cue.IsStopping + " | " + cue.IsStopped);
            ex(() => cue.Pause());
            ex(() => cue.Resume());

            ex(() => soundBank.PlayCue("Music_1000"));

            ex(() => soundBank.GetCue("Music_1000"));

            ex(() => audioEngine.SetGlobalVariable("hello", 1.1f));
            ex(() => audioEngine.GetGlobalVariable("hello"));

            ex(() => cue.SetVariable("hello", 1.1f));
            ex(() => cue.GetVariable("hello"));
        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
cue:True | False
cue:False | True
System.InvalidOperationException: The method or function that was called cannot be used in the manner requested.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 24
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.InvalidOperationException: The method or function that was called cannot be used in the manner requested.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.InvalidOperationException: An error occurred trying to play the cue named "Music_1000". Is the cue name correct?
   at Microsoft.Xna.Framework.Audio.SoundBank.PlayCue(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 27
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.ArgumentException: An error occurred trying to play the cue named "Music_1000". Is the cue name correct?
   at Microsoft.Xna.Framework.Audio.SoundBank.GetCue(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__3() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.IndexOutOfRangeException: The specified variable index is invalid.
   at Microsoft.Xna.Framework.Audio.AudioEngine.SetGlobalVariable(String name, Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__4() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 31
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.IndexOutOfRangeException: The specified variable index is invalid.
   at Microsoft.Xna.Framework.Audio.AudioEngine.GetGlobalVariable(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__5() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 32
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.IndexOutOfRangeException: The specified variable index is invalid.
   at Microsoft.Xna.Framework.Audio.Cue.SetVariable(String name, Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__6() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 34
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.IndexOutOfRangeException: The specified variable index is invalid.
   at Microsoft.Xna.Framework.Audio.Cue.GetVariable(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__7() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 35
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42
```
FNA output:
```
cue:False | True
cue:False | True
System.InvalidOperationException: Invalid cue name!
   at Microsoft.Xna.Framework.Audio.SoundBank.PlayCue(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 27
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.InvalidOperationException: Invalid cue name!
   at Microsoft.Xna.Framework.Audio.SoundBank.GetCue(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__3() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.InvalidOperationException: Invalid variable name!
   at Microsoft.Xna.Framework.Audio.AudioEngine.SetGlobalVariable(String name, Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__4() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 31
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.InvalidOperationException: Invalid variable name!
   at Microsoft.Xna.Framework.Audio.AudioEngine.GetGlobalVariable(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__5() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 32
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.InvalidOperationException: Invalid variable name!
   at Microsoft.Xna.Framework.Audio.Cue.SetVariable(String name, Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__6() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 34
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42

System.InvalidOperationException: Invalid variable name!
   at Microsoft.Xna.Framework.Audio.Cue.GetVariable(String name)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__7() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 35
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 42
```