### PR TITLE
optimize: Directly pass wave format without parse in SoundEffectReader and FromStream for SoundEffect. Swap Endiness with unsafe in SoundEffectReader.

### DIFF
--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -165,23 +165,17 @@ namespace Microsoft.Xna.Framework.Audio
 			int sampleRate,
 			AudioChannels channels
 		) : this(
-			string.Empty,
 			buffer,
 			0,
 			buffer.Length,
-			null,
-			1,
-			(ushort) channels,
-			(uint) sampleRate,
-			(uint) (sampleRate * ((ushort) channels * 2)),
-			(ushort) ((ushort) channels * 2),
-			16,
+			sampleRate,
+			channels,
 			0,
 			0
 		) {
 		}
 
-		public SoundEffect(
+		public unsafe SoundEffect(
 			byte[] buffer,
 			int offset,
 			int count,
@@ -189,79 +183,52 @@ namespace Microsoft.Xna.Framework.Audio
 			AudioChannels channels,
 			int loopStart,
 			int loopLength
-		) : this(
-			string.Empty,
-			buffer,
-			offset,
-			count,
-			null,
-			1,
-			(ushort) channels,
-			(uint) sampleRate,
-			(uint) (sampleRate * ((ushort) channels * 2)),
-			(ushort) ((ushort) channels * 2),
-			16,
-			loopStart,
-			loopLength
 		) {
+			int blockAlign = (int) channels * 2;
+
+			IntPtr formatPtr = FNAPlatform.Malloc(sizeof(FAudio.FAudioWaveFormatEx));
+			FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) formatPtr;
+
+			wfx->wFormatTag = 1;
+			wfx->nChannels = (ushort) channels;
+			wfx->nSamplesPerSec = (uint) sampleRate;
+			wfx->nAvgBytesPerSec = (uint) (blockAlign * sampleRate);
+			wfx->nBlockAlign = (ushort) blockAlign;
+			wfx->wBitsPerSample = 16;
+			wfx->cbSize = 0;
+
+			FromBuffer(string.Empty, buffer, offset, count, formatPtr, loopStart, loopLength);
 		}
 
 		#endregion
 
 		#region Internal Constructor
 
-		internal unsafe SoundEffect(
+		internal SoundEffect() { }
+
+		#endregion
+
+		#region Internal Methods
+
+		internal unsafe SoundEffect FromBuffer(
 			string name,
 			byte[] buffer,
 			int offset,
 			int count,
-			byte[] extraData,
-			ushort wFormatTag,
-			ushort nChannels,
-			uint nSamplesPerSec,
-			uint nAvgBytesPerSec,
-			ushort nBlockAlign,
-			ushort wBitsPerSample,
+			IntPtr formatPtr,
 			int loopStart,
 			int loopLength
 		) {
 			FAudio.FAudio_AddRef(Device().Handle);
 
+			FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) formatPtr;
 			this.name = name;
-			channels = nChannels;
-			sampleRate = nSamplesPerSec;
+			channels = wfx->nChannels;
+			sampleRate = wfx->nSamplesPerSec;
 			this.loopStart = (uint) loopStart;
 			this.loopLength = (uint) loopLength;
 
-			/* Buffer format */
-			if (extraData == null)
-			{
-				formatPtr = FNAPlatform.Malloc(
-					MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>()
-				);
-			}
-			else
-			{
-				formatPtr = FNAPlatform.Malloc(
-					MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>() +
-					extraData.Length
-				);
-				Marshal.Copy(
-					extraData,
-					0,
-					formatPtr + MarshalHelper.SizeOf<FAudio.FAudioWaveFormatEx>(),
-					extraData.Length
-				);
-			}
-
-			FAudio.FAudioWaveFormatEx* pcm = (FAudio.FAudioWaveFormatEx*) formatPtr;
-			pcm->wFormatTag = wFormatTag;
-			pcm->nChannels = nChannels;
-			pcm->nSamplesPerSec = nSamplesPerSec;
-			pcm->nAvgBytesPerSec = nAvgBytesPerSec;
-			pcm->nBlockAlign = nBlockAlign;
-			pcm->wBitsPerSample = wBitsPerSample;
-			pcm->cbSize = (ushort) ((extraData == null) ? 0 : extraData.Length);
+			this.formatPtr = formatPtr;
 
 			/* Easy stuff */
 			handle = new FAudio.FAudioBuffer();
@@ -280,23 +247,23 @@ namespace Microsoft.Xna.Framework.Audio
 
 			/* Play regions */
 			handle.PlayBegin = 0;
-			if (wFormatTag == 1)
+			if (wfx->wFormatTag == 1)
 			{
 				handle.PlayLength = (uint) (
 					count /
-					nChannels /
-					(wBitsPerSample / 8)
+					wfx->nChannels /
+					(wfx->wBitsPerSample / 8)
 				);
 			}
-			else if (wFormatTag == 2)
+			else if (wfx->wFormatTag == 2)
 			{
 				handle.PlayLength = (uint) (
 					count /
-					nBlockAlign *
-					(((nBlockAlign / nChannels) - 6) * 2)
+					wfx->nBlockAlign *
+					(((wfx->nBlockAlign / wfx->nChannels) - 6) * 2)
 				);
 			}
-			else if (wFormatTag == 0x166)
+			else if (wfx->wFormatTag == 0x166)
 			{
 				FAudio.FAudioXMA2WaveFormatEx* xma2 = (FAudio.FAudioXMA2WaveFormatEx*) formatPtr;
 				// dwSamplesEncoded / nChannels / (wBitsPerSample / 8) doesn't always (if ever?) match up.
@@ -307,6 +274,8 @@ namespace Microsoft.Xna.Framework.Audio
 			handle.LoopBegin = 0;
 			handle.LoopLength = 0;
 			handle.LoopCount = 0;
+
+			return this;
 		}
 
 		#endregion
@@ -437,7 +406,7 @@ namespace Microsoft.Xna.Framework.Audio
 			return INTERNAL_GetSampleSizeInBytes(duration, sampleRate, channels);
 		}
 
