### PR TITLE
Fix GetSampleSizeInBytes and GetSampleDuration for SubmitFloatBufferEXT

### DIFF
--- a/src/Audio/DynamicSoundEffectInstance.cs
+++ b/src/Audio/DynamicSoundEffectInstance.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Xna.Framework.Audio
 			return SoundEffect.INTERNAL_GetSampleDuration(
 				sizeInBytes,
 				(int) format.nSamplesPerSec,
-				(AudioChannels) format.nChannels
+				format.nBlockAlign
 			);
 		}
 
@@ -149,7 +149,7 @@ namespace Microsoft.Xna.Framework.Audio
 			return SoundEffect.INTERNAL_GetSampleSizeInBytes(
 				duration,
 				(int) format.nSamplesPerSec,
-				(AudioChannels) format.nChannels
+				format.nBlockAlign
 			);
 		}
 

--- a/src/Audio/Microphone.cs
+++ b/src/Audio/Microphone.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Xna.Framework.Audio
 			return SoundEffect.INTERNAL_GetSampleDuration(
 				sizeInBytes,
 				SampleRate,
-				AudioChannels.Mono
+				2 // 16-bit PCM!
 			);
 		}
 
@@ -187,7 +187,7 @@ namespace Microsoft.Xna.Framework.Audio
 			return SoundEffect.INTERNAL_GetSampleSizeInBytes(
 				duration,
 				SampleRate,
-				AudioChannels.Mono
+				2 // 16-bit PCM!
 			);
 		}
 

--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				throw new ArgumentOutOfRangeException("channels");
 			}
-			return INTERNAL_GetSampleDuration(sizeInBytes, sampleRate, channels);
+			return INTERNAL_GetSampleDuration(sizeInBytes, sampleRate, 2 * (int) channels); // 16-bit PCM!
 		}
 
 		public static int GetSampleSizeInBytes(
@@ -434,7 +434,7 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				throw new ArgumentOutOfRangeException("channels");
 			}
-			return INTERNAL_GetSampleSizeInBytes(duration, sampleRate, channels);
+			return INTERNAL_GetSampleSizeInBytes(duration, sampleRate, 2 * (int) channels); // 16-bit PCM!
 		}
 
 		public static SoundEffect FromStream(Stream stream)
@@ -593,11 +593,10 @@ namespace Microsoft.Xna.Framework.Audio
 		internal static TimeSpan INTERNAL_GetSampleDuration(
 			int sizeInBytes,
 			int sampleRate,
-			AudioChannels channels
+			int blockAlign
 		) {
-			sizeInBytes /= 2; // 16-bit PCM!
 			int ms = (int) (
-				(sizeInBytes / (int) channels) /
+				(sizeInBytes / blockAlign) /
 				(sampleRate / 1000.0f)
 			);
 			return new TimeSpan(0, 0, 0, 0, ms);
@@ -606,13 +605,12 @@ namespace Microsoft.Xna.Framework.Audio
 		internal static int INTERNAL_GetSampleSizeInBytes(
 			TimeSpan duration,
 			int sampleRate,
-			AudioChannels channels
+			int blockAlign
 		) {
 			return (int) (
 				duration.TotalSeconds *
 				sampleRate *
-				(int) channels *
-				2 // 16-bit PCM!
+				blockAlign
 			);
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

