### PR TITLE
accuracy: avoid dispose SpriteBatch when GraphicsDevice Dispose

### DIFF
--- a/src/Graphics/SpriteBatch.cs
+++ b/src/Graphics/SpriteBatch.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("graphicsDevice");
 			}
-			GraphicsDevice = graphicsDevice;
+			base.graphicsDevice = graphicsDevice;
 
 			vertexInfo = new VertexPositionColorTexture4[MAX_SPRITES];
 			textureInfo = new Texture2D[MAX_SPRITES];


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace Show
{
    internal class Program
    {
        static void Main()
        {
            Game game = new Game();
            PresentationParameters pp = new PresentationParameters() { DeviceWindowHandle = game.Window.Handle };
            GraphicsDevice gd = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.Reach, pp);

            SpriteBatch spriteBatch = new SpriteBatch(gd);
            gd.Dispose();
            Console.WriteLine(spriteBatch.IsDisposed);
        }
    }
}
```
XNA output:
```
False
```
FNA output:
```
True
```