-		public static SoundEffect FromStream(Stream stream)
+		public static unsafe SoundEffect FromStream(Stream stream)
 		{
 			if (stream == null)
 			{
@@ -447,13 +416,7 @@ namespace Microsoft.Xna.Framework.Audio
 			byte[] data;
 
 			// WaveFormatEx data
-			ushort wFormatTag;
-			ushort nChannels;
-			uint nSamplesPerSec;
-			uint nAvgBytesPerSec;
-			ushort nBlockAlign;
-			ushort wBitsPerSample;
-			// ushort cbSize;
+			byte[] format;
 
 			int samplerLoopStart = 0;
 			int samplerLoopEnd = 0;
@@ -485,17 +448,10 @@ namespace Microsoft.Xna.Framework.Audio
 
 				int format_chunk_size = reader.ReadInt32();
 
-				wFormatTag = reader.ReadUInt16();
-				nChannels = reader.ReadUInt16();
-				nSamplesPerSec = reader.ReadUInt32();
-				nAvgBytesPerSec = reader.ReadUInt32();
-				nBlockAlign = reader.ReadUInt16();
-				wBitsPerSample = reader.ReadUInt16();
-
-				// Reads residual bytes
-				if (format_chunk_size > 16)
+				format = reader.ReadBytes(format_chunk_size);
+				if (format.Length < 16)
 				{
-					reader.ReadBytes(format_chunk_size - 16);
+					throw new InvalidOperationException();
 				}
 
 				// data Signature
@@ -569,18 +525,15 @@ namespace Microsoft.Xna.Framework.Audio
 				// End scan
 			}
 
-			return new SoundEffect(
+			IntPtr formatPtr = FNAPlatform.Malloc(format.Length);
+			Marshal.Copy(format, 0, formatPtr, format.Length);
+
+			return new SoundEffect().FromBuffer(
 				string.Empty,
 				data,
 				0,
 				data.Length,
-				null,
-				wFormatTag,
-				nChannels,
-				nSamplesPerSec,
-				nAvgBytesPerSec,
-				nBlockAlign,
-				wBitsPerSample,
+				formatPtr,
 				samplerLoopStart,
 				samplerLoopEnd - samplerLoopStart
 			);

--- a/src/Content/ContentReaders/SoundEffectReader.cs
+++ b/src/Content/ContentReaders/SoundEffectReader.cs
@@ -8,7 +8,8 @@
 #endregion
 
 #region Using Statements
-using System.IO;
+using System;
+using System.Runtime.InteropServices;
 
 using Microsoft.Xna.Framework.Audio;
 #endregion
@@ -19,7 +20,7 @@ namespace Microsoft.Xna.Framework.Content
 	{
 		#region Protected Read Method
 
-		protected internal override SoundEffect Read(
+		protected internal override unsafe SoundEffect Read(
 			ContentReader input,
 			SoundEffect existingInstance
 		) {
@@ -29,50 +30,9 @@ namespace Microsoft.Xna.Framework.Content
 			bool se = input.platform == 'x';
 
 			// Format block length
-			uint formatLength = input.ReadUInt32();
+			int formatLength = input.ReadInt32();
 
-			// WaveFormatEx data
-			ushort wFormatTag = Swap(se, input.ReadUInt16());
-			ushort nChannels = Swap(se, input.ReadUInt16());
-			uint nSamplesPerSec = Swap(se, input.ReadUInt32());
-			uint nAvgBytesPerSec = Swap(se, input.ReadUInt32());
-			ushort nBlockAlign = Swap(se, input.ReadUInt16());
-			ushort wBitsPerSample = Swap(se, input.ReadUInt16());
-
-			byte[] extra = null;
-			if (formatLength > 16)
-			{
-				ushort cbSize = Swap(se, input.ReadUInt16());
-
-				if (wFormatTag == 0x166 && cbSize == 34)
-				{
-					// XMA2 has got some nice extra crap.
-					extra = new byte[34];
-					using (MemoryStream extraStream = new MemoryStream(extra))
-					using (BinaryWriter extraWriter = new BinaryWriter(extraStream))
-					{
-						// See FAudio.FAudioXMA2WaveFormatEx for the layout.
-						extraWriter.Write(Swap(se, input.ReadUInt16()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(Swap(se, input.ReadUInt32()));
-						extraWriter.Write(input.ReadByte());
-						extraWriter.Write(input.ReadByte());
-						extraWriter.Write(Swap(se, input.ReadUInt16()));
-					}
-					// Is there any crap that needs skipping? Eh whatever.
-					input.ReadBytes((int) (formatLength - 18 - 34));
-				}
-				else
-				{
-					// Seek past the rest of this crap (cannot seek though!)
-					input.ReadBytes((int) (formatLength - 18));
-				}
-			}
+			byte[] format = input.ReadBytes(formatLength);
 
 			// Wavedata
 			byte[] data = input.ReadBytes(input.ReadInt32());
@@ -84,18 +44,43 @@ namespace Microsoft.Xna.Framework.Content
 			// Sound duration in milliseconds, unused
 			input.ReadUInt32();
 
-			return new SoundEffect(
+			IntPtr formatPtr = FNAPlatform.Malloc(format.Length);
+			Marshal.Copy(format, 0, formatPtr, format.Length);
+
+			if (format.Length >= 16)
+			{
+				FAudio.FAudioWaveFormatEx* wfx = (FAudio.FAudioWaveFormatEx*) formatPtr;
+				wfx->wFormatTag = Swap(se, wfx->wFormatTag);
+				wfx->nChannels = Swap(se, wfx->nChannels);
+				wfx->nSamplesPerSec = Swap(se, wfx->nSamplesPerSec);
+				wfx->nAvgBytesPerSec = Swap(se, wfx->nAvgBytesPerSec);
+				wfx->nBlockAlign = Swap(se, wfx->nBlockAlign);
+				wfx->wBitsPerSample = Swap(se, wfx->wBitsPerSample);
+				if (format.Length >= 18)
+				{
+					wfx->cbSize = Swap(se, wfx->cbSize);
+					if (format.Length >= 18 + 34 && wfx->wFormatTag == 0x166 && wfx->cbSize == 34)
+					{
+						FAudio.FAudioXMA2WaveFormatEx* xma2format = (FAudio.FAudioXMA2WaveFormatEx*) formatPtr;
+						xma2format->wNumStreams = Swap(se, xma2format->wNumStreams);
+						xma2format->dwChannelMask = Swap(se, xma2format->dwChannelMask);
+						xma2format->dwSamplesEncoded = Swap(se, xma2format->dwSamplesEncoded);
+						xma2format->dwBytesPerBlock = Swap(se, xma2format->dwBytesPerBlock);
+						xma2format->dwPlayBegin = Swap(se, xma2format->dwPlayBegin);
+						xma2format->dwPlayLength = Swap(se, xma2format->dwPlayLength);
+						xma2format->dwLoopBegin = Swap(se, xma2format->dwLoopBegin);
+						xma2format->dwLoopLength = Swap(se, xma2format->dwLoopLength);
+						xma2format->wBlockCount = Swap(se, xma2format->wBlockCount);
+					}
+				}
+			}
+
+			return new SoundEffect().FromBuffer(
 				input.AssetName,
 				data,
 				0,
 				data.Length,
-				extra,
-				wFormatTag,
-				nChannels,
-				nSamplesPerSec,
-				nAvgBytesPerSec,
-				nBlockAlign,
-				wBitsPerSample,
+				formatPtr,
 				loopStart,
 				loopLength
 			);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

