### PR TITLE
Fix Exception for Stop in AudioCategory Cue

### DIFF
--- a/src/Audio/AudioCategory.cs
+++ b/src/Audio/AudioCategory.cs
@@ -94,6 +94,10 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public void Stop(AudioStopOptions options)
 		{
+			if (unchecked((uint) options) > 1)
+			{
+				throw new ArgumentException();
+			}
 			lock (parent.gcSync)
 			{
 				if (parent.IsDisposed)
@@ -103,9 +107,7 @@ namespace Microsoft.Xna.Framework.Audio
 				FAudio.FACTAudioEngine_Stop(
 					parent.handle,
 					index,
-					(options == AudioStopOptions.Immediate) ?
-						FAudio.FACT_FLAG_STOP_IMMEDIATE :
-						FAudio.FACT_FLAG_STOP_RELEASE
+					(uint) options
 				);
 			}
 		}

--- a/src/Audio/Cue.cs
+++ b/src/Audio/Cue.cs
@@ -264,11 +264,13 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public void Stop(AudioStopOptions options)
 		{
+			if (unchecked((uint) options) > 1)
+			{
+				throw new ArgumentException();
+			}
 			FAudio.FACTCue_Stop(
 				handle,
-				(options == AudioStopOptions.Immediate) ?
-					FAudio.FACT_FLAG_STOP_IMMEDIATE :
-					FAudio.FACT_FLAG_STOP_RELEASE
+				(uint) options
 			);
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            AudioEngine engine = new AudioEngine("Music.xgs");
            SoundBank soundBank = new SoundBank(engine, @"Sound Bank.xsb");
            WaveBank waveBank = new WaveBank(engine, @"Wave Bank.xwb", 0, 512);

            engine.Update();

            AudioStopOptions option2 = (AudioStopOptions) 2;
            AudioStopOptions option_1 = (AudioStopOptions) (-1);

            Cue cue = soundBank.GetCue("Music_100");
            ex(() => cue.Stop(option2));
            ex(() => cue.Stop(option_1));

            AudioCategory category = engine.GetCategory("Global");
            ex(() => category.Stop(option2));
            ex(() => category.Stop(option_1));

        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
System.ArgumentException: Value does not fall within the expected range.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 18
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 31

System.ArgumentException: Value does not fall within the expected range.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 19
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 31

System.ArgumentException: Value does not fall within the expected range.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 22
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 31

System.ArgumentException: Value does not fall within the expected range.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__3() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 23
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 31
```
FNA no any output