### PR TITLE
throw Exception for AudioCategory when AudioEngine Disposed

### DIFF
--- a/src/Audio/AudioCategory.cs
+++ b/src/Audio/AudioCategory.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				if (parent.IsDisposed)
 				{
-					return;
+					throw new ArgumentException();
 				}
 				FAudio.FACTAudioEngine_Pause(parent.handle, index, 1);
 			}
@@ -70,7 +70,7 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				if (parent.IsDisposed)
 				{
-					return;
+					throw new ArgumentException();
 				}
 				FAudio.FACTAudioEngine_Pause(parent.handle, index, 0);
 			}
@@ -90,7 +90,7 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				if (parent.IsDisposed)
 				{
-					return;
+					throw new ArgumentException();
 				}
 				FAudio.FACTAudioEngine_SetVolume(parent.handle, index, volume);
 			}
@@ -106,7 +106,7 @@ namespace Microsoft.Xna.Framework.Audio
 			{
 				if (parent.IsDisposed)
 				{
-					return;
+					throw new ArgumentException();
 				}
 				FAudio.FACTAudioEngine_Stop(
 					parent.handle,


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            AudioEngine engine = new AudioEngine("Music.xgs");
            engine.Update();

            AudioCategory category = engine.GetCategory("Global");
            engine.Update();

            category.SetVolume(0.5f);
            category.Resume();
            category.Stop(AudioStopOptions.Immediate);

            engine.Update();

            category.SetVolume(0.5f);
            category.Resume();
            category.Stop(AudioStopOptions.Immediate);

            engine.Dispose();
            Console.WriteLine("Engine Disposed");

            ex(() => category.SetVolume(0.5f));
            ex(() => category.Resume());
            ex(() => category.Stop(AudioStopOptions.Immediate));
        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
Engine Disposed
System.ArgumentException: Value does not fall within the expected range.
   at Microsoft.Xna.Framework.Audio.AudioCategory.SetVolume(Single volume)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 30
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 39

System.ArgumentException: Value does not fall within the expected range.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 31
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 39

System.ArgumentException: Value does not fall within the expected range.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 32
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 39
```
FNA output:
```
Engine Disposed
```