### PR TITLE
optimize: Speed up Vector4.Dot and Vector4.Equals with SIMD

### DIFF
--- a/src/Vector4.cs
+++ b/src/Vector4.cs
@@ -230,10 +230,16 @@ namespace Microsoft.Xna.Framework
 		/// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
 		public bool Equals(Vector4 other)
 		{
+#if NETCOREAPP3_0_OR_GREATER
+			return Unsafe.As<Vector4, System.Numerics.Vector4>(ref this).Equals(
+				Unsafe.As<Vector4, System.Numerics.Vector4>(ref other)
+			);
+#else
 			return (	X == other.X &&
 					Y == other.Y &&
 					Z == other.Z &&
 					W == other.W	);
+#endif
 		}
 
 		/// <summary>
@@ -620,12 +626,19 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">The dot product of two vectors as an output parameter.</param>
 		public static void Dot(ref Vector4 vector1, ref Vector4 vector2, out float result)
 		{
+#if NETCOREAPP3_0_OR_GREATER
+			result = System.Numerics.Vector4.Dot(
+				Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector1),
+				Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector2)
+			);
+#else
 			result = (
 				(vector1.X * vector2.X) +
 				(vector1.Y * vector2.Y) +
 				(vector1.Z * vector2.Z) +
 				(vector1.W * vector2.W)
 			);
+#endif
 		}
 
 		/// <summary>
@@ -1410,15 +1423,25 @@ namespace Microsoft.Xna.Framework
 
 		public static bool operator ==(Vector4 value1, Vector4 value2)
 		{
+#if NETCOREAPP3_0_OR_GREATER
+			return Unsafe.As<Vector4, System.Numerics.Vector4>(ref value1)
+				== Unsafe.As<Vector4, System.Numerics.Vector4>(ref value2);
+#else
 			return (	value1.X == value2.X &&
 					value1.Y == value2.Y &&
 					value1.Z == value2.Z &&
 					value1.W == value2.W	);
+#endif
 		}
 
 		public static bool operator !=(Vector4 value1, Vector4 value2)
 		{
+#if NETCOREAPP3_0_OR_GREATER
+			return Unsafe.As<Vector4, System.Numerics.Vector4>(ref value1)
+				!= Unsafe.As<Vector4, System.Numerics.Vector4>(ref value2);
+#else
 			return !(value1 == value2);
+#endif
 		}
 
 		public static Vector4 operator +(Vector4 value1, Vector4 value2)

--- a/src/Vector4.cs
+++ b/src/Vector4.cs
@@ -15,6 +15,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 using Microsoft.Xna.Framework.Design;
 #endregion
@@ -596,12 +597,19 @@ namespace Microsoft.Xna.Framework
 		/// <returns>The dot product of two vectors.</returns>
 		public static float Dot(Vector4 vector1, Vector4 vector2)
 		{
+#if NETCOREAPP3_0_OR_GREATER
+			return System.Numerics.Vector4.Dot(
+				Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector1),
+				Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector2)
+			);
+#else
 			return (
 				vector1.X * vector2.X +
 				vector1.Y * vector2.Y +
 				vector1.Z * vector2.Z +
 				vector1.W * vector2.W
 			);
+#endif
 		}
 
 		/// <summary>


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Benchmark:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Runtime.CompilerServices;

namespace Microsoft.Xna.Framework
{
    public struct Vector4
    {
        public float X;
        public float Y;
        public float Z;
        public float W;
        public Vector4(float x, float y, float z, float w)
        {
            this.X = x;
            this.Y = y;
            this.Z = z;
            this.W = w;
        }
        public static float Dot1(Vector4 vector1, Vector4 vector2)
        {
            return (
                vector1.X * vector2.X +
                vector1.Y * vector2.Y +
                vector1.Z * vector2.Z +
                vector1.W * vector2.W
            );
        }
        public static float Dot2(Vector4 vector1, Vector4 vector2)
        {
            Dot(ref vector1, ref vector2, out float result);
            return result;
        }
        public static void Dot(ref Vector4 vector1, ref Vector4 vector2, out float result)
        {
            result = (
                (vector1.X * vector2.X) +
                (vector1.Y * vector2.Y) +
                (vector1.Z * vector2.Z) +
                (vector1.W * vector2.W)
            );
        }
        public static float NumericsDot(Vector4 vector1, Vector4 vector2)
        {
            return System.Numerics.Vector4.Dot(
                Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector1),
                Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector2)
            );
        }
        public static void NumericsDot(ref Vector4 vector1, ref Vector4 vector2, out float result)
        {
            result = System.Numerics.Vector4.Dot(
                Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector1),
                Unsafe.As<Vector4, System.Numerics.Vector4>(ref vector2)
            );
        }
    }
}

