### PR TITLE
Set graphicsDevice for RasterizerState and BlendState and DepthStencilState

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					throw new ArgumentNullException("value", "This method does not accept null for this parameter.");
 				}
+				if (value.IsDisposed)
+				{
+					throw new ObjectDisposedException(typeof(BlendState).Name);
+				}
+				value.graphicsDevice = this;
 				nextBlend = value;
 			}
 		}
@@ -141,6 +146,11 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					throw new ArgumentNullException("value", "This method does not accept null for this parameter.");
 				}
+				if (value.IsDisposed)
+				{
+					throw new ObjectDisposedException(typeof(DepthStencilState).Name);
+				}
+				value.graphicsDevice = this;
 				nextDepthStencil = value;
 			}
 		}
@@ -162,6 +172,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					throw new ObjectDisposedException(typeof(RasterizerState).Name);
 				}
+				value.graphicsDevice = this;
 				cachedRasterizerState = value;
 			}
 		}

--- a/src/Graphics/GraphicsResource.cs
+++ b/src/Graphics/GraphicsResource.cs
@@ -80,11 +80,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
+		#region Internal Variables
+
+		internal GraphicsDevice graphicsDevice;
+
+		#endregion
+
 		#region Private Variables
 
 		private GCHandle selfReference;
-
-		private GraphicsDevice graphicsDevice;
 
 		#endregion
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace ConsoleApp5
{
    static class Show
    {
        [STAThread]
        static void Main()
        {
            Game game = new Game();
            PresentationParameters pp = new PresentationParameters() { DeviceWindowHandle = game.Window.Handle };
            GraphicsDevice gd = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.Reach, pp);

            BlendState blendState = new BlendState();
            DepthStencilState depthStencilState = new DepthStencilState();
            RasterizerState rasterizerState = new RasterizerState();

            Console.WriteLine("BlendState " + blendState.GraphicsDevice);
            Console.WriteLine("DepthStencilState " + depthStencilState.GraphicsDevice);
            Console.WriteLine("RasterizerState " + rasterizerState.GraphicsDevice);
            gd.BlendState = blendState;
            gd.DepthStencilState = depthStencilState;
            gd.RasterizerState = rasterizerState;
            Console.WriteLine("BlendState " + blendState.GraphicsDevice);
            Console.WriteLine("DepthStencilState " + depthStencilState.GraphicsDevice);
            Console.WriteLine("RasterizerState " + rasterizerState.GraphicsDevice);
            gd.Dispose();
            Console.WriteLine("BlendState " + blendState.IsDisposed);
            Console.WriteLine("DepthStencilState " + depthStencilState.IsDisposed);
            Console.WriteLine("RasterizerState " + rasterizerState.IsDisposed);
        }
    }
}
```
XNA output:
```
BlendState
DepthStencilState
RasterizerState
BlendState Microsoft.Xna.Framework.Graphics.GraphicsDevice
DepthStencilState Microsoft.Xna.Framework.Graphics.GraphicsDevice
RasterizerState Microsoft.Xna.Framework.Graphics.GraphicsDevice
BlendState False
DepthStencilState False
RasterizerState False
```
FNA output:
```
BlendState
DepthStencilState
RasterizerState
BlendState
DepthStencilState
RasterizerState
BlendState False
DepthStencilState False
RasterizerState False
```