### PR TITLE
fix: Rectangle.Intersect

### DIFF
--- a/src/Rectangle.cs
+++ b/src/Rectangle.cs
@@ -397,16 +397,13 @@ namespace Microsoft.Xna.Framework
 			ref Rectangle value2,
 			out Rectangle result
 		) {
-			int right1 = value1.X + value1.Width;	// inline value1.Right
-			int right2 = value2.X + value2.Width;	// inline value2.Right
-			int bottom1 = value1.Y + value1.Height;	// inline value1.Bottom
-			int bottom2 = value2.Y + value2.Height;	// inline value2.Bottom
-			if (value1.X < right2 && value2.X < right1 && value1.Y < bottom2 && value2.Y < bottom1)
+			int right = Math.Min(value1.Right, value2.Right);
+			int bottom = Math.Min(value1.Bottom, value2.Bottom);
+			int left = Math.Max(value1.Left, value2.Left);
+			int top = Math.Max(value1.Top, value2.Top);
+			if (left < right && top < bottom)
 			{
-				result.X = Math.Max(value1.X, value2.X);
-				result.Y = Math.Max(value1.Y, value2.Y);
-				result.Width = Math.Min(right1, right2) - result.X;
-				result.Height = Math.Min(bottom1, bottom2) - result.Y;
+				result = new Rectangle(left, top, right - left, bottom - top);
 			}
 			else
 			{


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using System;

namespace RenderTargetTest
{
    internal class Program
    {
        static void Main(string[] args)
        {
            var r1 = new Rectangle(0, 831, -2, 514);
            var r2 = new Rectangle(-5, 831, 1497, 2520);

            Rectangle r;
            Rectangle.Intersect(ref r1, ref r2, out r);

            Console.WriteLine(r);
        }
    }
}
```
XNA output:
```
{X:0 Y:0 Width:0 Height:0}
```
FNA output:
```
{X:0 Y:831 Width:-2 Height:514}
```