### PR TITLE
Fix BackBufferWidth and BackBufferHeight default. Simplify PresentationParameters Property

### DIFF
--- a/src/Graphics/PresentationParameters.cs
+++ b/src/Graphics/PresentationParameters.cs
@@ -159,8 +159,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		public PresentationParameters()
 		{
 			BackBufferFormat = SurfaceFormat.Color;
-			BackBufferWidth = GraphicsDeviceManager.DefaultBackBufferWidth;
-			BackBufferHeight = GraphicsDeviceManager.DefaultBackBufferHeight;
+			BackBufferWidth = 0;
+			BackBufferHeight = 0;
 			DeviceWindowHandle = IntPtr.Zero;
 			IsFullScreen = true;
 			DepthStencilFormat = DepthFormat.None;

--- a/src/GraphicsDeviceInformation.cs
+++ b/src/GraphicsDeviceInformation.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Xna.Framework
 		/// </summary>
 		public PresentationParameters PresentationParameters
 		{
-			get { return presentationParameters; }
-			set { presentationParameters = value; }
+			get;
+			set;
 		}
 
 		#endregion
@@ -66,7 +66,15 @@ namespace Microsoft.Xna.Framework
 		#region Private Variable
 
 		private GraphicsAdapter adapter = GraphicsAdapter.DefaultAdapter;
-		private PresentationParameters presentationParameters = new PresentationParameters();
+
+		#endregion
+
+		#region Public Constructor
+
+		public GraphicsDeviceInformation()
+		{
+			PresentationParameters = new PresentationParameters();
+		}
 
 		#endregion
 
@@ -79,16 +87,16 @@ namespace Microsoft.Xna.Framework
 				gdi != null &&
 				gdi.adapter.Equals(adapter) &&
 				gdi.GraphicsProfile == GraphicsProfile &&
-				gdi.presentationParameters.BackBufferWidth == presentationParameters.BackBufferWidth &&
-				gdi.presentationParameters.BackBufferHeight == presentationParameters.BackBufferHeight &&
-				gdi.presentationParameters.BackBufferFormat == presentationParameters.BackBufferFormat &&
-				gdi.presentationParameters.DepthStencilFormat == presentationParameters.DepthStencilFormat &&
-				gdi.presentationParameters.MultiSampleCount == presentationParameters.MultiSampleCount &&
-				gdi.presentationParameters.DisplayOrientation == presentationParameters.DisplayOrientation &&
-				gdi.presentationParameters.PresentationInterval == presentationParameters.PresentationInterval &&
-				gdi.presentationParameters.RenderTargetUsage == presentationParameters.RenderTargetUsage &&
-				gdi.presentationParameters.DeviceWindowHandle == presentationParameters.DeviceWindowHandle &&
-				gdi.presentationParameters.IsFullScreen == presentationParameters.IsFullScreen
+				gdi.PresentationParameters.BackBufferWidth == PresentationParameters.BackBufferWidth &&
+				gdi.PresentationParameters.BackBufferHeight == PresentationParameters.BackBufferHeight &&
+				gdi.PresentationParameters.BackBufferFormat == PresentationParameters.BackBufferFormat &&
+				gdi.PresentationParameters.DepthStencilFormat == PresentationParameters.DepthStencilFormat &&
+				gdi.PresentationParameters.MultiSampleCount == PresentationParameters.MultiSampleCount &&
+				gdi.PresentationParameters.DisplayOrientation == PresentationParameters.DisplayOrientation &&
+				gdi.PresentationParameters.PresentationInterval == PresentationParameters.PresentationInterval &&
+				gdi.PresentationParameters.RenderTargetUsage == PresentationParameters.RenderTargetUsage &&
+				gdi.PresentationParameters.DeviceWindowHandle == PresentationParameters.DeviceWindowHandle &&
+				gdi.PresentationParameters.IsFullScreen == PresentationParameters.IsFullScreen
 			);
 		}
 		public override int GetHashCode()
@@ -96,16 +104,16 @@ namespace Microsoft.Xna.Framework
 			return (
 				GraphicsProfile.GetHashCode() ^
 				adapter.GetHashCode() ^
-				presentationParameters.BackBufferWidth.GetHashCode() ^
-				presentationParameters.BackBufferHeight.GetHashCode() ^
-				presentationParameters.BackBufferFormat.GetHashCode() ^
-				presentationParameters.DepthStencilFormat.GetHashCode() ^
-				presentationParameters.MultiSampleCount.GetHashCode() ^
-				presentationParameters.DisplayOrientation.GetHashCode() ^
-				presentationParameters.PresentationInterval.GetHashCode() ^
-				presentationParameters.RenderTargetUsage.GetHashCode() ^
-				presentationParameters.DeviceWindowHandle.GetHashCode() ^
-				presentationParameters.IsFullScreen.GetHashCode()
+				PresentationParameters.BackBufferWidth.GetHashCode() ^
+				PresentationParameters.BackBufferHeight.GetHashCode() ^
+				PresentationParameters.BackBufferFormat.GetHashCode() ^
+				PresentationParameters.DepthStencilFormat.GetHashCode() ^
+				PresentationParameters.MultiSampleCount.GetHashCode() ^
+				PresentationParameters.DisplayOrientation.GetHashCode() ^
+				PresentationParameters.PresentationInterval.GetHashCode() ^
+				PresentationParameters.RenderTargetUsage.GetHashCode() ^
+				PresentationParameters.DeviceWindowHandle.GetHashCode() ^
+				PresentationParameters.IsFullScreen.GetHashCode()
 			);
 		}
 
@@ -115,7 +123,7 @@ namespace Microsoft.Xna.Framework
 			{
 				Adapter = Adapter,
 				GraphicsProfile = GraphicsProfile,
-				presentationParameters = presentationParameters.Clone()
+				PresentationParameters = PresentationParameters.Clone()
 			};
 		}
 

--- a/src/GraphicsDeviceManager.cs
+++ b/src/GraphicsDeviceManager.cs
@@ -327,6 +327,8 @@ namespace Microsoft.Xna.Framework
 
 			// Recreate device information before resetting
 			GraphicsDeviceInformation gdi = new GraphicsDeviceInformation();
+			gdi.PresentationParameters.BackBufferWidth = DefaultBackBufferWidth;
+			gdi.PresentationParameters.BackBufferHeight = DefaultBackBufferHeight;
 			gdi.Adapter = graphicsDevice.Adapter;
 			gdi.PresentationParameters = graphicsDevice.PresentationParameters.Clone();
 			INTERNAL_CreateGraphicsDeviceInformation(gdi);
@@ -553,6 +555,8 @@ namespace Microsoft.Xna.Framework
 
 			// Set the default device information
 			GraphicsDeviceInformation gdi = new GraphicsDeviceInformation();
+			gdi.PresentationParameters.BackBufferWidth = DefaultBackBufferWidth;
+			gdi.PresentationParameters.BackBufferHeight = DefaultBackBufferHeight;
 			gdi.PresentationParameters.DeviceWindowHandle = game.Window.Handle;
 			INTERNAL_CreateGraphicsDeviceInformation(gdi);
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            PresentationParameters pp = new PresentationParameters();
            GraphicsDeviceInformation gdi = new GraphicsDeviceInformation();
            Console.WriteLine("pp:" + pp.BackBufferWidth + " | " + pp.BackBufferHeight);
            Console.WriteLine("gdi:" + gdi.PresentationParameters.BackBufferWidth + " | " + gdi.PresentationParameters.BackBufferHeight);
        }
    }
}
```
XNA output:
```
pp:0 | 0
gdi:0 | 0
```