namespace Net8App
{
    [DisassemblyDiagnoser]
    public class Vector4DotBenchmark
    {
        static Random random = new Random();
        static float x1 = random.NextSingle();
        static float y1 = random.NextSingle();
        static float z1 = random.NextSingle();
        static float w1 = random.NextSingle();
        static float x2 = random.NextSingle();
        static float y2 = random.NextSingle();
        static float z2 = random.NextSingle();
        static float w2 = random.NextSingle();
        static Microsoft.Xna.Framework.Vector4 xnavec1 = new Microsoft.Xna.Framework.Vector4(x1, y1, z1, w1);
        static Microsoft.Xna.Framework.Vector4 xnavec2 = new Microsoft.Xna.Framework.Vector4(x2, y2, z2, w2);
        static System.Numerics.Vector4 vec1 = new System.Numerics.Vector4(x1, y1, z1, w1);
        static System.Numerics.Vector4 vec2 = new System.Numerics.Vector4(x2, y2, z2, w2);

        const int loop = 0xFF;
        [Benchmark]
        public float Manual1()
        {
            float sum = 0;
            for (int i = 0; i < loop; i++)
            {
                sum += Microsoft.Xna.Framework.Vector4.Dot1(xnavec1, xnavec2);
            }
            return sum;
        }
        [Benchmark]
        public float Manual2()
        {
            float sum = 0;
            for (int i = 0; i < loop; i++)
            {
                sum += Microsoft.Xna.Framework.Vector4.Dot2(xnavec1, xnavec2);
            }
            return sum;
        }
        [Benchmark]
        public float ManualRef()
        {
            float sum = 0;
            for (int i = 0; i < loop; i++)
            {
                Microsoft.Xna.Framework.Vector4.Dot(ref xnavec1, ref xnavec2, out float result);
                sum += result;
            }
            return sum;
        }
        [Benchmark]
        public float Numerics()
        {
            float sum = 0;
            for (int i = 0; i < loop; i++)
            {
                sum += System.Numerics.Vector4.Dot(vec1, vec2);
            }
            return sum;
        }
        [Benchmark]
        public unsafe float Transform()
        {
            float sum = 0;
            for (int i = 0; i < loop; i++)
            {
                sum += Microsoft.Xna.Framework.Vector4.NumericsDot(xnavec1, xnavec2);
            }
            return sum;
        }
        [Benchmark]
        public unsafe float TransformRef()
        {
            float sum = 0;
            for (int i = 0; i < loop; i++)
            {
                Microsoft.Xna.Framework.Vector4.NumericsDot(ref xnavec1, ref xnavec2, out float result);
                sum += result;
            }
            return sum;
        }
    }

