### PR TITLE
accuracy: Fix BoundingBox.Contains with NaN

### DIFF
--- a/src/BoundingBox.cs
+++ b/src/BoundingBox.cs
@@ -266,18 +266,18 @@ namespace Microsoft.Xna.Framework
 		public void Contains(ref Vector3 point, out ContainmentType result)
 		{
 			// Determine if point is outside of this box.
-			if (	point.X < this.Min.X ||
-				point.X > this.Max.X ||
-				point.Y < this.Min.Y ||
-				point.Y > this.Max.Y ||
-				point.Z < this.Min.Z ||
-				point.Z > this.Max.Z	)
+			if (	point.X >= this.Min.X &&
+				point.X <= this.Max.X &&
+				point.Y >= this.Min.Y &&
+				point.Y <= this.Max.Y &&
+				point.Z >= this.Min.Z &&
+				point.Z <= this.Max.Z	)
 			{
-				result = ContainmentType.Disjoint;
+				result = ContainmentType.Contains;
 			}
 			else
 			{
-				result = ContainmentType.Contains;
+				result = ContainmentType.Disjoint;
 			}
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            BoundingBox box = new BoundingBox(new Vector3(-1f, -1f, -1f), new Vector3(1f, 1f, 1f));
            Console.WriteLine(box.Contains(new Vector3(float.NaN)));
        }
    }
}
```
XNA output:
```
Disjoint
```
FNA output:
```
Contains
```