### PR TITLE
FACTENGINE_E_INVALIDDATA for WaveBank. Avoid resource leak for AudioEngine and WaveBank and SoundBank.

### DIFF
--- a/src/Audio/AudioEngine.cs
+++ b/src/Audio/AudioEngine.cs
@@ -179,10 +179,12 @@ namespace Microsoft.Xna.Framework.Audio
 			uint ret = FAudio.FACTAudioEngine_Initialize(handle, ref settings);
 			if (ret == 0x8ac70007) // FACTENGINE_E_INVALIDDATA
 			{
+				FAudio.FACTAudioEngine_Release(handle);
 				throw new ArgumentException("XACT could not load the data provided. Make sure you are using the correct version of the XACT tool.");
 			}
 			else if (ret != 0)
 			{
+				FAudio.FACTAudioEngine_Release(handle);
 				throw new InvalidOperationException(
 					"Engine initialization failed!"
 				);

--- a/src/Audio/SoundBank.cs
+++ b/src/Audio/SoundBank.cs
@@ -81,12 +81,11 @@ namespace Microsoft.Xna.Framework.Audio
 				0,
 				out handle
 			);
+			FNAPlatform.FreeFilePointer(buffer);
 			if (ret == 0x8ac70007) // FACTENGINE_E_INVALIDDATA
 			{
 				throw new ArgumentException("XACT could not load the data provided. Make sure you are using the correct version of the XACT tool.");
 			}
-
-			FNAPlatform.FreeFilePointer(buffer);
 
 			engine = audioEngine;
 			selfReference = new WeakReference(this, true);

--- a/src/Audio/WaveBank.cs
+++ b/src/Audio/WaveBank.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Xna.Framework.Audio
 				out bankDataLen
 			);
 
-			FAudio.FACTAudioEngine_CreateInMemoryWaveBank(
+			uint ret = FAudio.FACTAudioEngine_CreateInMemoryWaveBank(
 				audioEngine.handle,
 				bankData,
 				(uint) bankDataLen,
@@ -94,6 +94,11 @@ namespace Microsoft.Xna.Framework.Audio
 				0,
 				out handle
 			);
+			if (ret == 0x8ac70007) // FACTENGINE_E_INVALIDDATA
+			{
+				FNAPlatform.FreeFilePointer(bankData);
+				throw new ArgumentException("XACT could not load the data provided. Make sure you are using the correct version of the XACT tool.");
+			}
 
 			engine = audioEngine;
 			selfReference = new WeakReference(this, true);
@@ -137,6 +142,7 @@ namespace Microsoft.Xna.Framework.Audio
 			);
 			if (ret == 0x8ac70007) // FACTENGINE_E_INVALIDDATA
 			{
+				FAudio.FAudio_close(bankData);
 				throw new ArgumentException("XACT could not load the data provided. Make sure you are using the correct version of the XACT tool.");
 			}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

