### PR TITLE
exception accuracy: GL State Properties in GraphicsDevice

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -175,6 +175,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
+				if (IsDisposed)
+				{
+					throw new ObjectDisposedException(GetType().Name);
+				}
 				return INTERNAL_scissorRectangle;
 			}
 			set
@@ -204,6 +208,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
+				if (IsDisposed)
+				{
+					throw new ObjectDisposedException(GetType().Name);
+				}
 				return INTERNAL_viewport;
 			}
 			set

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -121,6 +121,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			set
 			{
+				if (value == null)
+				{
+					throw new ArgumentNullException("value", "This method does not accept null for this parameter.");
+				}
 				nextBlend = value;
 			}
 		}
@@ -133,14 +137,33 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			set
 			{
+				if (value == null)
+				{
+					throw new ArgumentNullException("value", "This method does not accept null for this parameter.");
+				}
 				nextDepthStencil = value;
 			}
 		}
 
+		private RasterizerState cachedRasterizerState;
 		public RasterizerState RasterizerState
 		{
-			get;
-			set;
+			get
+			{
+				return cachedRasterizerState;
+			}
+			set
+			{
+				if (value == null)
+				{
+					throw new ArgumentNullException("value", "This method does not accept null for this parameter.");
+				}
+				if (value.IsDisposed)
+				{
+					throw new ObjectDisposedException(typeof(RasterizerState).Name);
+				}
+				cachedRasterizerState = value;
+			}
 		}
 
 		/* We have to store this internally because we flip the Rectangle for
@@ -156,6 +179,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			set
 			{
+				if (IsDisposed)
+				{
+					throw new ObjectDisposedException(GetType().Name);
+				}
 				INTERNAL_scissorRectangle = value;
 				FNA3D.FNA3D_SetScissorRect(
 					GLDevice,
@@ -177,6 +204,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			set
 			{
+				if (IsDisposed)
+				{
+					throw new ObjectDisposedException(GetType().Name);
+				}
+				if (!(value.X >= 0 && value.Y >= 0 && value.Width > 0 && value.Height > 0))
+				{
+					throw new ArgumentException("The viewport is invalid. The viewport cannot be larger than or outside of the current render target bounds. The MinDepth and MaxDepth must be between 0 and 1.", "value");
+				}
 				INTERNAL_viewport = value;
 				FNA3D.FNA3D_SetViewport(
 					GLDevice,
@@ -195,6 +230,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			set
 			{
+				if (IsDisposed)
+				{
+					throw new ObjectDisposedException(GetType().Name);
+				}
 				/* FIXME: Does this affect the value found in
 				 * BlendState?
 				 * -flibit
@@ -211,6 +250,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			set
 			{
+				if (IsDisposed)
+				{
+					throw new ObjectDisposedException(GetType().Name);
+				}
 				/* FIXME: Does this affect the value found in
 				 * BlendState?
 				 * -flibit
@@ -227,6 +270,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 			set
 			{
+				if (IsDisposed)
+				{
+					throw new ObjectDisposedException(GetType().Name);
+				}
 				/* FIXME: Does this affect the value found in
 				 * DepthStencilState?
 				 * -flibit

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -183,6 +183,10 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					throw new ObjectDisposedException(GetType().Name);
 				}
+				if (!(value.X >= 0 && value.Y >= 0 && value.Width >= 0 && value.Height >= 0))
+				{
+					throw new ArgumentException("The scissor rectangle is invalid. The scissor rectangle cannot be larger than or outside of the current render target bounds.", "value");
+				}
 				INTERNAL_scissorRectangle = value;
 				FNA3D.FNA3D_SetScissorRect(
 					GLDevice,

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					throw new ObjectDisposedException(GetType().Name);
 				}
-				if (!(value.X >= 0 && value.Y >= 0 && value.Width >= 0 && value.Height >= 0))
+				if (value.X < 0 || value.Y < 0 || value.Width < 0 || value.Height < 0)
 				{
 					throw new ArgumentException("The scissor rectangle is invalid. The scissor rectangle cannot be larger than or outside of the current render target bounds.", "value");
 				}
@@ -213,10 +213,10 @@ namespace Microsoft.Xna.Framework.Graphics
 					throw new ObjectDisposedException(GetType().Name);
 				}
 				if (
-					!(value.X >= 0 && value.Y >= 0 && value.Width > 0 && value.Height > 0)
-					|| value.MinDepth < 0f || value.MinDepth > 1f
-					|| value.MaxDepth < 0f || value.MaxDepth > 1f
-					|| value.MaxDepth < value.MinDepth
+					value.X < 0 || value.Y < 0 || value.Width <= 0 || value.Height <= 0 ||
+					value.MinDepth < 0f || value.MinDepth > 1f ||
+					value.MaxDepth < 0f || value.MaxDepth > 1f ||
+					value.MaxDepth < value.MinDepth
 				)
 				{
 					throw new ArgumentException("The viewport is invalid. The viewport cannot be larger than or outside of the current render target bounds. The MinDepth and MaxDepth must be between 0 and 1.", "value");

--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -208,7 +208,12 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					throw new ObjectDisposedException(GetType().Name);
 				}
-				if (!(value.X >= 0 && value.Y >= 0 && value.Width > 0 && value.Height > 0))
+				if (
+					!(value.X >= 0 && value.Y >= 0 && value.Width > 0 && value.Height > 0)
+					|| value.MinDepth < 0f || value.MinDepth > 1f
+					|| value.MaxDepth < 0f || value.MaxDepth > 1f
+					|| value.MaxDepth < value.MinDepth
+				)
 				{
 					throw new ArgumentException("The viewport is invalid. The viewport cannot be larger than or outside of the current render target bounds. The MinDepth and MaxDepth must be between 0 and 1.", "value");
 				}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            Game game = new Game();
            PresentationParameters pp = new PresentationParameters() { DeviceWindowHandle = game.Window.Handle };
            GraphicsDevice gd = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.Reach, pp);

            ex(() => { gd.Viewport = new Viewport(-1, -1, -1, -1); });
            gd.Dispose();
            ex(() => { gd.BlendState = null; });
            ex(() => { gd.DepthStencilState = null; });
            ex(() => { gd.RasterizerState = null; });
            RasterizerState rasterizerState = new RasterizerState();
            rasterizerState.Dispose();
            ex(() => { gd.RasterizerState = rasterizerState; });
            ex(() => { gd.ScissorRectangle = default; });
            ex(() => { gd.Viewport = default; });
            ex(() => { gd.BlendFactor = default; });
            ex(() => { gd.MultiSampleMask = default; });
            ex(() => { gd.ReferenceStencil = default; });
        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
System.ArgumentException: The viewport is invalid. The viewport cannot be larger than or outside of the current render target bounds. The MinDepth and MaxDepth must be between 0 and 1.
Parameter name: value
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_Viewport(Viewport value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 17
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ArgumentNullException: This method does not accept null for this parameter.
Parameter name: value
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_BlendState(BlendState value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 19
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ArgumentNullException: This method does not accept null for this parameter.
Parameter name: value
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_DepthStencilState(DepthStencilState value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 20
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ArgumentNullException: This method does not accept null for this parameter.
Parameter name: value
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_RasterizerState(RasterizerState value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__3() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 21
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'RasterizerState'.
   at Microsoft.Xna.Framework.Graphics.RasterizerState.Apply(GraphicsDevice device)
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_RasterizerState(RasterizerState value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__4() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 24
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'GraphicsDevice'.
   at Microsoft.Xna.Framework.Helpers.CheckDisposed(Object obj, IntPtr pComPtr)
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_ScissorRectangle(Rectangle value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__5() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'GraphicsDevice'.
   at Microsoft.Xna.Framework.Helpers.CheckDisposed(Object obj, IntPtr pComPtr)
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_Viewport(Viewport value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__6() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 26
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'GraphicsDevice'.
   at Microsoft.Xna.Framework.Helpers.CheckDisposed(Object obj, IntPtr pComPtr)
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_BlendFactor(Color value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__7() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 27
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'GraphicsDevice'.
   at Microsoft.Xna.Framework.Helpers.CheckDisposed(Object obj, IntPtr pComPtr)
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_MultiSampleMask(Int32 value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__8() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 28
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'GraphicsDevice'.
   at Microsoft.Xna.Framework.Helpers.CheckDisposed(Object obj, IntPtr pComPtr)
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.set_ReferenceStencil(Int32 value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__9() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 29
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 36
```
FNA output:
```
SDL_GPUSupportsProperties failed: No supported SDL_GPU backend found!
FNA3D Driver: D3D11
D3D11 Adapter: Microsoft Basic Render Driver
Backbuffer color buffer creation failed! Error Code: The parameter is incorrect. (0x80070057)

Unhandled Exception: Microsoft.Xna.Framework.Graphics.NoSuitableGraphicsDeviceException: Backbuffer color buffer creation failed! Error Code: The parameter is incorrect. (0x80070057)
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice..ctor(GraphicsAdapter adapter, GraphicsProfile graphicsProfile, PresentationParameters presentationParameters) in C:\Users\Given\Downloads\FNA-2609\src\Graphics\GraphicsDevice.cs:line 426
   at EX.EX.Main() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 12
```