### PR TITLE
accuracy: BoundingFrustum.Intersects(Plane) when plane at bound, inline plane.Intersects(Vector3)

### DIFF
--- a/src/BoundingFrustum.cs
+++ b/src/BoundingFrustum.cs
@@ -422,14 +422,19 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">A plane intersection type as an output parameter.</param>
 		public void Intersects(ref Plane plane, out PlaneIntersectionType result)
 		{
-			result = plane.Intersects(ref corners[0]);
-			for (int i = 1; i < corners.Length; i += 1)
+			float distance;
+			plane.DotCoordinate(ref corners[0], out distance);
+			bool flag = distance > 0f;
+			for (int i = 1; i < corners.Length; i++)
 			{
-				if (plane.Intersects(ref corners[i]) != result)
+				plane.DotCoordinate(ref corners[i], out distance);
+				if (distance > 0f != flag)
 				{
 					result = PlaneIntersectionType.Intersecting;
+					return;
 				}
 			}
+			result = flag ? PlaneIntersectionType.Front : PlaneIntersectionType.Back;
 		}
 
 		/// <summary>

--- a/src/BoundingFrustum.cs
+++ b/src/BoundingFrustum.cs
@@ -424,17 +424,22 @@ namespace Microsoft.Xna.Framework
 		{
 			float distance;
 			plane.DotCoordinate(ref corners[0], out distance);
-			bool flag = distance > 0f;
+			bool isInFront = (distance > 0f);
 			for (int i = 1; i < corners.Length; i++)
 			{
 				plane.DotCoordinate(ref corners[i], out distance);
-				if (distance > 0f != flag)
+				// If one corner is in front and another behind, we're intersecting no matter what
+				bool anotherInFront = (distance > 0f);
+				if (anotherInFront != isInFront)
 				{
 					result = PlaneIntersectionType.Intersecting;
 					return;
 				}
 			}
-			result = flag ? PlaneIntersectionType.Front : PlaneIntersectionType.Back;
+
+			// If we made it here, all corners are on the same side as the first corner we checked.
+			// Note that all corners having a distance of exactly 0 also counts as Back, not Intersecting
+			result = isInFront ? PlaneIntersectionType.Front : PlaneIntersectionType.Back;
 		}
 
 		/// <summary>

--- a/src/Plane.cs
+++ b/src/Plane.cs
@@ -177,25 +177,6 @@ namespace Microsoft.Xna.Framework
 
 		#endregion
 
-		#region Internal Methods
-
-		internal PlaneIntersectionType Intersects(ref Vector3 point)
-		{
-			float distance;
-			DotCoordinate(ref point, out distance);
-			if (distance > 0)
-			{
-				return PlaneIntersectionType.Front;
-			}
-			if (distance < 0)
-			{
-				return PlaneIntersectionType.Back;
-			}
-			return PlaneIntersectionType.Intersecting;
-		}
-
-		#endregion
-
 		#region Public Static Methods
 
 		public static Plane Normalize(Plane value)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            BoundingFrustum frustum = new BoundingFrustum(Matrix.Identity);
            foreach (Vector3 corner in frustum.GetCorners())
            {
                Console.WriteLine(corner);
            }
            Console.WriteLine(frustum.Intersects(new Plane(0f, 0f, 1f, 0.5f)));
            Console.WriteLine(frustum.Intersects(new Plane(0f, 0f, 1f, 0.0f)));
            Console.WriteLine(frustum.Intersects(new Plane(0f, 0f, 1f, -0.5f)));
            Console.WriteLine(frustum.Intersects(new Plane(0f, 0f, 1f, -1.0f)));
            Console.WriteLine(frustum.Intersects(new Plane(0f, 0f, 1f, -1.5f)));
        }
    }
}
```
XNA output:
```
{X:-1 Y:1 Z:0}
{X:1 Y:1 Z:0}
{X:1 Y:-1 Z:0}
{X:-1 Y:-1 Z:0}
{X:-1 Y:1 Z:1}
{X:1 Y:1 Z:1}
{X:1 Y:-1 Z:1}
{X:-1 Y:-1 Z:1}
Front
Intersecting
Intersecting
Back
Back
```
FNA output:
```
{X:-1 Y:1 Z:0}
{X:1 Y:1 Z:0}
{X:1 Y:-1 Z:0}
{X:-1 Y:-1 Z:0}
{X:-1 Y:1 Z:1}
{X:1 Y:1 Z:1}
{X:1 Y:-1 Z:1}
{X:-1 Y:-1 Z:1}
Front
Intersecting
Intersecting
Intersecting
Back
```