### PR TITLE
accuracy: BoundingFrustum.Contains(Vector3)

### DIFF
--- a/src/BoundingFrustum.cs
+++ b/src/BoundingFrustum.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>Result of testing for containment between this <see cref="BoundingFrustum"/> and specified <see cref="Vector3"/>.</returns>
 		public ContainmentType Contains(Vector3 point)
 		{
-			ContainmentType result = default(ContainmentType);
+			ContainmentType result;
 			this.Contains(ref point, out result);
 			return result;
 		}
@@ -296,7 +296,6 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">Result of testing for containment between this <see cref="BoundingFrustum"/> and specified <see cref="Vector3"/> as an output parameter.</param>
 		public void Contains(ref Vector3 point, out ContainmentType result)
 		{
-			bool intersects = false;
 			for (int i = 0; i < PlaneCount; i += 1)
 			{
 				float classifyPoint = (
@@ -305,18 +304,13 @@ namespace Microsoft.Xna.Framework
 					(point.Z * planes[i].Normal.Z) +
 					planes[i].D
 				);
-				if (classifyPoint > 0)
+				if (classifyPoint > 1E-5f)
 				{
 					result = ContainmentType.Disjoint;
 					return;
 				}
-				else if (classifyPoint == 0)
-				{
-					intersects = true;
-					break;
-				}
 			}
-			result = intersects ? ContainmentType.Intersects : ContainmentType.Contains;
+			result = ContainmentType.Contains;
 		}
 
 		/// <summary>


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            BoundingFrustum frustum = new BoundingFrustum(Matrix.Identity);
            Console.WriteLine(frustum.Near);
            Console.WriteLine(frustum.Far);
            Console.WriteLine(frustum.Left);
            Console.WriteLine(frustum.Right);
            Console.WriteLine(frustum.Top);
            Console.WriteLine(frustum.Bottom);
            Console.WriteLine(frustum.Contains(new Vector3(0f, 0f, 1E-6f)));
            Console.WriteLine(frustum.Contains(new Vector3(0f, 0f, 0f)));
            Console.WriteLine(frustum.Contains(new Vector3(0f, 0f, -1E-6f)));
            Console.WriteLine(frustum.Contains(new Vector3(0f, 0f, -1E-4f)));
        }
    }
}
```
XNA output:
```
{Normal:{X:0 Y:0 Z:-1} D:0}
{Normal:{X:0 Y:0 Z:1} D:-1}
{Normal:{X:-1 Y:0 Z:0} D:-1}
{Normal:{X:1 Y:0 Z:0} D:-1}
{Normal:{X:0 Y:1 Z:0} D:-1}
{Normal:{X:0 Y:-1 Z:0} D:-1}
Contains
Contains
Contains
Disjoint
```
FNA output:
```
{Normal:{X:0 Y:0 Z:-1} D:0}
{Normal:{X:0 Y:0 Z:1} D:-1}
{Normal:{X:-1 Y:0 Z:0} D:-1}
{Normal:{X:1 Y:0 Z:0} D:-1}
{Normal:{X:0 Y:1 Z:0} D:-1}
{Normal:{X:0 Y:-1 Z:0} D:-1}
Contains
Intersects
Disjoint
Disjoint
```