### PR TITLE
exception accuracy: SamplerStateCollection

### DIFF
--- a/src/Graphics/SamplerStateCollection.cs
+++ b/src/Graphics/SamplerStateCollection.cs
@@ -7,6 +7,10 @@
  */
 #endregion
 
+#region Using Statements
+using System;
+#endregion
+
 namespace Microsoft.Xna.Framework.Graphics
 {
 	public sealed class SamplerStateCollection
@@ -17,10 +21,22 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get
 			{
+				if (unchecked((uint) index >= (uint) samplers.Length))
+				{
+					throw new ArgumentOutOfRangeException("index");
+				}
 				return samplers[index];
 			}
 			set
 			{
+				if (unchecked((uint) index >= (uint) samplers.Length))
+				{
+					throw new ArgumentOutOfRangeException("index");
+				}
+				if (value == null)
+				{
+					throw new ArgumentNullException("value", "This method does not accept null for this parameter.");
+				}
 				samplers[index] = value;
 				modifiedSamplers[index] = true;
 			}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace EX
{
    class EX
    {
        [STAThread]
        static void Main()
        {
            Game game = new Game();
            PresentationParameters pp = new PresentationParameters() { DeviceWindowHandle = game.Window.Handle };
            GraphicsDevice gd = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.Reach, pp);

            ex(() => { gd.SamplerStates[-1] = null; });
            ex(() => { gd.SamplerStates[0] = null; });
            ex(() => { SamplerState samplerState = gd.SamplerStates[-1]; });
        }

        static void ex(Action action)
        {
            try
            {
                action();
            }
            catch (Exception e)
            {
                Console.Error.WriteLine(e + "\n");
            }
        }
    }
}
```
XNA output:
```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: index
   at Microsoft.Xna.Framework.Graphics.SamplerStateCollection.set_Item(Int32 index, SamplerState value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 16
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25

System.ArgumentNullException: This method does not accept null for this parameter.
Parameter name: value
   at Microsoft.Xna.Framework.Graphics.SamplerStateCollection.set_Item(Int32 index, SamplerState value)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__1() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 17
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25

System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: index
   at Microsoft.Xna.Framework.Graphics.SamplerStateCollection.get_Item(Int32 index)
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 18
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25
```
FNA output:
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__0() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 16
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25

System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at EX.EX.<>c__DisplayClass0_0.<Main>b__2() in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 18
   at EX.EX.ex(Action action) in C:\Users\Given\source\repos\ConsoleApp2\ConsoleApp2\ex.cs:line 25
```