### PR TITLE
Throw Exception when pass NaN for AudioEmitter.DopplerScale

### DIFF
--- a/src/Audio/AudioEmitter.cs
+++ b/src/Audio/AudioEmitter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			set
 			{
-				if (value < 0f)
+				if (!(value >= 0f))
 				{
 					throw new ArgumentOutOfRangeException("value", "The doppler scale of an audio emitter must be greater than or equal to zero.");
 				}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

