### PR TITLE
Throw Exception when pass NaN for SoundEffect and SoundEffectInstance

### DIFF
--- a/src/Audio/SoundEffect.cs
+++ b/src/Audio/SoundEffect.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (value < -FAudio.FAUDIO_MAX_VOLUME_LEVEL || value > FAudio.FAUDIO_MAX_VOLUME_LEVEL) // XNA: value < 0f || value > 1f
+				if (!(value >= -FAudio.FAUDIO_MAX_VOLUME_LEVEL && value <= FAudio.FAUDIO_MAX_VOLUME_LEVEL)) // XNA: !(value >= 0f && value <= 1f)
 				{
 					throw new ArgumentOutOfRangeException("value");
 				}
@@ -108,7 +108,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (value < 0f)
+				if (!(value >= 0f))
 				{
 					throw new ArgumentOutOfRangeException("value");
 				}
@@ -124,7 +124,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (value <= 0f)
+				if (!(value > 0f))
 				{
 					throw new ArgumentOutOfRangeException("value");
 				}

--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (value < -1f || value > 1f)
+				if (!(value >= -1f && value <= 1f))
 				{
 					throw new ArgumentOutOfRangeException("value");
 				}
@@ -94,7 +94,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (value < -1f || value > 1f)
+				if (!(value >= -1f && value <= 1f))
 				{
 					throw new ArgumentOutOfRangeException("value");
 				}
@@ -143,7 +143,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (value < -FAudio.FAUDIO_MAX_VOLUME_LEVEL || value > FAudio.FAUDIO_MAX_VOLUME_LEVEL) // XNA: value < 0f || value > 1f
+				if (!(value >= -FAudio.FAUDIO_MAX_VOLUME_LEVEL && value <= FAudio.FAUDIO_MAX_VOLUME_LEVEL)) // XNA: !(value >= 0f && value <= 1f)
 				{
 					throw new ArgumentOutOfRangeException("value");
 				}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework.Audio;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            DynamicSoundEffectInstance dynamic = new DynamicSoundEffectInstance(44100, AudioChannels.Mono);
            ex(() => dynamic.Pan = 2f);
            ex(() => dynamic.Pan = float.NaN);
            ex(() => dynamic.Pitch = 2f);
            ex(() => dynamic.Pitch = float.NaN);
            ex(() => dynamic.Volume = 123456789f);
            ex(() => dynamic.Volume = float.NaN);

            Console.WriteLine("SoundEffect");

            ex(() => SoundEffect.MasterVolume = float.NaN);
            ex(() => SoundEffect.DopplerScale = float.NaN);
        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.set_Pan(Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 12
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.set_Pan(Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 13
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.set_Pitch(Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 14
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.set_Pitch(Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__3() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 15
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.set_Volume(Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__4() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 16
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.set_Volume(Single value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__5() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 17
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29

SoundEffect
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffect.set_MasterVolume(Single value)
   at EX.EX.<>c.<Main>b__0_6() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 21
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: value
   at Microsoft.Xna.Framework.Audio.SoundEffect.set_DopplerScale(Single value)
   at EX.EX.<>c.<Main>b__0_7() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 22
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29
```