### PR TITLE
accuracy: float.NaN for BoundingBox.Intersects(BoundingBox)

### DIFF
--- a/src/BoundingBox.cs
+++ b/src/BoundingBox.cs
@@ -371,20 +371,11 @@ namespace Microsoft.Xna.Framework
 
 		public void Intersects(ref BoundingBox box, out bool result)
 		{
-			if ((this.Max.X >= box.Min.X) && (this.Min.X <= box.Max.X))
-			{
-				if ((this.Max.Y < box.Min.Y) || (this.Min.Y > box.Max.Y))
-				{
-					result = false;
-					return;
-				}
-
-				result = (this.Max.Z >= box.Min.Z) && (this.Min.Z <= box.Max.Z);
-				return;
-			}
-
-			result = false;
-			return;
+			result = !(
+				this.Max.X < box.Min.X || this.Min.X > box.Max.X ||
+				this.Max.Y < box.Min.Y || this.Min.Y > box.Max.Y ||
+				this.Max.Z < box.Min.Z || this.Min.Z > box.Max.Z
+			);
 		}
 
 		public bool Intersects(BoundingSphere sphere)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            BoundingBox box;
            BoundingBox box1 = new BoundingBox(new Vector3(0f, 0f, 0f), new Vector3(2f, 2f, 2f));
            BoundingBox box2 = new BoundingBox(new Vector3(1f, 1f, 1f), new Vector3(3f, 3f, 3f));

            box = box1;
            Console.WriteLine(box.Intersects(box2));

            box = box1;
            box.Min.X = float.NaN;
            Console.WriteLine(box.Intersects(box2));

            box = box1;
            box.Min.Y = float.NaN;
            Console.WriteLine(box.Intersects(box2));

            box = box1;
            box.Min.Z = float.NaN;
            Console.WriteLine(box.Intersects(box2));
        }
    }
}
```
XNA output:
```
True
True
True
True
```
FNA output:
```
True
False
True
False
```