### PR TITLE
accuracy: Set SamplerState.GraphicsDevice

### DIFF
--- a/src/Graphics/GraphicsDevice.cs
+++ b/src/Graphics/GraphicsDevice.cs
@@ -532,6 +532,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				modifiedSamplers
 			);
 			SamplerStates = new SamplerStateCollection(
+				this,
 				maxTextures,
 				modifiedSamplers
 			);
@@ -540,6 +541,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				modifiedVertexSamplers
 			);
 			VertexSamplerStates = new SamplerStateCollection(
+				this,
 				maxVertexTextures,
 				modifiedVertexSamplers
 			);

--- a/src/Graphics/SamplerStateCollection.cs
+++ b/src/Graphics/SamplerStateCollection.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					throw new ArgumentNullException("value", "This method does not accept null for this parameter.");
 				}
+				value.graphicsDevice = pDevice;
 				samplers[index] = value;
 				modifiedSamplers[index] = true;
 			}
@@ -46,6 +47,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#region Private Variables
 
+		private readonly GraphicsDevice pDevice;
 		private readonly SamplerState[] samplers;
 		private readonly bool[] modifiedSamplers;
 
@@ -54,9 +56,11 @@ namespace Microsoft.Xna.Framework.Graphics
 		#region Internal Constructor
 
 		internal SamplerStateCollection(
+			GraphicsDevice pParent,
 			int slots,
 			bool[] modSamplers
 		) {
+			pDevice = pParent;
 			samplers = new SamplerState[slots];
 			modifiedSamplers = modSamplers;
 			for (int i = 0; i < samplers.Length; i += 1)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Ms-PL license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Test Case:
```C#
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using System;

namespace Show
{
    internal class Program
    {
        static void Main()
        {
            Game game = new Game();
            PresentationParameters pp = new PresentationParameters() { DeviceWindowHandle = game.Window.Handle };
            GraphicsDevice gd = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.Reach, pp);

            SamplerState samplerState = new SamplerState();
            Console.WriteLine(ObjString(samplerState.GraphicsDevice));
            gd.SamplerStates[0] = samplerState;
            Console.WriteLine(ObjString(samplerState.GraphicsDevice));
            gd.Dispose();
            Console.WriteLine(samplerState.IsDisposed);
        }
        static string ObjString(object obj)
        {
            return obj == null ? "null" : obj.ToString();
        }
    }
}
```
XNA output:
```
null
Microsoft.Xna.Framework.Graphics.GraphicsDevice
False
```
FNA output:
```
null
null
False
```