### PR TITLE
Check wavebank in SoundBank.GetCue

### DIFF
--- a/src/Audio/SoundBank.cs
+++ b/src/Audio/SoundBank.cs
@@ -180,13 +180,15 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 
 			IntPtr result;
-			FAudio.FACTSoundBank_Prepare(
+			if (FAudio.FACTSoundBank_Prepare(
 				handle,
 				cue,
 				0,
 				0,
 				out result
-			);
+			) == 0x8AC70013) {
+				throw new InvalidOperationException("No wavebank exists for the requested operation.");
+			}
 			return new Cue(result, name, this);
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            AudioEngine engine = new AudioEngine("Music.xgs");
            SoundBank soundBank = new SoundBank(engine, @"Sound Bank.xsb");

            engine.Update();

            Console.WriteLine("Engine Updated");

            soundBank.GetCue("Music_100");

            Console.WriteLine("End");
        }
    }
}
```
XNA output:
```
Engine Updated

Unhandled Exception: System.InvalidOperationException: No wavebank exists for the requested operation.
   at Microsoft.Xna.Framework.Audio.SoundBank.GetCue(String name)
   at ConsoleApp5.Show.Main() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\show.cs:line 18
```
FNA output:
```
Engine Updated

Unhandled Exception: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at FAudio.FACTSoundBank_Prepare(IntPtr pSoundBank, UInt16 nCueIndex, UInt32 dwFlags, Int32 timeOffset, IntPtr& ppCue)
   at Microsoft.Xna.Framework.Audio.SoundBank.GetCue(String name)
   at ConsoleApp5.Show.Main() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\show.cs:line 16
```