    static class Program
    {
        [STAThread]
        static void Main()
        {
            BenchmarkRunner.Run<Vector4DotBenchmark>();
        }
    }
}
```
## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.Manual1()
       sub       rsp,0B8
       vzeroupper
       vmovaps   [rsp+0A0],xmm6
       vmovaps   [rsp+90],xmm7
       vmovaps   [rsp+80],xmm8
       vmovaps   [rsp+70],xmm9
       vmovaps   [rsp+60],xmm10
       vmovaps   [rsp+50],xmm11
       vmovaps   [rsp+40],xmm12
       vmovaps   [rsp+30],xmm13
       vmovaps   [rsp+20],xmm14
       vmovaps   [rsp+10],xmm15
       vxorps    xmm0,xmm0,xmm0
       xor       eax,eax
       mov       rcx,2402C288DC8
       vmovss    xmm1,dword ptr [rcx]
       vmovss    dword ptr [rsp+0C],xmm1
       vmovss    xmm2,dword ptr [rcx+4]
       vmovss    xmm3,dword ptr [rcx+8]
       vmovss    xmm4,dword ptr [rcx+0C]
       mov       rcx,2402C288DE8
       vmovss    xmm5,dword ptr [rcx]
       vmovss    xmm6,dword ptr [rcx+4]
       vmovss    xmm7,dword ptr [rcx+8]
       vmovss    xmm8,dword ptr [rcx+0C]
M00_L00:
       vmovaps   xmm9,xmm1
       vmovaps   xmm10,xmm2
       vmovaps   xmm11,xmm3
       vmovaps   xmm12,xmm4
       vmovaps   xmm13,xmm5
       vmovaps   xmm14,xmm6
       vmovaps   xmm15,xmm7
       vmovaps   xmm1,xmm8
       vmulss    xmm9,xmm9,xmm13
       vmulss    xmm10,xmm10,xmm14
       vaddss    xmm9,xmm9,xmm10
       vmulss    xmm10,xmm11,xmm15
       vaddss    xmm9,xmm9,xmm10
       vmulss    xmm1,xmm12,xmm1
       vaddss    xmm1,xmm9,xmm1
       vaddss    xmm0,xmm1,xmm0
       inc       eax
       cmp       eax,0FF
       vmovss    xmm1,dword ptr [rsp+0C]
       jl        short M00_L00
       vmovaps   xmm6,[rsp+0A0]
       vmovaps   xmm7,[rsp+90]
       vmovaps   xmm8,[rsp+80]
       vmovaps   xmm9,[rsp+70]
       vmovaps   xmm10,[rsp+60]
       vmovaps   xmm11,[rsp+50]
       vmovaps   xmm12,[rsp+40]
       vmovaps   xmm13,[rsp+30]
       vmovaps   xmm14,[rsp+20]
       vmovaps   xmm15,[rsp+10]
       add       rsp,0B8
       ret
; Total bytes of code 311
```

## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.Manual2()
       sub       rsp,0B8
       vzeroupper
       vmovaps   [rsp+0A0],xmm6
       vmovaps   [rsp+90],xmm7
       vmovaps   [rsp+80],xmm8
       vmovaps   [rsp+70],xmm9
       vmovaps   [rsp+60],xmm10
       vmovaps   [rsp+50],xmm11
       vmovaps   [rsp+40],xmm12
       vmovaps   [rsp+30],xmm13
       vmovaps   [rsp+20],xmm14
       vmovaps   [rsp+10],xmm15
       vxorps    xmm0,xmm0,xmm0
       xor       eax,eax
       mov       rcx,27B92E38DC8
       vmovss    xmm1,dword ptr [rcx]
       vmovss    dword ptr [rsp+0C],xmm1
       vmovss    xmm2,dword ptr [rcx+4]
       vmovss    xmm3,dword ptr [rcx+8]
       vmovss    xmm4,dword ptr [rcx+0C]
       mov       rcx,27B92E38DE8
       vmovss    xmm5,dword ptr [rcx]
       vmovss    xmm6,dword ptr [rcx+4]
       vmovss    xmm7,dword ptr [rcx+8]
       vmovss    xmm8,dword ptr [rcx+0C]
M00_L00:
       vmovaps   xmm9,xmm1
       vmovaps   xmm10,xmm2
       vmovaps   xmm11,xmm3
       vmovaps   xmm12,xmm4
       vmovaps   xmm13,xmm5
       vmovaps   xmm14,xmm6
       vmovaps   xmm15,xmm7
       vmovaps   xmm1,xmm8
       vmulss    xmm9,xmm9,xmm13
       vmulss    xmm10,xmm10,xmm14
       vaddss    xmm9,xmm9,xmm10
       vmulss    xmm10,xmm11,xmm15
       vaddss    xmm9,xmm9,xmm10
       vmulss    xmm1,xmm12,xmm1
       vaddss    xmm1,xmm9,xmm1
       vaddss    xmm0,xmm1,xmm0
       inc       eax
       cmp       eax,0FF
       vmovss    xmm1,dword ptr [rsp+0C]
       jl        short M00_L00
       vmovaps   xmm6,[rsp+0A0]
       vmovaps   xmm7,[rsp+90]
       vmovaps   xmm8,[rsp+80]
       vmovaps   xmm9,[rsp+70]
       vmovaps   xmm10,[rsp+60]
       vmovaps   xmm11,[rsp+50]
       vmovaps   xmm12,[rsp+40]
       vmovaps   xmm13,[rsp+30]
       vmovaps   xmm14,[rsp+20]
       vmovaps   xmm15,[rsp+10]
       add       rsp,0B8
       ret
