### PR TITLE
accuracy: BoundingFrustum.Intersects(BoundingBox)

### DIFF
--- a/src/BoundingFrustum.cs
+++ b/src/BoundingFrustum.cs
@@ -374,6 +374,25 @@ namespace Microsoft.Xna.Framework
 		/// <param name="result"><c>true</c> if specified <see cref="BoundingBox"/> intersects with this <see cref="BoundingFrustum"/>; <c>false</c> otherwise as an output parameter.</param>
 		public void Intersects(ref BoundingBox box, out bool result)
 		{
+			BoundingBox wrapBox;
+			wrapBox.Min = corners[0];
+			wrapBox.Max = wrapBox.Min;
+			for (int i = 1; i < CornerCount; i++)
+			{
+				wrapBox.Min = Vector3.Min(wrapBox.Min, corners[i]);
+				wrapBox.Max = Vector3.Max(wrapBox.Max, corners[i]);
+			}
+			ContainmentType containmentType;
+			box.Contains(ref wrapBox, out containmentType);
+			switch (containmentType)
+			{
+				case ContainmentType.Disjoint:
+					result = false;
+					return;
+				case ContainmentType.Contains:
+					result = true;
+					return;
+			}
 			ContainmentType containment;
 			this.Contains(ref box, out containment);
 			result = containment != ContainmentType.Disjoint;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            float sqrt2 = (float) Math.Sqrt(2);
            Matrix matrix = Matrix.Identity;
            matrix.M11 = sqrt2;
            matrix.M22 = sqrt2;
            matrix.M12 = sqrt2;
            matrix.M21 = -sqrt2;
            BoundingFrustum frustum = new BoundingFrustum(matrix);
            Console.WriteLine(frustum.Matrix);
            foreach (Vector3 conner in frustum.GetCorners())
            {
                Console.WriteLine("conner:" + conner);
            }
            Console.WriteLine("Near:" + frustum.Near);
            Console.WriteLine("Far:" + frustum.Far);
            Console.WriteLine("Left:" + frustum.Left);
            Console.WriteLine("Right:" + frustum.Right);
            Console.WriteLine("Top:" + frustum.Top);
            Console.WriteLine("Bottom:" + frustum.Bottom);

            BoundingBox box = new BoundingBox(new Vector3(sqrt2 + 0.0005f, -1, -1), new Vector3(sqrt2 + 0.0005f, 1, 1));
            Console.WriteLine(frustum.Intersects(box));
        }
    }
}
```
XNA output:
```
{ {M11:1.414214 M12:1.414214 M13:0 M14:0} {M21:-1.414214 M22:1.414214 M23:0 M24:0} {M31:0 M32:0 M33:1 M34:0} {M41:0 M42:0 M43:0 M44:1} }
conner:{X:-1.77007E-08 Y:0.7071068 Z:0}
conner:{X:0.7071068 Y:-1.77007E-08 Z:0}
conner:{X:1.77007E-08 Y:-0.7071068 Z:0}
conner:{X:-0.7071068 Y:1.77007E-08 Z:0}
conner:{X:-1.77007E-08 Y:0.7071068 Z:1}
conner:{X:0.7071068 Y:-1.77007E-08 Z:1}
conner:{X:1.77007E-08 Y:-0.7071068 Z:1}
conner:{X:-0.7071068 Y:1.77007E-08 Z:1}
Near:{Normal:{X:0 Y:0 Z:-1} D:0}
Far:{Normal:{X:0 Y:0 Z:1} D:-1}
Left:{Normal:{X:-0.7071068 Y:0.7071068 Z:0} D:-0.5}
Right:{Normal:{X:0.7071068 Y:-0.7071068 Z:0} D:-0.5}
Top:{Normal:{X:0.7071068 Y:0.7071068 Z:0} D:-0.5}
Bottom:{Normal:{X:-0.7071068 Y:-0.7071068 Z:0} D:-0.5}
False
```
FNA output:
```
{M11:1.414214 M12:1.414214 M13:0 M14:0} {M21:-1.414214 M22:1.414214 M23:0 M24:0} {M31:0 M32:0 M33:1 M34:0} {M41:0 M42:0 M43:0 M44:1}
conner:{X:0 Y:0.7071068 Z:0}
conner:{X:0.7071068 Y:0 Z:0}
conner:{X:0 Y:-0.7071068 Z:0}
conner:{X:-0.7071068 Y:0 Z:0}
conner:{X:0 Y:0.7071068 Z:1}
conner:{X:0.7071068 Y:0 Z:1}
conner:{X:0 Y:-0.7071068 Z:1}
conner:{X:-0.7071068 Y:0 Z:1}
Near:{Normal:{X:0 Y:0 Z:-1} D:0}
Far:{Normal:{X:0 Y:0 Z:1} D:-1}
Left:{Normal:{X:-0.7071068 Y:0.7071068 Z:0} D:-0.5}
Right:{Normal:{X:0.7071068 Y:-0.7071068 Z:0} D:-0.5}
Top:{Normal:{X:0.7071068 Y:0.7071068 Z:0} D:-0.5}
Bottom:{Normal:{X:-0.7071068 Y:-0.7071068 Z:0} D:-0.5}
True
```