### PR TITLE
Check arguemnt for AudioCategory.SetVolume

### DIFF
--- a/src/Audio/AudioCategory.cs
+++ b/src/Audio/AudioCategory.cs
@@ -82,6 +82,10 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				throw new ArgumentException("Volume must be a positive float value.");
 			}
+			if (volume > FAudio.FACTVOLUME_MAX)
+			{
+				throw new ArgumentException();
+			}
 			lock (parent.gcSync)
 			{
 				if (parent.IsDisposed)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            AudioEngine engine = new AudioEngine("Music.xgs");

            engine.Update();

            AudioCategory category = engine.GetCategory("Global");
            ex(() => category.SetVolume(-1f));
            ex(() => category.SetVolume(123456789f));

        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
System.ArgumentException: Volume must be a positive float value.
   at Microsoft.Xna.Framework.Audio.AudioCategory.SetVolume(Single volume)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 16
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25

System.ArgumentException: Value does not fall within the expected range.
   at Microsoft.Xna.Framework.Audio.AudioCategory.SetVolume(Single volume)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 17
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25
```
FNA output:
```
System.ArgumentException: Volume must be a positive float value.
   at Microsoft.Xna.Framework.Audio.AudioCategory.SetVolume(Single volume)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 16
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25
```