; Total bytes of code 311
```

## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.ManualRef()
       sub       rsp,48
       vzeroupper
       vmovaps   [rsp+30],xmm6
       vmovaps   [rsp+20],xmm7
       vmovaps   [rsp+10],xmm8
       vmovaps   [rsp],xmm9
       vxorps    xmm0,xmm0,xmm0
       xor       eax,eax
       mov       rcx,15E01A68DC8
       vmovss    xmm1,dword ptr [rcx]
       mov       rdx,15E01A68DE8
       vmulss    xmm1,xmm1,dword ptr [rdx]
       vmovss    xmm2,dword ptr [rcx+4]
       vmovss    xmm3,dword ptr [rdx+4]
       vmovss    xmm4,dword ptr [rcx+8]
       vmovss    xmm5,dword ptr [rdx+8]
       vmovss    xmm6,dword ptr [rcx+0C]
       vmovss    xmm7,dword ptr [rdx+0C]
       xchg      ax,ax
M00_L00:
       vmulss    xmm8,xmm2,xmm3
       vaddss    xmm8,xmm8,xmm1
       vmulss    xmm9,xmm4,xmm5
       vaddss    xmm8,xmm8,xmm9
       vmulss    xmm9,xmm6,xmm7
       vaddss    xmm8,xmm8,xmm9
       vaddss    xmm0,xmm0,xmm8
       inc       eax
       cmp       eax,0FF
       jl        short M00_L00
       vmovaps   xmm6,[rsp+30]
       vmovaps   xmm7,[rsp+20]
       vmovaps   xmm8,[rsp+10]
       vmovaps   xmm9,[rsp]
       add       rsp,48
       ret
; Total bytes of code 164
```

## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.Numerics()
       vzeroupper
       vxorps    xmm0,xmm0,xmm0
       xor       eax,eax
       mov       rcx,235A9828DC8
       vmovups   xmm1,[rcx]
       mov       rcx,235A9828DE8
       vdpps     xmm1,xmm1,[rcx],0FF
M00_L00:
       vaddss    xmm0,xmm1,xmm0
       inc       eax
       cmp       eax,0FF
       jl        short M00_L00
       ret
; Total bytes of code 53
```

## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.Transform()
       vzeroupper
       vxorps    xmm0,xmm0,xmm0
       xor       eax,eax
       mov       rcx,29551BF8DC8
       vmovups   xmm1,[rcx]
       mov       rcx,29551BF8DE8
       vdpps     xmm1,xmm1,[rcx],0FF
M00_L00:
       vaddss    xmm0,xmm1,xmm0
       inc       eax
       cmp       eax,0FF
       jl        short M00_L00
       ret
; Total bytes of code 53
```

## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.TransformRef()
       vzeroupper
       vxorps    xmm0,xmm0,xmm0
       xor       eax,eax
       mov       rcx,25A84F08DC8
       vmovups   xmm1,[rcx]
       mov       rcx,25A84F08DE8
       vdpps     xmm1,xmm1,[rcx],0FF
M00_L00:
       vaddss    xmm0,xmm1,xmm0
       inc       eax
       cmp       eax,0FF
       jl        short M00_L00
       ret
; Total bytes of code 53
```

result:
| Method       | Mean     | Error   | StdDev  | Code Size |
|------------- |---------:|--------:|--------:|----------:|
| Manual1      | 280.9 ns | 0.38 ns | 0.34 ns |     311 B |
| Manual2      | 282.2 ns | 1.34 ns | 1.25 ns |     311 B |
| ManualRef    | 181.5 ns | 0.49 ns | 0.43 ns |     164 B |
| Numerics     | 169.5 ns | 0.33 ns | 0.29 ns |      53 B |
| Transform    | 169.3 ns | 0.23 ns | 0.19 ns |      53 B |
| TransformRef | 169.4 ns | 0.42 ns | 0.39 ns |      53 B |