### PR TITLE
Speed up Sqrt and Sin and Cos and Tan and Acos with MathF instead of Math

### DIFF
--- a/src/BoundingSphere.cs
+++ b/src/BoundingSphere.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Xna.Framework
 			sphere.Center = Vector3.Transform(this.Center, matrix);
 			sphere.Radius = this.Radius *
 				(
-					(float) Math.Sqrt((double) Math.Max(
+					MathF.Sqrt(Math.Max(
 						((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13),
 						Math.Max(
 							((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23),
@@ -112,7 +112,7 @@ namespace Microsoft.Xna.Framework
 			result.Center = Vector3.Transform(this.Center, matrix);
 			result.Radius = this.Radius *
 				(
-					(float) Math.Sqrt((double) Math.Max(
+					MathF.Sqrt(Math.Max(
 						((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13),
 						Math.Max(
 							((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23),
@@ -451,7 +451,7 @@ namespace Microsoft.Xna.Framework
 				float sqDist = diff.LengthSquared();
 				if (sqDist > sqRadius)
 				{
-					float distance = (float) Math.Sqrt(sqDist); // equal to diff.Length();
+					float distance = MathF.Sqrt(sqDist); // equal to diff.Length();
 					Vector3 direction = diff / distance;
 					Vector3 G = center - radius * direction;
 					center = (G + pt) / 2;

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -458,7 +458,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				color,
 				origin.X / sourceW / (float) texture.Width,
 				origin.Y / sourceH / (float) texture.Height,
-				(float) Math.Sin(rotation),
+				MathF.Sin(rotation),
 				(float) Math.Cos(rotation),
 				layerDepth,
 				(int) (effects & (SpriteEffects) 0x03)
@@ -515,7 +515,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				color,
 				origin.X / sourceW / (float) texture.Width,
 				origin.Y / sourceH / (float) texture.Height,
-				(float) Math.Sin(rotation),
+				MathF.Sin(rotation),
 				(float) Math.Cos(rotation),
 				layerDepth,
 				(int) (effects & (SpriteEffects) 0x03)
@@ -635,7 +635,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				color,
 				origin.X / sourceW / (float) texture.Width,
 				origin.Y / sourceH / (float) texture.Height,
-				(float) Math.Sin(rotation),
+				MathF.Sin(rotation),
 				(float) Math.Cos(rotation),
 				layerDepth,
 				(int) (effects & (SpriteEffects) 0x03)
@@ -840,7 +840,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					color,
 					offsetX / sourceW / (float) textureValue.Width,
 					offsetY / sourceH / (float) textureValue.Height,
-					(float) Math.Sin(rotation),
+					MathF.Sin(rotation),
 					(float) Math.Cos(rotation),
 					layerDepth,
 					(int) effects
@@ -1036,7 +1036,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					color,
 					offsetX / sourceW / (float) textureValue.Width,
 					offsetY / sourceH / (float) textureValue.Height,
-					(float) Math.Sin(rotation),
+					MathF.Sin(rotation),
 					(float) Math.Cos(rotation),
 					layerDepth,
 					(int) effects

--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				origin.X / sourceW / (float) texture.Width,
 				origin.Y / sourceH / (float) texture.Height,
 				MathF.Sin(rotation),
-				(float) Math.Cos(rotation),
+				MathF.Cos(rotation),
 				layerDepth,
 				(int) (effects & (SpriteEffects) 0x03)
 			);
@@ -516,7 +516,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				origin.X / sourceW / (float) texture.Width,
 				origin.Y / sourceH / (float) texture.Height,
 				MathF.Sin(rotation),
-				(float) Math.Cos(rotation),
+				MathF.Cos(rotation),
 				layerDepth,
 				(int) (effects & (SpriteEffects) 0x03)
 			);
@@ -636,7 +636,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				origin.X / sourceW / (float) texture.Width,
 				origin.Y / sourceH / (float) texture.Height,
 				MathF.Sin(rotation),
-				(float) Math.Cos(rotation),
+				MathF.Cos(rotation),
 				layerDepth,
 				(int) (effects & (SpriteEffects) 0x03)
 			);
@@ -841,7 +841,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					offsetX / sourceW / (float) textureValue.Width,
 					offsetY / sourceH / (float) textureValue.Height,
 					MathF.Sin(rotation),
-					(float) Math.Cos(rotation),
+					MathF.Cos(rotation),
 					layerDepth,
 					(int) effects
 				);
@@ -1037,7 +1037,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					offsetX / sourceW / (float) textureValue.Width,
 					offsetY / sourceH / (float) textureValue.Height,
 					MathF.Sin(rotation),
-					(float) Math.Cos(rotation),
+					MathF.Cos(rotation),
 					layerDepth,
 					(int) effects
 				);

--- a/src/MathHelper.cs
+++ b/src/MathHelper.cs
@@ -430,6 +430,7 @@ namespace Microsoft.Xna.Framework
 
 		#endregion
 	}
+
 	#region MathF
 #if !NETCOREAPP2_0_OR_GREATER
 	static class MathF
@@ -438,7 +439,12 @@ namespace Microsoft.Xna.Framework
 		{
 			return (float) Math.Sqrt(x);
 		}
+		internal static float Sin(float x)
+		{
+			return (float) Math.Sin(x);
+		}
 	}
 #endif
 	#endregion
+
 }

--- a/src/MathHelper.cs
+++ b/src/MathHelper.cs
@@ -443,6 +443,10 @@ namespace Microsoft.Xna.Framework
 		{
 			return (float) Math.Sin(x);
 		}
+		internal static float Cos(float x)
+		{
+			return (float) Math.Cos(x);
+		}
 	}
 #endif
 	#endregion

--- a/src/MathHelper.cs
+++ b/src/MathHelper.cs
@@ -430,4 +430,15 @@ namespace Microsoft.Xna.Framework
 
 		#endregion
 	}
+	#region MathF
+#if !NETCOREAPP2_0_OR_GREATER
+	static class MathF
+	{
+		internal static float Sqrt(float x)
+		{
+			return (float) Math.Sqrt(x);
+		}
+	}
+#endif
+	#endregion
 }

--- a/src/MathHelper.cs
+++ b/src/MathHelper.cs
@@ -435,17 +435,25 @@ namespace Microsoft.Xna.Framework
 #if !NETCOREAPP2_0_OR_GREATER
 	static class MathF
 	{
-		internal static float Sqrt(float x)
+		internal static float Acos(float x)
 		{
-			return (float) Math.Sqrt(x);
+			return (float) Math.Acos(x);
+		}
+		internal static float Cos(float x)
+		{
+			return (float) Math.Cos(x);
 		}
 		internal static float Sin(float x)
 		{
 			return (float) Math.Sin(x);
 		}
-		internal static float Cos(float x)
+		internal static float Sqrt(float x)
 		{
-			return (float) Math.Cos(x);
+			return (float) Math.Sqrt(x);
+		}
+		internal static float Tan(float x)
+		{
+			return (float) Math.Tan(x);
 		}
 	}
 #endif

--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -1200,7 +1200,7 @@ namespace Microsoft.Xna.Framework
 			{
 				throw new ArgumentException("nearPlaneDistance >= farPlaneDistance");
 			}
-			float num = 1f / ((float) Math.Tan((double) (fieldOfView * 0.5f)));
+			float num = 1f / MathF.Tan(fieldOfView * 0.5f);
 			float num9 = num / aspectRatio;
 			result.M11 = num9;
 			result.M12 = result.M13 = result.M14 = 0;

--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -804,7 +804,7 @@ namespace Microsoft.Xna.Framework
 			float y = axis.Y;
 			float z = axis.Z;
 			float num2 = MathF.Sin(angle);
-			float num = (float) Math.Cos((double) angle);
+			float num = MathF.Cos(angle);
 			float num11 = x * x;
 			float num10 = y * y;
 			float num9 = z * z;
@@ -1314,7 +1314,7 @@ namespace Microsoft.Xna.Framework
 		{
 			result = Matrix.Identity;
 
-			float val1 = (float) Math.Cos(radians);
+			float val1 = MathF.Cos(radians);
 			float val2 = MathF.Sin(radians);
 
 			result.M22 = val1;
@@ -1344,7 +1344,7 @@ namespace Microsoft.Xna.Framework
 		{
 			result = Matrix.Identity;
 
-			float val1 = (float) Math.Cos(radians);
+			float val1 = MathF.Cos(radians);
 			float val2 = MathF.Sin(radians);
 
 			result.M11 = val1;
@@ -1374,7 +1374,7 @@ namespace Microsoft.Xna.Framework
 		{
 			result = Matrix.Identity;
 
-			float val1 = (float) Math.Cos(radians);
+			float val1 = MathF.Cos(radians);
 			float val2 = MathF.Sin(radians);
 
 			result.M11 = val1;

--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -803,7 +803,7 @@ namespace Microsoft.Xna.Framework
 			float x = axis.X;
 			float y = axis.Y;
 			float z = axis.Z;
-			float num2 = (float) Math.Sin((double) angle);
+			float num2 = MathF.Sin(angle);
 			float num = (float) Math.Cos((double) angle);
 			float num11 = x * x;
 			float num10 = y * y;
@@ -1315,7 +1315,7 @@ namespace Microsoft.Xna.Framework
 			result = Matrix.Identity;
 
 			float val1 = (float) Math.Cos(radians);
-			float val2 = (float) Math.Sin(radians);
+			float val2 = MathF.Sin(radians);
 
 			result.M22 = val1;
 			result.M23 = val2;
@@ -1345,7 +1345,7 @@ namespace Microsoft.Xna.Framework
 			result = Matrix.Identity;
 
 			float val1 = (float) Math.Cos(radians);
-			float val2 = (float) Math.Sin(radians);
+			float val2 = MathF.Sin(radians);
 
 			result.M11 = val1;
 			result.M13 = -val2;
@@ -1375,7 +1375,7 @@ namespace Microsoft.Xna.Framework
 			result = Matrix.Identity;
 
 			float val1 = (float) Math.Cos(radians);
-			float val2 = (float) Math.Sin(radians);
+			float val2 = MathF.Sin(radians);
 
 			result.M11 = val1;
 			result.M12 = val2;

--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -356,9 +356,9 @@ namespace Microsoft.Xna.Framework
 			float ys = (Math.Sign(M21 * M22 * M23 * M24) < 0) ? -1 : 1;
 			float zs = (Math.Sign(M31 * M32 * M33 * M34) < 0) ? -1 : 1;
 
-			scale.X = xs * (float) Math.Sqrt(M11 * M11 + M12 * M12 + M13 * M13);
-			scale.Y = ys * (float) Math.Sqrt(M21 * M21 + M22 * M22 + M23 * M23);
-			scale.Z = zs * (float) Math.Sqrt(M31 * M31 + M32 * M32 + M33 * M33);
+			scale.X = xs * MathF.Sqrt(M11 * M11 + M12 * M12 + M13 * M13);
+			scale.Y = ys * MathF.Sqrt(M21 * M21 + M22 * M22 + M23 * M23);
+			scale.Z = zs * MathF.Sqrt(M31 * M31 + M32 * M32 + M33 * M33);
 
 			if (	MathHelper.WithinEpsilon(scale.X, 0.0f) ||
 				MathHelper.WithinEpsilon(scale.Y, 0.0f) ||
@@ -624,7 +624,7 @@ namespace Microsoft.Xna.Framework
 			{
 				Vector3.Multiply(
 					ref cameraDir,
-					(float) (1f / ((float) Math.Sqrt((double) num))),
+					1f / MathF.Sqrt(num),
 					out cameraDir
 				);
 			}
@@ -712,7 +712,7 @@ namespace Microsoft.Xna.Framework
 			{
 				Vector3.Multiply(
 					ref vector2,
-					(float) (1f / ((float) Math.Sqrt((double) num2))),
+					1f / MathF.Sqrt(num2),
 					out vector2
 				);
 			}

--- a/src/Quaternion.cs
+++ b/src/Quaternion.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Xna.Framework
 			out Quaternion result
 		) {
 			float half = angle * 0.5f;
-			float sin = (float) Math.Sin((double) half);
+			float sin = MathF.Sin(half);
 			float cos = (float) Math.Cos((double) half);
 			result.X = axis.X * sin;
 			result.Y = axis.Y * sin;
@@ -479,13 +479,13 @@ namespace Microsoft.Xna.Framework
 			out Quaternion result)
 		{
 			float halfRoll = roll * 0.5f;
-			float sinRoll = (float) Math.Sin(halfRoll);
+			float sinRoll = MathF.Sin(halfRoll);
 			float cosRoll = (float) Math.Cos(halfRoll);
 			float halfPitch = pitch * 0.5f;
-			float sinPitch = (float) Math.Sin(halfPitch);
+			float sinPitch = MathF.Sin(halfPitch);
 			float cosPitch = (float) Math.Cos(halfPitch);
 			float halfYaw = yaw * 0.5f;
-			float sinYaw = (float) Math.Sin(halfYaw);
+			float sinYaw = MathF.Sin(halfYaw);
 			float cosYaw = (float) Math.Cos(halfYaw);
 			result.X = ((cosYaw * sinPitch) * cosRoll) + ((sinYaw * cosPitch) * sinRoll);
 			result.Y = ((sinYaw * cosPitch) * cosRoll) - ((cosYaw * sinPitch) * sinRoll);
@@ -727,9 +727,9 @@ namespace Microsoft.Xna.Framework
 			else
 			{
 				float num5 = (float) Math.Acos((double) num4);
-				float num6 = (float) (1.0 / Math.Sin((double) num5));
-				num3 = ((float) Math.Sin((double) ((1f - num) * num5))) * num6;
-				num2 = flag * (((float) Math.Sin((double) (num * num5))) * num6);
+				float num6 = 1f / MathF.Sin(num5);
+				num3 = MathF.Sin((1f - num) * num5) * num6;
+				num2 = flag * (MathF.Sin(num * num5) * num6);
 			}
 			result.X = (num3 * quaternion1.X) + (num2 * quaternion2.X);
 			result.Y = (num3 * quaternion1.Y) + (num2 * quaternion2.Y);

--- a/src/Quaternion.cs
+++ b/src/Quaternion.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Xna.Framework
 		) {
 			float half = angle * 0.5f;
 			float sin = MathF.Sin(half);
-			float cos = (float) Math.Cos((double) half);
+			float cos = MathF.Cos(half);
 			result.X = axis.X * sin;
 			result.Y = axis.Y * sin;
 			result.Z = axis.Z * sin;
@@ -480,13 +480,13 @@ namespace Microsoft.Xna.Framework
 		{
 			float halfRoll = roll * 0.5f;
 			float sinRoll = MathF.Sin(halfRoll);
-			float cosRoll = (float) Math.Cos(halfRoll);
+			float cosRoll = MathF.Cos(halfRoll);
 			float halfPitch = pitch * 0.5f;
 			float sinPitch = MathF.Sin(halfPitch);
-			float cosPitch = (float) Math.Cos(halfPitch);
+			float cosPitch = MathF.Cos(halfPitch);
 			float halfYaw = yaw * 0.5f;
 			float sinYaw = MathF.Sin(halfYaw);
-			float cosYaw = (float) Math.Cos(halfYaw);
+			float cosYaw = MathF.Cos(halfYaw);
 			result.X = ((cosYaw * sinPitch) * cosRoll) + ((sinYaw * cosPitch) * sinRoll);
 			result.Y = ((sinYaw * cosPitch) * cosRoll) - ((cosYaw * sinPitch) * sinRoll);
 			result.Z = ((cosYaw * cosPitch) * sinRoll) - ((sinYaw * sinPitch) * cosRoll);

--- a/src/Quaternion.cs
+++ b/src/Quaternion.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Xna.Framework
 				(this.Z * this.Z) +
 				(this.W * this.W)
 			);
-			return (float) Math.Sqrt((double) num);
+			return MathF.Sqrt(num);
 		}
 
 		/// <summary>
@@ -212,12 +212,12 @@ namespace Microsoft.Xna.Framework
 		/// </summary>
 		public void Normalize()
 		{
-			float num = 1.0f / ((float) Math.Sqrt(
+			float num = 1.0f / MathF.Sqrt(
 				(X * X) +
 				(Y * Y) +
 				(Z * Z) +
 				(W * W)
-			));
+			);
 			this.X *= num;
 			this.Y *= num;
 			this.Z *= num;
@@ -411,7 +411,7 @@ namespace Microsoft.Xna.Framework
 
 			if (scale > 0.0f)
 			{
-				sqrt = (float) Math.Sqrt(scale + 1.0f);
+				sqrt = MathF.Sqrt(scale + 1.0f);
 				result.W = sqrt * 0.5f;
 				sqrt = 0.5f / sqrt;
 
@@ -421,7 +421,7 @@ namespace Microsoft.Xna.Framework
 			}
 			else if ((matrix.M11 >= matrix.M22) && (matrix.M11 >= matrix.M33))
 			{
-				sqrt = (float) Math.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
+				sqrt = MathF.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
 				half = 0.5f / sqrt;
 
 				result.X = 0.5f * sqrt;
@@ -431,7 +431,7 @@ namespace Microsoft.Xna.Framework
 			}
 			else if (matrix.M22 > matrix.M33)
 			{
-				sqrt = (float) Math.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
+				sqrt = MathF.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
 				half = 0.5f/sqrt;
 
 				result.X = (matrix.M21 + matrix.M12)*half;
@@ -441,7 +441,7 @@ namespace Microsoft.Xna.Framework
 			}
 			else
 			{
-				sqrt = (float) Math.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
+				sqrt = MathF.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
 				half = 0.5f / sqrt;
 
 				result.X = (matrix.M31 + matrix.M13) * half;
@@ -667,7 +667,7 @@ namespace Microsoft.Xna.Framework
 				(result.Z * result.Z) +
 				(result.W * result.W)
 			);
-			float num3 = 1f / ((float) Math.Sqrt((double) num4));
+			float num3 = 1f / MathF.Sqrt(num4);
 			result.X *= num3;
 			result.Y *= num3;
 			result.Z *= num3;
@@ -886,12 +886,12 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">The unit length quaternion an output parameter.</param>
 		public static void Normalize(ref Quaternion quaternion, out Quaternion result)
 		{
-			float num = 1.0f / ((float) Math.Sqrt(
+			float num = 1.0f / MathF.Sqrt(
 				(quaternion.X * quaternion.X) +
 				(quaternion.Y * quaternion.Y) +
 				(quaternion.Z * quaternion.Z) +
 				(quaternion.W * quaternion.W)
-			));
+			);
 			result.X = quaternion.X * num;
 			result.Y = quaternion.Y * num;
 			result.Z = quaternion.Z * num;

--- a/src/Quaternion.cs
+++ b/src/Quaternion.cs
@@ -726,7 +726,7 @@ namespace Microsoft.Xna.Framework
 			}
 			else
 			{
-				float num5 = (float) Math.Acos((double) num4);
+				float num5 = MathF.Acos(num4);
 				float num6 = 1f / MathF.Sin(num5);
 				num3 = MathF.Sin((1f - num) * num5) * num6;
 				num2 = flag * (MathF.Sin(num * num5) * num6);

--- a/src/Ray.cs
+++ b/src/Ray.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Xna.Framework
 				differenceLengthSquared
 			);
 
-			result = (dist < 0) ? null : distanceAlongRay - (float?) Math.Sqrt(dist);
+			result = (dist < 0) ? null : distanceAlongRay - (float?) MathF.Sqrt(dist);
 		}
 
 		#endregion

--- a/src/Vector2.cs
+++ b/src/Vector2.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>The length of this <see cref="Vector2"/>.</returns>
 		public float Length()
 		{
-			return (float) Math.Sqrt((X * X) + (Y * Y));
+			return MathF.Sqrt((X * X) + (Y * Y));
 		}
 
 		/// <summary>
@@ -197,7 +197,7 @@ namespace Microsoft.Xna.Framework
 		/// </summary>
 		public void Normalize()
 		{
-			float val = 1.0f / (float) Math.Sqrt((X * X) + (Y * Y));
+			float val = 1.0f / MathF.Sqrt((X * X) + (Y * Y));
 			X *= val;
 			Y *= val;
 		}
@@ -387,7 +387,7 @@ namespace Microsoft.Xna.Framework
 		public static float Distance(Vector2 value1, Vector2 value2)
 		{
 			float v1 = value1.X - value2.X, v2 = value1.Y - value2.Y;
-			return (float) Math.Sqrt((v1 * v1) + (v2 * v2));
+			return MathF.Sqrt((v1 * v1) + (v2 * v2));
 		}
 
 		/// <summary>
@@ -399,7 +399,7 @@ namespace Microsoft.Xna.Framework
 		public static void Distance(ref Vector2 value1, ref Vector2 value2, out float result)
 		{
 			float v1 = value1.X - value2.X, v2 = value1.Y - value2.Y;
-			result = (float) Math.Sqrt((v1 * v1) + (v2 * v2));
+			result = MathF.Sqrt((v1 * v1) + (v2 * v2));
 		}
 
 		/// <summary>
@@ -709,7 +709,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>Unit vector.</returns>
 		public static Vector2 Normalize(Vector2 value)
 		{
-			float val = 1.0f / (float) Math.Sqrt((value.X * value.X) + (value.Y * value.Y));
+			float val = 1.0f / MathF.Sqrt((value.X * value.X) + (value.Y * value.Y));
 			value.X *= val;
 			value.Y *= val;
 			return value;
@@ -722,7 +722,7 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">Unit vector as an output parameter.</param>
 		public static void Normalize(ref Vector2 value, out Vector2 result)
 		{
-			float val = 1.0f / (float) Math.Sqrt((value.X * value.X) + (value.Y * value.Y));
+			float val = 1.0f / MathF.Sqrt((value.X * value.X) + (value.Y * value.Y));
 			result.X = value.X * val;
 			result.Y = value.Y * val;
 		}

--- a/src/Vector3.cs
+++ b/src/Vector3.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>The length of this <see cref="Vector3"/>.</returns>
 		public float Length()
 		{
-			return (float) Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+			return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z));
 		}
 
 		/// <summary>
@@ -303,7 +303,7 @@ namespace Microsoft.Xna.Framework
 		/// </summary>
 		public void Normalize()
 		{
-			float factor = 1.0f / (float) Math.Sqrt(
+			float factor = 1.0f / MathF.Sqrt(
 				(X * X) +
 				(Y * Y) +
 				(Z * Z)
@@ -541,7 +541,7 @@ namespace Microsoft.Xna.Framework
 		{
 			float result;
 			DistanceSquared(ref vector1, ref vector2, out result);
-			return (float) Math.Sqrt(result);
+			return MathF.Sqrt(result);
 		}
 
 		/// <summary>
@@ -553,7 +553,7 @@ namespace Microsoft.Xna.Framework
 		public static void Distance(ref Vector3 value1, ref Vector3 value2, out float result)
 		{
 			DistanceSquared(ref value1, ref value2, out result);
-			result = (float) Math.Sqrt(result);
+			result = MathF.Sqrt(result);
 		}
 
 		/// <summary>
@@ -886,7 +886,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>Unit vector.</returns>
 		public static Vector3 Normalize(Vector3 value)
 		{
-			float factor = 1.0f / (float) Math.Sqrt(
+			float factor = 1.0f / MathF.Sqrt(
 				(value.X * value.X) +
 				(value.Y * value.Y) +
 				(value.Z * value.Z)
@@ -905,7 +905,7 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">Unit vector as an output parameter.</param>
 		public static void Normalize(ref Vector3 value, out Vector3 result)
 		{
-			float factor = 1.0f / (float) Math.Sqrt(
+			float factor = 1.0f / MathF.Sqrt(
 				(value.X * value.X) +
 				(value.Y * value.Y) +
 				(value.Z * value.Z)

--- a/src/Vector4.cs
+++ b/src/Vector4.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>The length of this <see cref="Vector4"/>.</returns>
 		public float Length()
 		{
-			return (float) Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+			return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
 		}
 
 		/// <summary>
@@ -267,7 +267,7 @@ namespace Microsoft.Xna.Framework
 		/// </summary>
 		public void Normalize()
 		{
-			float factor = 1.0f / (float) Math.Sqrt(
+			float factor = 1.0f / MathF.Sqrt(
 				(X * X) +
 				(Y * Y) +
 				(Z * Z) +
@@ -478,7 +478,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>The distance between two vectors.</returns>
 		public static float Distance(Vector4 value1, Vector4 value2)
 		{
-			return (float) Math.Sqrt(DistanceSquared(value1, value2));
+			return MathF.Sqrt(DistanceSquared(value1, value2));
 		}
 
 		/// <summary>
@@ -489,7 +489,7 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">The distance between two vectors as an output parameter.</param>
 		public static void Distance(ref Vector4 value1, ref Vector4 value2, out float result)
 		{
-			result = (float) Math.Sqrt(DistanceSquared(value1, value2));
+			result = MathF.Sqrt(DistanceSquared(value1, value2));
 		}
 
 		/// <summary>
@@ -852,7 +852,7 @@ namespace Microsoft.Xna.Framework
 		/// <returns>Unit vector.</returns>
 		public static Vector4 Normalize(Vector4 vector)
 		{
-			float factor = 1.0f / (float) Math.Sqrt(
+			float factor = 1.0f / MathF.Sqrt(
 				(vector.X * vector.X) +
 				(vector.Y * vector.Y) +
 				(vector.Z * vector.Z) +
@@ -873,7 +873,7 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result">Unit vector as an output parameter.</param>
 		public static void Normalize(ref Vector4 vector, out Vector4 result)
 		{
-			float factor = 1.0f / (float) Math.Sqrt(
+			float factor = 1.0f / MathF.Sqrt(
 				(vector.X * vector.X) +
 				(vector.Y * vector.Y) +
 				(vector.Z * vector.Z) +


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Benchmark
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace Net8App
{
    [DisassemblyDiagnoser]
    public class Vector4DotBenchmark
    {
        const int loop = 0xFFFF;

        static Random random = new Random();
        static float sf = random.NextSingle();
        static double sd = sf;
        [Benchmark]
        public double math1()
        {
            double f = sd;
            for (int i = 0; i < loop; i++)
            {
                f = Math.Sqrt(f);
            }
            return f;
        }
        [Benchmark]
        public double math2()
        {
            float f = sf;
            for (int i = 0; i < loop; i++)
            {
                f = (float) Math.Sqrt(f);
            }
            return f;
        }
        [Benchmark]
        public float mathf()
        {
            float f = sf;
            for (int i = 0; i < loop; i++)
            {
                f = MathF.Sqrt(f);
            }
            return f;
        }
    }

    static class Program
    {
        [STAThread]
        static void Main()
        {
            BenchmarkRunner.Run<Vector4DotBenchmark>();
        }
    }
}
```
## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.math1()
       vzeroupper
       vmovsd    xmm0,qword ptr [7FF9BAC41928]
       xor       eax,eax
M00_L00:
       vsqrtsd   xmm0,xmm0,xmm0
       inc       eax
       cmp       eax,0FFFF
       jl        short M00_L00
       ret
; Total bytes of code 27
```

## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.math2()
       vzeroupper
       vmovss    xmm0,dword ptr [7FF9BAC41930]
       xor       eax,eax
       nop       dword ptr [rax]
M00_L00:
       vcvtss2sd xmm0,xmm0,xmm0
       vsqrtsd   xmm0,xmm0,xmm0
       vcvtsd2ss xmm0,xmm0,xmm0
       inc       eax
       cmp       eax,0FFFF
       jl        short M00_L00
       vcvtss2sd xmm0,xmm0,xmm0
       ret
; Total bytes of code 42
```

## .NET 8.0.29 (8.0.29, 8.0.2926.32403), X64 RyuJIT x86-64-v3 (Job: DefaultJob)

```assembly
; Net8App.Vector4DotBenchmark.mathf()
       vzeroupper
       vmovss    xmm0,dword ptr [7FF9BAC11930]
       xor       eax,eax
M00_L00:
       vsqrtss   xmm0,xmm0,xmm0
       inc       eax
       cmp       eax,0FFFF
       jl        short M00_L00
       ret
; Total bytes of code 27
```

| Method | Mean     | Error   | StdDev  | Code Size |
|------- |---------:|--------:|--------:|----------:|
| math1  | 305.0 us | 0.52 us | 0.43 us |      27 B |
| math2  | 396.3 us | 0.87 us | 0.77 us |      42 B |
| mathf  | 213.3 us | 0.27 us | 0.25 us |      27 B |