### PR TITLE
optimize: CopyTo instead of loop for currentlyUpdatingComponents and currentlyDrawingComponents in Game

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Xna.Framework
 		 * -flibit
 		 */
 		private List<IUpdateable> updateableComponents;
-		private List<IUpdateable> currentlyUpdatingComponents;
+		private IUpdateable[] currentlyUpdatingComponents;
 		private List<IDrawable> drawableComponents;
 		private List<IDrawable> currentlyDrawingComponents;
 
@@ -238,7 +238,7 @@ namespace Microsoft.Xna.Framework
 			Content = new ContentManager(Services);
 
 			updateableComponents = new List<IUpdateable>();
-			currentlyUpdatingComponents = new List<IUpdateable>();
+			currentlyUpdatingComponents = new IUpdateable[4];
 			drawableComponents = new List<IDrawable>();
 			currentlyDrawingComponents = new List<IDrawable>();
 
@@ -667,21 +667,29 @@ namespace Microsoft.Xna.Framework
 
 		protected virtual void Update(GameTime gameTime)
 		{
+			int capacity = currentlyUpdatingComponents.Length;
 			lock (updateableComponents)
 			{
-				for (int i = 0; i < updateableComponents.Count; i += 1)
+				if (capacity < updateableComponents.Count)
 				{
-					currentlyUpdatingComponents.Add(updateableComponents[i]);
+					capacity *= 2;
+					if (capacity < updateableComponents.Count)
+					{
+						capacity = updateableComponents.Count;
+					}
+					currentlyUpdatingComponents = new IUpdateable[capacity];
 				}
+				capacity = updateableComponents.Count;
+				updateableComponents.CopyTo(currentlyUpdatingComponents);
 			}
-			foreach (IUpdateable updateable in currentlyUpdatingComponents)
+			for (int i = 0; i < capacity; i++)
 			{
+				IUpdateable updateable = currentlyUpdatingComponents[i];
 				if (updateable.Enabled)
 				{
 					updateable.Update(gameTime);
 				}
 			}
-			currentlyUpdatingComponents.Clear();
 
 			FrameworkDispatcher.Update();
 		}

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Xna.Framework
 		private List<IUpdateable> updateableComponents;
 		private IUpdateable[] currentlyUpdatingComponents;
 		private List<IDrawable> drawableComponents;
-		private List<IDrawable> currentlyDrawingComponents;
+		private IDrawable[] currentlyDrawingComponents;
 
 		private IGraphicsDeviceService graphicsDeviceService;
 		private IGraphicsDeviceManager graphicsDeviceManager;
@@ -240,7 +240,7 @@ namespace Microsoft.Xna.Framework
 			updateableComponents = new List<IUpdateable>();
 			currentlyUpdatingComponents = new IUpdateable[4];
 			drawableComponents = new List<IDrawable>();
-			currentlyDrawingComponents = new List<IDrawable>();
+			currentlyDrawingComponents = new IDrawable[4];
 
 			IsMouseVisible = false;
 			IsFixedTimeStep = true;
@@ -648,21 +648,30 @@ namespace Microsoft.Xna.Framework
 
 		protected virtual void Draw(GameTime gameTime)
 		{
+			int capacity = currentlyDrawingComponents.Length;
 			lock (drawableComponents)
 			{
-				for (int i = 0; i < drawableComponents.Count; i += 1)
+				if (capacity < drawableComponents.Count)
 				{
-					currentlyDrawingComponents.Add(drawableComponents[i]);
+					capacity *= 2;
+					if (capacity < drawableComponents.Count)
+					{
+						capacity = drawableComponents.Count;
+					}
+					currentlyDrawingComponents = new IDrawable[capacity];
 				}
+				capacity = drawableComponents.Count;
+				drawableComponents.CopyTo(currentlyDrawingComponents);
 			}
-			foreach (IDrawable drawable in currentlyDrawingComponents)
+			for (int i = 0; i < capacity; i++)
 			{
+				IDrawable drawable = currentlyDrawingComponents[i];
 				if (drawable.Visible)
 				{
 					drawable.Draw(gameTime);
 				}
 			}
-			currentlyDrawingComponents.Clear();
+			Array.Clear(currentlyDrawingComponents, 0, capacity);
 		}
 
 		protected virtual void Update(GameTime gameTime)

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -690,7 +690,7 @@ namespace Microsoft.Xna.Framework
 					updateable.Update(gameTime);
 				}
 			}
-
+			Array.Clear(currentlyUpdatingComponents, 0, capacity);
 			FrameworkDispatcher.Update();
 		}
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Learn from: https://github.com/dotnet/runtime/blob/v8.0.30/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs#L451