### PR TITLE
optimize: frustum.corners instead of frustum.GetCorners() avoid copy array

### DIFF
--- a/src/BoundingBox.cs
+++ b/src/BoundingBox.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Xna.Framework
 			 */
 			int i;
 			ContainmentType contained;
-			Vector3[] corners = frustum.GetCorners();
+			Vector3[] corners = frustum.corners;
 
 			// First we check if frustum is in box.
 			for (i = 0; i < corners.Length; i += 1)

--- a/src/BoundingSphere.cs
+++ b/src/BoundingSphere.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Xna.Framework
 			// Check if all corners are in sphere.
 			bool inside = true;
 
-			Vector3[] corners = frustum.GetCorners();
+			Vector3[] corners = frustum.corners;
 			foreach (Vector3 corner in corners)
 			{
 				if (this.Contains(corner) == ContainmentType.Disjoint)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

